### PR TITLE
Add weekly automatic image publishing

### DIFF
--- a/.github/workflows/buildLatest.yml
+++ b/.github/workflows/buildLatest.yml
@@ -1,6 +1,8 @@
 name: Docker Image CI/CD for latest
 
 on:
+  schedule:
+    - cron: '0 0 * * 1'  # Every Monday at midnight UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/buildNumberVersions.yml
+++ b/.github/workflows/buildNumberVersions.yml
@@ -1,6 +1,8 @@
 name: Docker Image CI/CD for number versions
 
 on:
+  schedule:
+    - cron: '0 0 * * 1'  # Every Monday at midnight UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Configure GitHub Actions workflows to automatically build and publish Docker images every Monday at midnight UTC.

- Add cron schedule trigger to buildLatest.yml and buildNumberVersions.yml
- Retain manual workflow_dispatch trigger for on-demand builds