### PR TITLE
Pin latest tag to 16

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -11,4 +11,4 @@ COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]
-CMD ["postgres", "-p", "5432", "-c", "listen_addresses=*"]
+CMD ["postgres", "--port=5432"]

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -1,4 +1,4 @@
-FROM postgres:latest
+FROM postgres:16
 
 # Install OpenSSL and sudo
 RUN apt-get update && apt-get install -y openssl sudo


### PR DESCRIPTION
So that redeploys of the latest tag don't get a major postgres version upgrade
