### PR TITLE
Redirect Postgres output to stdout when LOG_TO_STDOUT=true

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -12,5 +12,10 @@ unset PGHOST
 unset PGPORT
 
 # Call the entrypoint script with the
-# approriate PGHOST & PGPORT
-/usr/local/bin/docker-entrypoint.sh "$@"
+# approriate PGHOST & PGPORT and redirect
+# the output to stdout if LOG_TO_STDOUT is true
+if [[ "$LOG_TO_STDOUT" == "true" ]]; then
+    /usr/local/bin/docker-entrypoint.sh "$@" 2>&1
+else
+    /usr/local/bin/docker-entrypoint.sh "$@"
+fi


### PR DESCRIPTION
Postgres output logs will be redirected to stdout when variable LOG_TO_STDOUT=true, instead of the default stderr

This will prevent Railway from rendering the logs as errors in the web UI

For example, this is the way Railway shows Postgres logs as error when LOG_TO_STDOUT is not present:
![image](https://github.com/railwayapp-templates/postgres-ssl/assets/11246472/6166c1ff-58b5-4fdb-8899-57341fdc8d12)

After setting up LOG_TO_STDOUT=true in service settings, Postgres logs will be rendered as info:
![image](https://github.com/railwayapp-templates/postgres-ssl/assets/11246472/5a9f83ec-e9a7-4855-b111-fad0de1fec0c)

You can use the image built by this PR, for testing purposes by `docker pull ghcr.io/sami286/postgres-ssl:latest`