### PR TITLE
Generate valid x509v3 Certificate

### DIFF
--- a/.github/workflows/buildLatest.yml
+++ b/.github/workflows/buildLatest.yml
@@ -16,11 +16,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           platforms: linux/amd64,linux/arm64
 
@@ -32,7 +32,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Publish
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           file: Dockerfile.latest
           platforms: linux/arm64, linux/amd64

--- a/.github/workflows/buildLatest.yml
+++ b/.github/workflows/buildLatest.yml
@@ -25,7 +25,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/buildNumberVersions.yml
+++ b/.github/workflows/buildNumberVersions.yml
@@ -17,19 +17,19 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           platforms: linux/amd64,linux/arm64
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -40,12 +40,11 @@ jobs:
         run: |
           version="${{ matrix.dockerfile }}"
           version="${version#Dockerfile.}" # Remove "Dockerfile." prefix if it exists
-          echo "::set-output name=version::${version}"
+          echo "version=${version}" >> $GITHUB_OUTPUT
         shell: bash
 
-
       - name: Build and Publish
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           file: ${{ matrix.dockerfile }}
           platforms: linux/arm64, linux/amd64

--- a/Dockerfile.13
+++ b/Dockerfile.13
@@ -4,15 +4,11 @@ FROM postgres:13
 RUN apt-get update && apt-get install -y openssl sudo
 
 # Allow the postgres user to execute certain commands as root without a password
-RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown" > /etc/sudoers.d/postgres
+RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown, /usr/bin/openssl" > /etc/sudoers.d/postgres
 
-# Add init scripts
-COPY init-ssl.sh /usr/local/bin/init-ssl.sh
-COPY wrapper.sh /usr/local/bin/wrapper.sh
-
-# Set permissions
-RUN chmod +x /usr/local/bin/init-ssl.sh
-RUN chmod +x /usr/local/bin/wrapper.sh
+# Add init scripts while setting permissions
+COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
+COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]
 CMD ["postgres", "--port=5432"]

--- a/Dockerfile.14
+++ b/Dockerfile.14
@@ -4,15 +4,11 @@ FROM postgres:14
 RUN apt-get update && apt-get install -y openssl sudo
 
 # Allow the postgres user to execute certain commands as root without a password
-RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown" > /etc/sudoers.d/postgres
+RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown, /usr/bin/openssl" > /etc/sudoers.d/postgres
 
-# Add init scripts
-COPY init-ssl.sh /usr/local/bin/init-ssl.sh
-COPY wrapper.sh /usr/local/bin/wrapper.sh
-
-# Set permissions
-RUN chmod +x /usr/local/bin/init-ssl.sh
-RUN chmod +x /usr/local/bin/wrapper.sh
+# Add init scripts while setting permissions
+COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
+COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]
 CMD ["postgres", "--port=5432"]

--- a/Dockerfile.15
+++ b/Dockerfile.15
@@ -4,15 +4,11 @@ FROM postgres:15
 RUN apt-get update && apt-get install -y openssl sudo
 
 # Allow the postgres user to execute certain commands as root without a password
-RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown" > /etc/sudoers.d/postgres
+RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown, /usr/bin/openssl" > /etc/sudoers.d/postgres
 
-# Add init scripts
-COPY init-ssl.sh /usr/local/bin/init-ssl.sh
-COPY wrapper.sh /usr/local/bin/wrapper.sh
-
-# Set permissions
-RUN chmod +x /usr/local/bin/init-ssl.sh
-RUN chmod +x /usr/local/bin/wrapper.sh
+# Add init scripts while setting permissions
+COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
+COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]
 CMD ["postgres", "--port=5432"]

--- a/Dockerfile.16
+++ b/Dockerfile.16
@@ -4,15 +4,11 @@ FROM postgres:16
 RUN apt-get update && apt-get install -y openssl sudo
 
 # Allow the postgres user to execute certain commands as root without a password
-RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown" > /etc/sudoers.d/postgres
+RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown, /usr/bin/openssl" > /etc/sudoers.d/postgres
 
-# Add init scripts
-COPY init-ssl.sh /usr/local/bin/init-ssl.sh
-COPY wrapper.sh /usr/local/bin/wrapper.sh
-
-# Set permissions
-RUN chmod +x /usr/local/bin/init-ssl.sh
-RUN chmod +x /usr/local/bin/wrapper.sh
+# Add init scripts while setting permissions
+COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
+COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]
 CMD ["postgres", "--port=5432"]

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -4,15 +4,11 @@ FROM postgres:latest
 RUN apt-get update && apt-get install -y openssl sudo
 
 # Allow the postgres user to execute certain commands as root without a password
-RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown" > /etc/sudoers.d/postgres
+RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown, /usr/bin/openssl" > /etc/sudoers.d/postgres
 
-# Add init scripts
-COPY init-ssl.sh /usr/local/bin/init-ssl.sh
-COPY wrapper.sh /usr/local/bin/wrapper.sh
-
-# Set permissions
-RUN chmod +x /usr/local/bin/init-ssl.sh
-RUN chmod +x /usr/local/bin/wrapper.sh
+# Add init scripts while setting permissions
+COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
+COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]
 CMD ["postgres", "--port=5432"]

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This repository contains the logic to build SSL-enabled Postgres images.
 
-By default, when you deploy Postgres from the offical Postgres template on Railway, the image that is used is built from this repository!
+By default, when you deploy Postgres from the official Postgres template on Railway, the image that is used is built from this repository!
 
 [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/postgres)
 
 ### Why though?
 
-The offical Postgres image in Docker hub does not come with SSL baked in.
+The official Postgres image in Docker hub does not come with SSL baked in.
 
 Since this could pose a problem for applications or services attempting to connect to Postgres services, we decided to roll our own Postgres image with SSL enabled right out of the box.
 
@@ -16,8 +16,11 @@ Since this could pose a problem for applications or services attempting to conne
 
 The Dockerfiles contained in this repository start with the official Postgres image as base.  Then the `init-ssl.sh` script is copied into the `docker-entrypoint-initdb.d/` directory to be executed upon initialization.
 
-#### Cert expiry
-By default, the cert expiry is set to 820 days.  You can control this by configuring the `SSL_CERT_DAYS` environment variable as needed.
+### Certificate expiry
+By default, the cert expiry is set to 820 days. You can control this by configuring the `SSL_CERT_DAYS` environment variable as needed.
+
+### Certificate renewal
+When a redeploy or restart is done the certificates expiry is checked, if it has expired or will expire in 30 days a new certificate is automatically generated.
 
 ### A note about ports
 

--- a/init-ssl.sh
+++ b/init-ssl.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 
+# exit as soon as any of these commands fail, this prevents starting a database without certificates
+set -e
+
 SSL_DIR="/var/lib/postgresql/data/certs"
+
+SSL_SERVER_CRT="$SSL_DIR/server.crt"
+SSL_SERVER_KEY="$SSL_DIR/server.key"
+SSL_SERVER_CSR="$SSL_DIR/server.csr"
+
+SSL_ROOT_KEY="$SSL_DIR/root.key"
+SSL_ROOT_CRT="$SSL_DIR/root.crt"
+
+SSL_V3_EXT="$SSL_DIR/v3.ext"
+
+POSTGRES_CONF_FILE="$PGDATA/postgresql.conf"
 
 # Use sudo to create the directory as root
 sudo mkdir -p "$SSL_DIR"
@@ -8,20 +22,31 @@ sudo mkdir -p "$SSL_DIR"
 # Use sudo to change ownership as root
 sudo chown postgres:postgres "$SSL_DIR"
 
-# Generate Root CA
-openssl req -new -x509 -days "${SSL_CERT_DAYS:-820}" -nodes -text -out "$SSL_DIR/root.crt" -keyout "$SSL_DIR/root.key" -subj "/CN=root-ca"
+# Generate self-signed 509v3 certificates
+# ref: https://www.postgresql.org/docs/16/ssl-tcp.html#SSL-CERTIFICATE-CREATION
 
-# Generate Server Certificates
-openssl req -new -nodes -text -out "$SSL_DIR/server.csr" -keyout "$SSL_DIR/server.key" -subj "/CN=localhost"
-openssl x509 -req -in "$SSL_DIR/server.csr" -text -out "$SSL_DIR/server.crt" -CA "$SSL_DIR/root.crt" -CAkey "$SSL_DIR/root.key" -CAcreateserial -days "${SSL_CERT_DAYS:-820}"
+openssl req -new -x509 -days "${SSL_CERT_DAYS:-820}" -nodes -text -out "$SSL_ROOT_CRT" -keyout "$SSL_ROOT_KEY" -subj "/CN=root-ca"
 
-chown postgres:postgres "$SSL_DIR/server.key"
-chmod 600 "$SSL_DIR/server.key"
+chmod og-rwx "$SSL_ROOT_KEY"
+
+openssl req -new -nodes -text -out "$SSL_SERVER_CSR" -keyout "$SSL_SERVER_KEY" -subj "/CN=localhost"
+
+chmod og-rwx "$SSL_SERVER_KEY"
+
+cat >| "$SSL_V3_EXT" <<EOF
+[v3_req]
+authorityKeyIdentifier = keyid, issuer
+basicConstraints = critical, CA:TRUE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = DNS:localhost
+EOF
+
+openssl x509 -req -in "$SSL_SERVER_CSR" -extfile "$SSL_V3_EXT" -extensions v3_req -text -days "${SSL_CERT_DAYS:-820}" -CA "$SSL_ROOT_CRT" -CAkey "$SSL_ROOT_KEY" -CAcreateserial -out "$SSL_SERVER_CRT"
 
 # PostgreSQL configuration
-cat >> "$PGDATA/postgresql.conf" <<EOF
+cat >> "$POSTGRES_CONF_FILE" <<EOF
 ssl = on
-ssl_cert_file = '$SSL_DIR/server.crt'
-ssl_key_file = '$SSL_DIR/server.key'
-ssl_ca_file = '$SSL_DIR/root.crt'
+ssl_cert_file = '$SSL_SERVER_CRT'
+ssl_key_file = '$SSL_SERVER_KEY'
+ssl_ca_file = '$SSL_ROOT_CRT'
 EOF

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -3,8 +3,16 @@
 # exit as soon as any of these commands fail, this prevents starting a database without certificates
 set -e
 
+# Make sure there is a PGDATA variable available
+if [ -z "$PGDATA" ]; then
+  echo "Missing PGDATA variable"
+  exit 1
+fi
+
+# Set up needed variables
 SSL_DIR="/var/lib/postgresql/data/certs"
 INIT_SSL_SCRIPT="/docker-entrypoint-initdb.d/init-ssl.sh"
+POSTGRES_CONF_FILE="$PGDATA/postgresql.conf"
 
 # Regenerate if the certificate is not a x509v3 certificate
 if [ -f "$SSL_DIR/server.crt" ] && ! openssl x509 -noout -text -in "$SSL_DIR/server.crt" | grep -q "DNS:localhost"; then
@@ -16,6 +24,13 @@ fi
 # 2592000 seconds = 30 days
 if [ -f "$SSL_DIR/server.crt" ] && ! openssl x509 -checkend 2592000 -noout -in "$SSL_DIR/server.crt"; then
   echo "Certificate has or will expire soon, regenerating certificates..."
+  bash "$INIT_SSL_SCRIPT"
+fi
+
+# Generate a certificate if the database was initialized but is missing a certificate
+# Useful when going from the base postgres image to this ssl image
+if [ -f "$POSTGRES_CONF_FILE" ] && [ ! -f "$SSL_DIR/server.crt" ]; then
+  echo "Database initialized without certificate, generating certificates..."
   bash "$INIT_SSL_SCRIPT"
 fi
 
@@ -31,5 +46,5 @@ unset PGHOST
 unset PGPORT
 
 # Call the entrypoint script with the
-# approriate PGHOST & PGPORT
+# appropriate PGHOST & PGPORT
 /usr/local/bin/docker-entrypoint.sh "$@"


### PR DESCRIPTION
Main change -
- Updates `init-ssl.sh` to generate valid x509v3 certificates, previously it was generating v1 certificates and that was not compatible with rustls, Two community members have confirmed the changes made here worked, Alex and Milo.

Other changes -
- Updates `wrapper.sh` with these changes -
    - Detect if the current certificate is not v3 and regenerate it if so upon redeployment.
    - Detect if the current certificate will or has expired and regenerate it if so upon restart or redeploy.
    - Detect if the database was previously initialized without a certificate and generates a new certificate. Useful when going from `postgres:latest` to this image.
- Move the `init-ssl.sh` script back into the `docker-entrypoint-initdb.d` directory so that the database is first initialized and then the certificates are generated, otherwise there would be no `postgresql.conf` file to enable ssl on.
- Set the `-e` flag on the `wrapper.sh` and `init-ssl.sh` scripts so they exit if any command happens to fail, as i believe it would be better to fail than to risk starting the database without certificates.
- Updates the actions to use new versions of the docker action scripts.

Miscellaneous changes -
- Use `--chmod=755` when copying in scripts to set the execution permissions vs doing `chmod +x` as another RUN command.
- Spelling