### PR TITLE
Have postgres 17 listen on all hosts

### DIFF
--- a/Dockerfile.17
+++ b/Dockerfile.17
@@ -11,4 +11,4 @@ COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]
-CMD ["postgres", "--port=5432"]
+CMD ["postgres", "-p", "5432", "-c", "listen_addresses=*"]


### PR DESCRIPTION
Postgres 17 listens on 127.0.0.1 by default, this changes that.