### PR TITLE
fix(pitr): install ca-certificates so pgbackrest can verify S3 TLS

### DIFF
--- a/Dockerfile.13
+++ b/Dockerfile.13
@@ -1,8 +1,10 @@
 ARG POSTGRES_VERSION=13
 FROM postgres:${POSTGRES_VERSION}
 
-# Install OpenSSL, sudo, pgvector, and pgbackrest
-RUN apt-get update && apt-get install -y openssl sudo pgbackrest postgresql-13-pgvector \
+# Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
+# so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
+# image disables apt Recommends, so ca-certificates isn't pulled implicitly)
+RUN apt-get update && apt-get install -y openssl sudo ca-certificates pgbackrest postgresql-13-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.14
+++ b/Dockerfile.14
@@ -1,8 +1,10 @@
 ARG POSTGRES_VERSION=14
 FROM postgres:${POSTGRES_VERSION}
 
-# Install OpenSSL, sudo, pgvector, and pgbackrest
-RUN apt-get update && apt-get install -y openssl sudo pgbackrest postgresql-14-pgvector \
+# Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
+# so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
+# image disables apt Recommends, so ca-certificates isn't pulled implicitly)
+RUN apt-get update && apt-get install -y openssl sudo ca-certificates pgbackrest postgresql-14-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.15
+++ b/Dockerfile.15
@@ -1,8 +1,10 @@
 ARG POSTGRES_VERSION=15
 FROM postgres:${POSTGRES_VERSION}
 
-# Install OpenSSL, sudo, pgvector, and pgbackrest
-RUN apt-get update && apt-get install -y openssl sudo pgbackrest postgresql-15-pgvector \
+# Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
+# so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
+# image disables apt Recommends, so ca-certificates isn't pulled implicitly)
+RUN apt-get update && apt-get install -y openssl sudo ca-certificates pgbackrest postgresql-15-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.16
+++ b/Dockerfile.16
@@ -1,8 +1,10 @@
 ARG POSTGRES_VERSION=16
 FROM postgres:${POSTGRES_VERSION}
 
-# Install OpenSSL, sudo, pgvector, and pgbackrest
-RUN apt-get update && apt-get install -y openssl sudo pgbackrest postgresql-16-pgvector \
+# Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
+# so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
+# image disables apt Recommends, so ca-certificates isn't pulled implicitly)
+RUN apt-get update && apt-get install -y openssl sudo ca-certificates pgbackrest postgresql-16-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.17
+++ b/Dockerfile.17
@@ -1,8 +1,10 @@
 ARG POSTGRES_VERSION=17
 FROM postgres:${POSTGRES_VERSION}
 
-# Install OpenSSL, sudo, pgvector, and pgbackrest
-RUN apt-get update && apt-get install -y openssl sudo pgbackrest postgresql-17-pgvector \
+# Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
+# so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
+# image disables apt Recommends, so ca-certificates isn't pulled implicitly)
+RUN apt-get update && apt-get install -y openssl sudo ca-certificates pgbackrest postgresql-17-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.18
+++ b/Dockerfile.18
@@ -1,8 +1,10 @@
 ARG POSTGRES_VERSION=18
 FROM postgres:${POSTGRES_VERSION}
 
-# Install OpenSSL, sudo, pgvector, and pgbackrest
-RUN apt-get update && apt-get install -y openssl sudo pgbackrest postgresql-18-pgvector \
+# Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
+# so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
+# image disables apt Recommends, so ca-certificates isn't pulled implicitly)
+RUN apt-get update && apt-get install -y openssl sudo ca-certificates pgbackrest postgresql-18-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password


### PR DESCRIPTION
## Summary
- Adds `ca-certificates` to the explicit apt install in every `Dockerfile.{13..18}` so the system trust store is present.

## Why
Without this, `pgbackrest`'s S3 archive-push fails on every WAL segment with:

```
CryptoError: unable to verify certificate presented by '<bucket>.t3.storageapi.dev:443':
  [20] unable to get local issuer certificate
HINT: archive.info cannot be opened but is required to push/get WAL segments.
```

The Docker library `postgres:N` base image ships an apt config with `Apt::Install-Recommends "false"`, so `ca-certificates` (a Recommends, not a hard dep, of `openssl`/`pgbackrest`) silently never installs. Result: `dpkg -l ca-certificates` → `un` and `/etc/ssl/certs/ca-certificates.crt` is missing. The S3 endpoint cert is normal Let's Encrypt — verifies fine once the bundle is present.

Caught while end-to-end testing PITR on a fresh service: 3 `.ready` segments piled up in `pg_wal/archive_status/`, `pg_stat_archiver.failed_count` ticked up every 60s, and the spool's `global.error` was the smoking gun.

## Test plan
- [ ] Build locally and confirm `dpkg -l ca-certificates` shows `ii` and `/etc/ssl/certs/ca-certificates.crt` exists
- [ ] After republish, verify the failing PITR service archives cleanly (`pg_stat_archiver.archived_count` increments, no spool `global.error`)