### PR TITLE
add postgres 18

### DIFF
--- a/Dockerfile.18
+++ b/Dockerfile.18
@@ -1,0 +1,15 @@
+ARG POSTGRES_VERSION=18
+FROM postgres:${POSTGRES_VERSION}
+
+# Install OpenSSL and sudo
+RUN apt-get update && apt-get install -y openssl sudo
+
+# Allow the postgres user to execute certain commands as root without a password
+RUN echo "postgres ALL=(root) NOPASSWD: /usr/bin/mkdir, /bin/chown, /usr/bin/openssl" > /etc/sudoers.d/postgres
+
+# Add init scripts while setting permissions
+COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
+COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
+
+ENTRYPOINT ["wrapper.sh"]
+CMD ["postgres", "-p", "5432", "-c", "listen_addresses=*"]

--- a/init-ssl.sh
+++ b/init-ssl.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Set up needed variables
-SSL_DIR="/var/lib/postgresql/data/certs"
+SSL_DIR="/var/lib/postgresql/certs"
 
 SSL_SERVER_CRT="$SSL_DIR/server.crt"
 SSL_SERVER_KEY="$SSL_DIR/server.key"

--- a/init-ssl.sh
+++ b/init-ssl.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Set up needed variables
-SSL_DIR="/var/lib/postgresql/certs"
+SSL_DIR="$PGDATA/certs"
 
 SSL_SERVER_CRT="$SSL_DIR/server.crt"
 SSL_SERVER_KEY="$SSL_DIR/server.key"

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -3,7 +3,7 @@
 # exit as soon as any of these commands fail, this prevents starting a database without certificates or with the wrong volume mount path
 set -e
 
-EXPECTED_VOLUME_MOUNT_PATH="/var/lib/postgresql/data"
+EXPECTED_VOLUME_MOUNT_PATH="/var/lib/postgresql"
 
 # check if the Railway volume is mounted to the correct path
 # we do this by checking the current mount path (RAILWAY_VOLUME_MOUNT_PATH) agiant the expected mount path
@@ -25,7 +25,7 @@ if [[ ! "$PGDATA" =~ ^"$EXPECTED_VOLUME_MOUNT_PATH" ]]; then
 fi
 
 # Set up needed variables
-SSL_DIR="/var/lib/postgresql/data/certs"
+SSL_DIR="/var/lib/postgresql/certs"
 INIT_SSL_SCRIPT="/docker-entrypoint-initdb.d/init-ssl.sh"
 POSTGRES_CONF_FILE="$PGDATA/postgresql.conf"
 

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -3,24 +3,50 @@
 # exit as soon as any of these commands fail, this prevents starting a database without certificates or with the wrong volume mount path
 set -e
 
-EXPECTED_VOLUME_MOUNT_PATH="/var/lib/postgresql"
+EXPECTED_VOLUME_MOUNT_PATHS=("/var/lib/postgresql" "/var/lib/postgresql/data")
 
-# check if the Railway volume is mounted to the correct path
-# we do this by checking the current mount path (RAILWAY_VOLUME_MOUNT_PATH) agiant the expected mount path
-# if the paths are different, we print an error message and exit
+# Function to check if a path matches any of the expected volume mount paths
+# Usage: check_path_matches "exact" "/path/to/check" - for exact match
+# Usage: check_path_matches "starts_with" "/path/to/check" - for prefix match
+check_path_matches() {
+  local match_type="$1"
+  local path_to_check="$2"
+  
+  for expected_path in "${EXPECTED_VOLUME_MOUNT_PATHS[@]}"; do
+    if [ "$match_type" = "exact" ]; then
+      if [ "$path_to_check" = "$expected_path" ]; then
+        return 0  # true - path matches
+      fi
+    elif [ "$match_type" = "starts_with" ]; then
+      if [[ "$path_to_check" =~ ^"$expected_path" ]]; then
+        return 0  # true - path starts with expected path
+      fi
+    fi
+  done
+  
+  return 1  # false - no match found
+}
+
+# check if the Railway volume is mounted to one of the correct paths
+# we do this by checking the current mount path (RAILWAY_VOLUME_MOUNT_PATH) against the expected mount paths
+# if the paths don't match any of the expected paths, we print an error message and exit
 # only perform this check if this image is deployed to Railway by checking for the existence of the RAILWAY_ENVIRONMENT variable
-if [ -n "$RAILWAY_ENVIRONMENT" ] && [ "$RAILWAY_VOLUME_MOUNT_PATH" != "$EXPECTED_VOLUME_MOUNT_PATH" ]; then
-  echo "Railway volume not mounted to the correct path, expected $EXPECTED_VOLUME_MOUNT_PATH but got $RAILWAY_VOLUME_MOUNT_PATH"
-  echo "Please update the volume mount path to the expected path and redeploy the service"
+if [ -n "$RAILWAY_ENVIRONMENT" ] && ! check_path_matches "exact" "$RAILWAY_VOLUME_MOUNT_PATH"; then
+  echo "Railway volume not mounted to any of the correct paths"
+  echo "Expected one of: ${EXPECTED_VOLUME_MOUNT_PATHS[*]}"
+  echo "But got: $RAILWAY_VOLUME_MOUNT_PATH"
+  echo "Please update the volume mount path to one of the expected paths and redeploy the service"
   exit 1
 fi
 
-# check if PGDATA starts with the expected volume mount path
+# check if PGDATA starts with one of the expected volume mount paths
 # this ensures data files are stored in the correct location
 # if not, print error and exit to prevent data loss or access issues
-if [[ ! "$PGDATA" =~ ^"$EXPECTED_VOLUME_MOUNT_PATH" ]]; then
-  echo "PGDATA variable does not start with the expected volume mount path, expected to start with $EXPECTED_VOLUME_MOUNT_PATH"
-  echo "Please update the PGDATA variable to start with the expected volume mount path and redeploy the service"
+if ! check_path_matches "starts_with" "$PGDATA"; then
+  echo "PGDATA variable does not start with any of the expected volume mount paths"
+  echo "Expected to start with one of: ${EXPECTED_VOLUME_MOUNT_PATHS[*]}"
+  echo "But got: $PGDATA"
+  echo "Please update the PGDATA variable to start with one of the expected volume mount paths and redeploy the service"
   exit 1
 fi
 


### PR DESCRIPTION
## TLDR

**Breaking change in Postgres 18:**
Volume mount path changed from `/var/lib/postgresql/data` to `/var/lib/postgresql`

**What Railway needs to do:**
Update volume mount configuration to use `/var/lib/postgresql` instead of `/var/lib/postgresql/data`

**Decision needed:**
- **Option 1:** Just fix the mount path (this PR)
- **Option 2:** Also add major version `/var/lib/postgresql/18/docker` (recommended by Docker)

Current deployments fail without the mount path fix. The version-specific path is optional but follows Docker image's new recommendations for easier upgrades.

*yep, that's AI generated. refer to #30 for more context

If you really need a Postgres 18 instance, take a look at my template https://railway.com/deploy/postgresql-18. Please note that some features won't work, such as the `data` tab.