### PR TITLE
Update Dockerfile.latest to listen on all interfaces

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -11,4 +11,4 @@ COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]
-CMD ["postgres", "--port=5432"]
+CMD ["postgres", "-p", "5432", "-c", "listen_addresses=*"]


### PR DESCRIPTION
Updates Dockerfile.latest to listen on all network interfaces, matching the configuration already present in Dockerfile.17.