### PR TITLE
Support INITDB arg

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -45,11 +45,21 @@ unset PGHOST
 ## it ends up being empty
 unset PGPORT
 
-# Call the entrypoint script with the
-# appropriate PGHOST & PGPORT and redirect
-# the output to stdout if LOG_TO_STDOUT is true
-if [[ "$LOG_TO_STDOUT" == "true" ]]; then
-    /usr/local/bin/docker-entrypoint.sh "$@" 2>&1
+# Control whether we want to initialize the database. If false, this will
+# start the container in sleep mode.
+if [[ "$INITDB" == "false" ]]; then
+    echo "Database initialization disabled, starting in sleep mode..."
+    echo "To initialize and run the database, set the INITDB environment variable to true"
+    trap "echo Shutting down; exit 0" SIGTERM SIGINT SIGKILL
+    sleep infinity & wait
 else
-    /usr/local/bin/docker-entrypoint.sh "$@"
+    # Call the entrypoint script with the
+    # appropriate PGHOST & PGPORT and redirect
+    # the output to stdout if LOG_TO_STDOUT is true
+    if [[ "$LOG_TO_STDOUT" == "true" ]]; then
+        /usr/local/bin/docker-entrypoint.sh "$@" 2>&1
+    else
+        /usr/local/bin/docker-entrypoint.sh "$@"
+    fi
 fi
+


### PR DESCRIPTION
This adds an `INITDB` arg inside wrapper.sh to control whether we initialize the database (i.e. run `/usr/local/bin/docker-entrypoint.sh`)

If `INITDB=false`, it will `sleep infinity` instead of running the entrypoint.sh of base Postgres image. This lets us keep the container alive for `railway ssh` to work

This is for scenarios where we want to bootstrap the template on Railway with service configuration (env vars, tcp proxies, etc.) but we do not _yet_ want the database to be initialized (e.g. spinning up replica instances where pgdata dir should not be initialized yet)