### PR TITLE
Melissa/handle cert regen

### DIFF
--- a/.github/workflows/buildNumberVersions.yml
+++ b/.github/workflows/buildNumberVersions.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        dockerfile: ['Dockerfile.13', 'Dockerfile.14','Dockerfile.15']
+        dockerfile: ['Dockerfile.13', 'Dockerfile.14', 'Dockerfile.15', 'Dockerfile.16']
 
     steps:
       - name: Checkout sources

--- a/Dockerfile.13
+++ b/Dockerfile.13
@@ -7,11 +7,11 @@ RUN apt-get update && apt-get install -y openssl sudo
 RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown" > /etc/sudoers.d/postgres
 
 # Add init scripts
-COPY init-ssl.sh /docker-entrypoint-initdb.d/
+COPY init-ssl.sh /usr/local/bin/init-ssl.sh
 COPY wrapper.sh /usr/local/bin/wrapper.sh
 
 # Set permissions
-RUN chmod +x /docker-entrypoint-initdb.d/init-ssl.sh
+RUN chmod +x /usr/local/bin/init-ssl.sh
 RUN chmod +x /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]

--- a/Dockerfile.14
+++ b/Dockerfile.14
@@ -7,11 +7,11 @@ RUN apt-get update && apt-get install -y openssl sudo
 RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown" > /etc/sudoers.d/postgres
 
 # Add init scripts
-COPY init-ssl.sh /docker-entrypoint-initdb.d/
+COPY init-ssl.sh /usr/local/bin/init-ssl.sh
 COPY wrapper.sh /usr/local/bin/wrapper.sh
 
 # Set permissions
-RUN chmod +x /docker-entrypoint-initdb.d/init-ssl.sh
+RUN chmod +x /usr/local/bin/init-ssl.sh
 RUN chmod +x /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]

--- a/Dockerfile.15
+++ b/Dockerfile.15
@@ -7,11 +7,11 @@ RUN apt-get update && apt-get install -y openssl sudo
 RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown" > /etc/sudoers.d/postgres
 
 # Add init scripts
-COPY init-ssl.sh /docker-entrypoint-initdb.d/
+COPY init-ssl.sh /usr/local/bin/init-ssl.sh
 COPY wrapper.sh /usr/local/bin/wrapper.sh
 
 # Set permissions
-RUN chmod +x /docker-entrypoint-initdb.d/init-ssl.sh
+RUN chmod +x /usr/local/bin/init-ssl.sh
 RUN chmod +x /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]

--- a/Dockerfile.16
+++ b/Dockerfile.16
@@ -1,0 +1,18 @@
+FROM postgres:16
+
+# Install OpenSSL and sudo
+RUN apt-get update && apt-get install -y openssl sudo
+
+# Allow the postgres user to execute certain commands as root without a password
+RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown" > /etc/sudoers.d/postgres
+
+# Add init scripts
+COPY init-ssl.sh /docker-entrypoint-initdb.d/
+COPY wrapper.sh /usr/local/bin/wrapper.sh
+
+# Set permissions
+RUN chmod +x /docker-entrypoint-initdb.d/init-ssl.sh
+RUN chmod +x /usr/local/bin/wrapper.sh
+
+ENTRYPOINT ["wrapper.sh"]
+CMD ["postgres", "--port=5432"]

--- a/Dockerfile.16
+++ b/Dockerfile.16
@@ -7,11 +7,11 @@ RUN apt-get update && apt-get install -y openssl sudo
 RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown" > /etc/sudoers.d/postgres
 
 # Add init scripts
-COPY init-ssl.sh /docker-entrypoint-initdb.d/
+COPY init-ssl.sh /usr/local/bin/init-ssl.sh
 COPY wrapper.sh /usr/local/bin/wrapper.sh
 
 # Set permissions
-RUN chmod +x /docker-entrypoint-initdb.d/init-ssl.sh
+RUN chmod +x /usr/local/bin/init-ssl.sh
 RUN chmod +x /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -7,11 +7,11 @@ RUN apt-get update && apt-get install -y openssl sudo
 RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown" > /etc/sudoers.d/postgres
 
 # Add init scripts
-COPY init-ssl.sh /docker-entrypoint-initdb.d/
+COPY init-ssl.sh /usr/local/bin/init-ssl.sh
 COPY wrapper.sh /usr/local/bin/wrapper.sh
 
 # Set permissions
-RUN chmod +x /docker-entrypoint-initdb.d/init-ssl.sh
+RUN chmod +x /usr/local/bin/init-ssl.sh
 RUN chmod +x /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]

--- a/init-ssl.sh
+++ b/init-ssl.sh
@@ -8,18 +8,15 @@ sudo mkdir -p "$SSL_DIR"
 # Use sudo to change ownership as root
 sudo chown postgres:postgres "$SSL_DIR"
 
-# Check if certificates already exist
-if [ ! -f "$SSL_DIR/server.key" ] || [ ! -f "$SSL_DIR/server.crt" ] || [ ! -f "$SSL_DIR/root.crt" ]; then
-    # Generate Root CA
-    openssl req -new -x509 -days "${SSL_CERT_DAYS:-820}" -nodes -text -out "$SSL_DIR/root.crt" -keyout "$SSL_DIR/root.key" -subj "/CN=root-ca"
+# Generate Root CA
+openssl req -new -x509 -days "${SSL_CERT_DAYS:-820}" -nodes -text -out "$SSL_DIR/root.crt" -keyout "$SSL_DIR/root.key" -subj "/CN=root-ca"
 
-    # Generate Server Certificates
-    openssl req -new -nodes -text -out "$SSL_DIR/server.csr" -keyout "$SSL_DIR/server.key" -subj "/CN=localhost"
-    openssl x509 -req -in "$SSL_DIR/server.csr" -text -out "$SSL_DIR/server.crt" -CA "$SSL_DIR/root.crt" -CAkey "$SSL_DIR/root.key" -CAcreateserial
+# Generate Server Certificates
+openssl req -new -nodes -text -out "$SSL_DIR/server.csr" -keyout "$SSL_DIR/server.key" -subj "/CN=localhost"
+openssl x509 -req -in "$SSL_DIR/server.csr" -text -out "$SSL_DIR/server.crt" -CA "$SSL_DIR/root.crt" -CAkey "$SSL_DIR/root.key" -CAcreateserial -days "${SSL_CERT_DAYS:-820}"
 
-    chown postgres:postgres "$SSL_DIR/server.key"
-    chmod 600 "$SSL_DIR/server.key"
-fi
+chown postgres:postgres "$SSL_DIR/server.key"
+chmod 600 "$SSL_DIR/server.key"
 
 # PostgreSQL configuration
 cat >> "$PGDATA/postgresql.conf" <<EOF

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+SSL_DIR="/var/lib/postgresql/data/certs"
+INIT_SSL_SCRIPT="/docker-entrypoint-initdb.d/init-ssl.sh"
+
+# Check if certificates need to be regenerated
+if [ "$REGENERATE_CERTS" = "true" ] || [ ! -f "$SSL_DIR/server.key" ] || [ ! -f "$SSL_DIR/server.crt" ] || [ ! -f "$SSL_DIR/root.crt" ]; then
+    echo "Running init-ssl.sh to generate new certificates..."
+    bash "$INIT_SSL_SCRIPT"
+else
+    echo "Certificates already exist and REGENERATE_CERTS is not set to true. Skipping certificate generation."
+fi
+
 # unset PGHOST to force psql to use Unix socket path
 # this is specific to Railway and allows
 # us to use PGHOST after the init

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SSL_DIR="/var/lib/postgresql/data/certs"
-INIT_SSL_SCRIPT="/docker-entrypoint-initdb.d/init-ssl.sh"
+INIT_SSL_SCRIPT="/usr/local/bin/init-ssl.sh"
 
 # Check if certificates need to be regenerated
 if [ "$REGENERATE_CERTS" = "true" ] || [ ! -f "$SSL_DIR/server.key" ] || [ ! -f "$SSL_DIR/server.crt" ] || [ ! -f "$SSL_DIR/root.crt" ]; then


### PR DESCRIPTION
- Allow users to regenerate certs by passing in a REGENERATE_CERTS=true env var
- honor the cert expiry for the server cert
- move conditional logic to check if cert should be generated into the wrapper script
- move ssl script out of docker-entrypoint-initdb.d so it doesn't execute twice on a fresh deploy