### PR TITLE
fix(pitr): rename PGBACKREST_DROP_THRESHOLD_MB → WAL_DROP_THRESHOLD_MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Three modes:
 `archive_command` points at `/usr/local/bin/pgbackrest-archive-push-wrapper.sh`
 rather than calling `pgbackrest archive-push` directly. The wrapper tries the
 real push; on failure it measures `pg_wal/`, and when it exceeds the
-threshold (default 500 MiB, override via `PGBACKREST_DROP_THRESHOLD_MB`) it
+threshold (default 500 MiB, override via `WAL_DROP_THRESHOLD_MB`) it
 returns success to Postgres anyway, dropping the segment. This is the
 never-halt safety net for failure modes that bypass pgBackRest's own
 queue-max — bad credentials, deleted bucket, expired keys,
@@ -99,7 +99,7 @@ The two thresholds gate orthogonal failure regimes:
   Trips on transient S3 stalls — async worker keeps retrying and most
   segments eventually land. Generous buffer to absorb multi-hour outages
   cleanly.
-- `PGBACKREST_DROP_THRESHOLD_MB=500` (default) governs **`pg_wal/`** when
+- `WAL_DROP_THRESHOLD_MB=500` (default) governs **`pg_wal/`** when
   pgbackrest's foreground returns non-zero. Trips on hard failures (bad
   creds, deleted bucket) where retrying without operator intervention has
   zero chance of success. Smaller cap so we don't hold 5 GiB of pg_wal
@@ -122,7 +122,7 @@ Image-level tuning knobs (pgBackRest-native, internal):
 
 | Env var | Purpose |
 |---|---|
-| `PGBACKREST_DROP_THRESHOLD_MB` | `pg_wal/` size at which the archive-push wrapper drops failing segments to keep Postgres running (default `500`) |
+| `WAL_DROP_THRESHOLD_MB` | `pg_wal/` size at which the archive-push wrapper drops failing segments to keep Postgres running (default `500`). Outside the `PGBACKREST_*` namespace on purpose — pgBackRest treats unknown `PGBACKREST_*` vars as config options and warns about them on every push. |
 | `PGBACKREST_ARCHIVE_PUSH_PROCESS_MAX` | parallel workers for `archive-push`. Default auto-sized as `clamp(cpus/8, 2, 8)`. |
 | `PGBACKREST_ARCHIVE_GET_PROCESS_MAX` | parallel workers for `archive-get`. Default `1` (WAL replay is serial). |
 | `PGBACKREST_BACKUP_PROCESS_MAX` | parallel workers for `backup`. Default auto-sized as `clamp(cpus/4, 1, 16)` (≤25% of CPUs to leave room for live DB). |

--- a/pgbackrest-archive-push-wrapper.sh
+++ b/pgbackrest-archive-push-wrapper.sh
@@ -4,12 +4,18 @@
 # Wraps `pgbackrest archive-push` so that any kind of archive failure (hard
 # repo error, stuck async worker, anything else) cannot fill pg_wal/ and halt
 # Postgres. When pgbackrest fails AND pg_wal/ has grown past a threshold
-# (default 500 MiB, override via PGBACKREST_DROP_THRESHOLD_MB), the wrapper
-# returns success to Postgres anyway. Postgres recycles the WAL segment as
-# if archiving were disabled. The PITR window gets a coverage gap from this
-# segment forward; the dashboard reads pg_stat_archiver to surface "PITR
-# broken — fix archiving config" so the underlying issue (bad creds, deleted
-# bucket, expired keys, …) gets fixed.
+# (default 500 MiB, override via WAL_DROP_THRESHOLD_MB), the wrapper returns
+# success to Postgres anyway. Postgres recycles the WAL segment as if
+# archiving were disabled. The PITR window gets a coverage gap from this
+# segment forward; below the threshold pg_stat_archiver.failed_count climbs
+# normally and the dashboard surfaces "PITR broken — fix archiving config",
+# so the underlying issue (bad creds, deleted bucket, expired keys, …) gets
+# fixed before the threshold trips and the failure signal disappears.
+#
+# The env var name avoids the PGBACKREST_* prefix on purpose: pgBackRest
+# treats every PGBACKREST_* variable as a config option and warns about
+# unknown names on every invocation. WAL_DROP_THRESHOLD_MB sits outside
+# that namespace so it doesn't pollute logs.
 #
 # Why 500 MiB here, vs pgBackRest's archive-push-queue-max=5GiB:
 # the two thresholds gate orthogonal failure regimes. archive-push-queue-max
@@ -45,7 +51,7 @@ if [ -z "$WAL_FILE" ]; then
 fi
 
 PGDATA="${PGDATA:-/var/lib/postgresql/data}"
-PGWAL_THRESHOLD_MB="${PGBACKREST_DROP_THRESHOLD_MB:-500}"
+PGWAL_THRESHOLD_MB="${WAL_DROP_THRESHOLD_MB:-500}"
 PGWAL_THRESHOLD_BYTES=$(( PGWAL_THRESHOLD_MB * 1024 * 1024 ))
 
 # When two repos are configured (restored service: repo1=recover-from,

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -145,7 +145,7 @@ fi
 #     below) governs the SPOOL. Trips on transient S3 stalls; pgBackRest
 #     drops segments from spool and reports success to archive_command.
 #     Generous buffer to absorb multi-hour outages cleanly.
-#   - pgbackrest-archive-push-wrapper.sh's PGBACKREST_DROP_THRESHOLD_MB
+#   - pgbackrest-archive-push-wrapper.sh's WAL_DROP_THRESHOLD_MB
 #     (default 500 MiB) governs pg_wal/. Trips on HARD failures (bad creds,
 #     deleted bucket, expired keys) where pgbackrest's foreground returns
 #     non-zero and retrying without operator intervention has zero chance


### PR DESCRIPTION
Split out from #38.

pgBackRest treats every `PGBACKREST_*` env var as a config option and emits

```
WARN: environment contains invalid option 'drop-threshold-mb'
```

on every archive-push invocation. With `archive_timeout=60s` that's one
warning per minute under steady state. Move the wrapper-side knob outside
the `PGBACKREST_*` namespace so it doesn't pollute logs.

Also tightens the `pg_stat_archiver` story in the wrapper comment:
`failed_count` only climbs **below** the threshold; once the wrapper starts
dropping, the counter goes silent. So the threshold doubles as the deadline
for the operator to have fixed the underlying issue before the dashboard's
signal disappears.

## Test plan

- [x] Image builds cleanly
- [x] `WAL_DROP_THRESHOLD_MB` override is honored by the wrapper
- [x] No `invalid option` warnings in the container logs under steady-state archiving