### PR TITLE
feat(pitr): image-owned base backups + restore-from-S3

### DIFF
--- a/Dockerfile.13
+++ b/Dockerfile.13
@@ -16,6 +16,7 @@ RUN install -d -m 0750 -o postgres -g postgres /etc/pgbackrest
 COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
 COPY --chmod=755 pgbackrest-init.sh /docker-entrypoint-initdb.d/99-pgbackrest-init.sh
 COPY --chmod=755 pgbackrest-archive-push-wrapper.sh /usr/local/bin/pgbackrest-archive-push-wrapper.sh
+COPY --chmod=755 pgbackrest-backup-watcher.sh /usr/local/bin/pgbackrest-backup-watcher.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]

--- a/Dockerfile.14
+++ b/Dockerfile.14
@@ -16,6 +16,7 @@ RUN install -d -m 0750 -o postgres -g postgres /etc/pgbackrest
 COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
 COPY --chmod=755 pgbackrest-init.sh /docker-entrypoint-initdb.d/99-pgbackrest-init.sh
 COPY --chmod=755 pgbackrest-archive-push-wrapper.sh /usr/local/bin/pgbackrest-archive-push-wrapper.sh
+COPY --chmod=755 pgbackrest-backup-watcher.sh /usr/local/bin/pgbackrest-backup-watcher.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]

--- a/Dockerfile.15
+++ b/Dockerfile.15
@@ -16,6 +16,7 @@ RUN install -d -m 0750 -o postgres -g postgres /etc/pgbackrest
 COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
 COPY --chmod=755 pgbackrest-init.sh /docker-entrypoint-initdb.d/99-pgbackrest-init.sh
 COPY --chmod=755 pgbackrest-archive-push-wrapper.sh /usr/local/bin/pgbackrest-archive-push-wrapper.sh
+COPY --chmod=755 pgbackrest-backup-watcher.sh /usr/local/bin/pgbackrest-backup-watcher.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]

--- a/Dockerfile.16
+++ b/Dockerfile.16
@@ -16,6 +16,7 @@ RUN install -d -m 0750 -o postgres -g postgres /etc/pgbackrest
 COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
 COPY --chmod=755 pgbackrest-init.sh /docker-entrypoint-initdb.d/99-pgbackrest-init.sh
 COPY --chmod=755 pgbackrest-archive-push-wrapper.sh /usr/local/bin/pgbackrest-archive-push-wrapper.sh
+COPY --chmod=755 pgbackrest-backup-watcher.sh /usr/local/bin/pgbackrest-backup-watcher.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]

--- a/Dockerfile.17
+++ b/Dockerfile.17
@@ -16,6 +16,7 @@ RUN install -d -m 0750 -o postgres -g postgres /etc/pgbackrest
 COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
 COPY --chmod=755 pgbackrest-init.sh /docker-entrypoint-initdb.d/99-pgbackrest-init.sh
 COPY --chmod=755 pgbackrest-archive-push-wrapper.sh /usr/local/bin/pgbackrest-archive-push-wrapper.sh
+COPY --chmod=755 pgbackrest-backup-watcher.sh /usr/local/bin/pgbackrest-backup-watcher.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]

--- a/Dockerfile.18
+++ b/Dockerfile.18
@@ -16,6 +16,7 @@ RUN install -d -m 0750 -o postgres -g postgres /etc/pgbackrest
 COPY --chmod=755 init-ssl.sh /docker-entrypoint-initdb.d/init-ssl.sh
 COPY --chmod=755 pgbackrest-init.sh /docker-entrypoint-initdb.d/99-pgbackrest-init.sh
 COPY --chmod=755 pgbackrest-archive-push-wrapper.sh /usr/local/bin/pgbackrest-archive-push-wrapper.sh
+COPY --chmod=755 pgbackrest-backup-watcher.sh /usr/local/bin/pgbackrest-backup-watcher.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
 ENTRYPOINT ["wrapper.sh"]

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Operator-facing env contract:
 | `WAL_RECOVER_FROM_BUCKET` / `_ENDPOINT` / `_REGION` / `_KEY` / `_SECRET` / `_PATH` | source-bucket coordinates on a PITR-restored service; `archive-get` reads source WAL from here during replay. Set by backboard on restore; not normally a manual knob. |
 | `POSTGRES_RECOVERY_TARGET_TIME` | ISO 8601 timestamp; stages archive-recovery replay on next start |
 | `POSTGRES_ARCHIVE_TIMEOUT` | seconds Postgres waits before forcing a WAL switch (default `60`) |
+| `WAL_BACKUP_FULL_INTERVAL_HOURS` | image-owned full base-backup cadence (default `168` = weekly; `0` disables periodic fulls). Initial / gap-recovery fulls fire regardless. |
+| `WAL_BACKUP_DIFF_INTERVAL_HOURS` | image-owned differential base-backup cadence (default `24`; `0` disables) |
+| `WAL_BACKUP_RETENTION_FULL` | full backups kept by `pgbackrest expire` (default `4`) |
+| `WAL_BACKUP_RETENTION_DIFF` | differentials kept by `pgbackrest expire` (default `14`) |
 
 Image-level tuning knobs (pgBackRest-native, internal):
 
@@ -174,30 +178,88 @@ timeline and replaying again would corrupt it. To probe a different
 target, restore from a fresh volume snapshot (or, advanced: remove
 `$PGDATA/.pitr_configured` before the next start).
 
-PITR runs only against an existing data directory. If
-`POSTGRES_RECOVERY_TARGET_TIME` is set on a brand-new container with no
-`$PGDATA`, the wrapper refuses to start and points at the fix (restore
-from a base snapshot first, or unset the recovery target).
+When `POSTGRES_RECOVERY_TARGET_TIME` is set on a brand-new container
+(no `$PGDATA/PG_VERSION`), the wrapper runs `pgbackrest --repo=1 restore
+--type=time --target=<T> --target-action=promote` against the source
+bucket *before* `docker-entrypoint` initializes anything. pgBackRest
+pulls the most recent base backup ≤ T plus the WAL chain forward into
+`$PGDATA`, writes `recovery.signal` + recovery params, and Postgres
+boots straight into archive recovery. A `.pgbackrest_restored` marker is
+written on success; `configure_pgbackrest_recovery` defers to the
+restore's own settings on subsequent starts of the same volume.
 
-#### Retention coupling
+If `$PGDATA` is already populated (the legacy snapshot-based restore
+flow), the conf.d-include path is used as before — `recovery_target_time`
++ `restore_command` are written to `$PGDATA/conf.d/pgbackrest-recovery.conf`,
+`recovery.signal` is touched, and Postgres replays WAL from the source
+bucket via `archive-get`. The two paths share the same env contract
+(`WAL_RECOVER_FROM_*` + `POSTGRES_RECOVERY_TARGET_TIME`) and only differ
+on the initial-volume question.
 
-This image ships WAL archiving only — there is no `pgbackrest backup`
-running in-container. The "base" for any restore is a block-level
-snapshot of the data volume (e.g. a Railway volume snapshot); pgBackRest
-supplies the WAL needed to replay forward from that snapshot's
-checkpoint LSN to the target time.
+#### Image-owned base backups
 
-Because of that, **bucket WAL retention must be ≥ snapshot retention**.
-If snapshots live 30 days but the bucket TTL is 14 days, a 16-day-old
-snapshot is unrecoverable: there is no archived WAL to bridge from its
-checkpoint LSN to anywhere useful. Pick a bucket TTL (or lifecycle rule)
-that covers your oldest restorable snapshot plus the longest replay
-window you care about.
+When `WAL_ARCHIVE_BUCKET` is set, the wrapper forks a background watcher
+(`pgbackrest-backup-watcher.sh`) that polls Postgres every 60 s and
+runs `pgbackrest backup` against the archive bucket when one of three
+conditions holds:
 
-This image does not enforce the coupling. The bucket lifecycle is the
-sole source of truth for WAL retention — the image never runs
-`pgbackrest backup`/`expire`, so no `repo1-retention-*` settings are
-written to `/etc/pgbackrest/pgbackrest.conf`.
+1. **Initial backup** — `pg_stat_archiver.archived_count > 0` and no
+   full has been recorded on this volume. Triggers the first
+   `--type=full`, anchoring the PITR window from the first archived LSN
+   forward.
+2. **Gap recovery** — either the archive-push wrapper dropped a segment
+   (touches `$PGDATA/.pgbackrest_gap_pending`) or
+   `pg_stat_archiver.failed_count` grew since the last full. Once
+   archive failures have been quiescent for 5 minutes, runs a fresh full
+   so the PITR window resumes from the new base. The dropped segment
+   itself remains unrestorable; everything from the new base forward is.
+3. **Periodic** — `WAL_BACKUP_FULL_INTERVAL_HOURS` (default 168 h /
+   weekly) for fulls, `WAL_BACKUP_DIFF_INTERVAL_HOURS` (default 24 h)
+   for differentials. Set either to `0` to disable that schedule.
+
+State persists at `$PGDATA/.pgbackrest_backup_state` (key=value lines:
+`last_full_at`, `last_diff_at`, `last_full_failed_count`). The
+bucket-side `pgbackrest --stanza=main info --output=json` is the
+canonical source of truth for what actually exists in the repo; the
+local file is a cache that survives restarts. A wiped volume re-derives
+from a single redundant initial full — pgBackRest's stanza locks
+prevent concurrent backups across cluster nodes.
+
+In HA, every Postgres node runs the watcher and standbys exit early on
+`SELECT pg_is_in_recovery()` — only the leader performs backups. v1 of
+the watcher backs up from the primary; `--backup-standby` is a
+follow-up. After a Patroni failover, the new leader's watcher takes
+over; if its local state is stale, an extra full may run, which is
+harmless.
+
+**Known gap**: pgBackRest's `archive-push-queue-max` trip drops segments
+without going through the archive-push wrapper *and* without
+incrementing `failed_count`, so neither gap signal fires. Until log
+parsing or LSN-lag detection lands, queue-max-trip gaps are sealed by
+the next periodic full rather than promptly.
+
+`pgbackrest backup` is invoked with `--type=full` or `--type=diff`
+depending on the trigger; the `process-max=backup` setting (default
+`clamp(cpus/4, 1, 16)`) caps copy concurrency to leave CPU for live DB
+traffic. `pgbackrest expire` runs automatically after each backup and
+removes fulls/diffs beyond `WAL_BACKUP_RETENTION_FULL` /
+`_DIFF`, plus the WAL their manifests no longer pin.
+
+#### Retention
+
+For PITR-enabled services, **`pgbackrest expire` is the source of truth
+for WAL retention**, not the bucket lifecycle policy. Backup manifests
+pin the WAL needed to make each backup restorable; expire removes them
+together when a backup ages out. The bucket's lifecycle TTL should be
+set as a safety net (≈ 2 × the longest pinned-WAL window) — looser than
+expire's effective horizon, so it never expires WAL out from under a
+live manifest.
+
+The default retention (full=4, diff=14, weekly fulls + daily diffs)
+covers approximately a four-week PITR window before the oldest full
+ages out. Tune via `WAL_BACKUP_RETENTION_FULL`,
+`WAL_BACKUP_RETENTION_DIFF`, `WAL_BACKUP_FULL_INTERVAL_HOURS`,
+`WAL_BACKUP_DIFF_INTERVAL_HOURS`.
 
 ### Disabling PITR
 
@@ -206,6 +268,9 @@ container on next start wipes the archive-side state so a later
 re-enable starts from a clean slate:
 
 - `$PGDATA/conf.d/pgbackrest.conf` (archive settings)
+- `$PGDATA/.pgbackrest_backup_state` and `$PGDATA/.pgbackrest_gap_pending`
+  (backup-watcher state — bucket-scoped, so re-enable starts from
+  `NEEDS_INITIAL_BACKUP` rather than a stale cache)
 - `/etc/pgbackrest/pgbackrest.conf` (image-level operator policy — only
   removed when both `WAL_ARCHIVE_BUCKET` and `WAL_RECOVER_FROM_BUCKET`
   are unset, since recovery-only services still need it)
@@ -213,9 +278,10 @@ re-enable starts from a clean slate:
   repo to push to; any in-flight WAL was already covered by the
   archive-push wrapper's drop-on-failure path)
 - `$PGDATA/conf.d/pgbackrest-recovery.conf` and the
-  `$PGDATA/.pitr_staging` / `$PGDATA/.pitr_configured` markers are
-  scoped to `WAL_RECOVER_FROM_BUCKET` and only cleared when *that*
-  variable goes away.
+  `$PGDATA/.pitr_staging` / `$PGDATA/.pitr_configured` /
+  `$PGDATA/.pgbackrest_restored` markers are scoped to
+  `WAL_RECOVER_FROM_BUCKET` and only cleared when *that* variable goes
+  away.
 
 With the conf-file-as-sentinel model, removal IS the disable —
 `archive_mode`, `archive_command`, and any recovery settings vanish on

--- a/pgbackrest-archive-push-wrapper.sh
+++ b/pgbackrest-archive-push-wrapper.sh
@@ -77,6 +77,10 @@ fi
 if [ "$PGWAL_BYTES" -ge "$PGWAL_THRESHOLD_BYTES" ]; then
   PGWAL_MB=$(( PGWAL_BYTES / 1024 / 1024 ))
   echo "pgbackrest-wrapper: pg_wal at ${PGWAL_MB} MiB (threshold ${PGWAL_THRESHOLD_MB} MiB) and archive-push failing; dropping ${WAL_FILE} to keep Postgres up" >&2
+  # Signal to pgbackrest-backup-watcher.sh that a gap was just created. The
+  # watcher takes a fresh full backup once archiving recovers, sealing the
+  # gap forward (the dropped segment itself is unrestorable, as before).
+  touch "$PGDATA/.pgbackrest_gap_pending" 2>/dev/null || true
   exit 0
 fi
 

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+# pgbackrest-backup-watcher.sh — long-running daemon that triggers pgBackRest
+# base backups based on archiving health. Forked from wrapper.sh at container
+# start when WAL_ARCHIVE_BUCKET is set; same pattern as bootstrap_pgbackrest_stanza.
+#
+# Triggers (any of):
+#   1. NEEDS_INITIAL_BACKUP — first archive-push success after enable. Takes
+#      the first full so PITR is restorable from this LSN forward. Replaces
+#      v1's "immediate snapshot on enable" race: pgbackrest backup brackets
+#      the base in pg_backup_start/stop so the LSN window of the base and
+#      the WAL covering it are the same thing — no coordination gap.
+#   2. Gap recovery — archive-push had hard failures since the last full
+#      (either pgbackrest-archive-push-wrapper.sh dropped a segment and
+#      touched .pgbackrest_gap_pending, or pg_stat_archiver.failed_count grew
+#      since the last full's checkpoint). Once failures are decisively over,
+#      runs a fresh full so PITR window resumes from this base forward.
+#   3. Periodic — full every WAL_BACKUP_FULL_INTERVAL_HOURS, diff every
+#      WAL_BACKUP_DIFF_INTERVAL_HOURS.
+#
+# State persists at $PGDATA/.pgbackrest_backup_state (key=value lines, no JSON
+# dep). The bucket-side `pgbackrest --stanza=main info` is the canonical
+# source of truth for backup history; the local file is a cache that survives
+# restarts. A wiped volume / fresh failover-promote with stale local state
+# triggers an extra full — harmless, pgBackRest's stanza locks prevent
+# concurrent backups across nodes.
+#
+# HA: every node runs the watcher. Standbys exit early via pg_is_in_recovery().
+# Only the leader runs backups. v1 of this watcher backs up from the primary;
+# `--backup-standby` is a follow-up.
+#
+# Known gap: pgBackRest's archive-push-queue-max trip drops segments without
+# incrementing pg_stat_archiver.failed_count and without going through our
+# archive-push wrapper, so neither gap signal fires. Until log-parsing or LSN-
+# lag detection lands, queue-max-trip gaps are sealed by the next periodic
+# full rather than promptly. Documented in README.
+
+set -u
+
+PGDATA="${PGDATA:-/var/lib/postgresql/data}"
+STATE_FILE="$PGDATA/.pgbackrest_backup_state"
+GAP_MARKER="$PGDATA/.pgbackrest_gap_pending"
+
+POLL_INTERVAL_SECONDS=60
+
+# Failures must have been quiescent for this long before a gap-recovery backup
+# fires. Hard failures often resolve and re-fail (intermittent S3, half-rotated
+# creds); without the grace the watcher burns one full per flap.
+GAP_RESOLVED_GRACE_SECONDS=300
+
+FULL_INTERVAL_HOURS="${WAL_BACKUP_FULL_INTERVAL_HOURS:-168}"
+DIFF_INTERVAL_HOURS="${WAL_BACKUP_DIFF_INTERVAL_HOURS:-24}"
+
+log() { echo "pgbackrest-watcher: $*"; }
+
+# State file is `key=value\n`-shaped: trivially read/written by bash without
+# adding a JSON dep. Schema (all values are integer epoch seconds or counts):
+#   last_full_at=<epoch>
+#   last_diff_at=<epoch>
+#   last_full_failed_count=<int>
+read_state() {
+  local field="$1"
+  [ ! -f "$STATE_FILE" ] && return 0
+  grep -E "^${field}=" "$STATE_FILE" 2>/dev/null | tail -1 | cut -d= -f2-
+}
+
+write_state_field() {
+  local field="$1" value="$2"
+  local tmp
+  tmp=$(mktemp "$STATE_FILE.XXXX") || return 1
+  if [ -f "$STATE_FILE" ]; then
+    grep -vE "^${field}=" "$STATE_FILE" > "$tmp" 2>/dev/null || true
+  fi
+  echo "${field}=${value}" >> "$tmp"
+  mv "$tmp" "$STATE_FILE"
+}
+
+# Stats from pg_stat_archiver. Sets globals so callers can branch on them
+# without repeated psql round-trips.
+ARCHIVED_COUNT=0
+FAILED_COUNT=0
+LAST_ARCHIVED_EPOCH=0
+LAST_FAILED_EPOCH=0
+
+refresh_archiver_stats() {
+  local stats
+  stats=$(psql -U postgres -tAXq -F' ' -c "
+    SELECT
+      archived_count,
+      failed_count,
+      COALESCE(EXTRACT(EPOCH FROM last_archived_time)::bigint, 0),
+      COALESCE(EXTRACT(EPOCH FROM last_failed_time)::bigint, 0)
+    FROM pg_stat_archiver
+  " 2>/dev/null) || return 1
+  [ -z "$stats" ] && return 1
+  read -r ARCHIVED_COUNT FAILED_COUNT LAST_ARCHIVED_EPOCH LAST_FAILED_EPOCH <<<"$stats"
+}
+
+# 0 = standby (skip backups). 1 = leader-or-unknown (proceed; pgBackRest's
+# stanza lock is the second-line guarantee against double-trigger).
+is_standby() {
+  local r
+  r=$(psql -U postgres -tAXq -c "SELECT pg_is_in_recovery()" 2>/dev/null) || return 1
+  [ "$r" = "t" ]
+}
+
+# Returns 0 if archive failures look decisively over.
+gap_recovered() {
+  local now="$1" last_fail="$2"
+  # Never failed (fresh stat reset, or never had a failure) → trivially recovered.
+  [ "$last_fail" -eq 0 ] && return 0
+  [ $((now - last_fail)) -ge "$GAP_RESOLVED_GRACE_SECONDS" ]
+}
+
+run_backup() {
+  local type="$1"
+  log "running pgbackrest backup --type=$type"
+  if pgbackrest --stanza=main backup --type="$type"; then
+    local now; now=$(date +%s)
+    case "$type" in
+      full)
+        write_state_field last_full_at "$now"
+        write_state_field last_diff_at "$now"
+        # Re-read failed_count *after* the backup so a failure during the
+        # backup itself is folded into the high-water mark; otherwise the
+        # next iteration would see growth and re-trigger immediately.
+        refresh_archiver_stats || true
+        write_state_field last_full_failed_count "$FAILED_COUNT"
+        [ -f "$GAP_MARKER" ] && rm -f "$GAP_MARKER" && log "cleared gap marker"
+        ;;
+      diff|incr)
+        write_state_field last_diff_at "$now"
+        ;;
+    esac
+    log "backup --type=$type completed"
+    return 0
+  fi
+  log "backup --type=$type failed (will retry on next poll)"
+  return 1
+}
+
+# Returns the type to run on stdout, or empty if no action.
+decide_action() {
+  refresh_archiver_stats || return 0
+
+  local now; now=$(date +%s)
+  local last_full last_diff last_full_failed
+  last_full=$(read_state last_full_at)
+  last_diff=$(read_state last_diff_at)
+  last_full_failed=$(read_state last_full_failed_count)
+  : "${last_full_failed:=0}"
+
+  # NEEDS_INITIAL_BACKUP — archiving has produced any segments, no full on record.
+  if [ -z "$last_full" ] && [ "$ARCHIVED_COUNT" -gt 0 ]; then
+    echo "full"; return 0
+  fi
+  [ -z "$last_full" ] && return 0  # archiving hasn't started, wait
+
+  # Gap recovery — explicit drop marker OR failed_count grew since last full.
+  # Either signal indicates archive-push had problems since the last
+  # LSN-coordinated baseline, so a fresh full re-anchors the PITR window.
+  local has_gap=0
+  [ -f "$GAP_MARKER" ] && has_gap=1
+  [ "$FAILED_COUNT" -gt "$last_full_failed" ] && has_gap=1
+
+  if [ "$has_gap" -eq 1 ]; then
+    if gap_recovered "$now" "$LAST_FAILED_EPOCH"; then
+      echo "full"; return 0
+    fi
+    return 0  # gap still open, waiting for grace
+  fi
+
+  # Periodic full.
+  if [ "$FULL_INTERVAL_HOURS" -gt 0 ] \
+     && [ "$now" -ge $((last_full + FULL_INTERVAL_HOURS * 3600)) ]; then
+    echo "full"; return 0
+  fi
+
+  # Periodic diff.
+  if [ "$DIFF_INTERVAL_HOURS" -gt 0 ]; then
+    local diff_anchor="${last_diff:-$last_full}"
+    if [ "$now" -ge $((diff_anchor + DIFF_INTERVAL_HOURS * 3600)) ]; then
+      echo "diff"; return 0
+    fi
+  fi
+}
+
+watcher_iteration() {
+  pg_isready -h 127.0.0.1 -p 5432 -U postgres -q 2>/dev/null || return 0
+  is_standby && return 0
+
+  local action
+  action=$(decide_action)
+  [ -z "$action" ] && return 0
+
+  run_backup "$action" || true
+}
+
+# wrapper.sh forks us unconditionally; bail silently if archiving isn't on.
+[ -z "${WAL_ARCHIVE_BUCKET:-}" ] && exit 0
+
+# In dual-repo recovery mode (WAL_RECOVER_FROM_* + WAL_ARCHIVE_*), backups
+# would target both repos by default, including source's read-only repo1.
+# The standard PITR-enable flow on a restored service clears WAL_RECOVER_FROM_*
+# before adding WAL_ARCHIVE_*; until then, skip.
+if [ -n "${WAL_RECOVER_FROM_BUCKET:-}" ]; then
+  log "skipping — both WAL_RECOVER_FROM_* and WAL_ARCHIVE_* are set; clear the recover-from vars to enable backups"
+  exit 0
+fi
+
+log "starting (poll=${POLL_INTERVAL_SECONDS}s, full=${FULL_INTERVAL_HOURS}h, diff=${DIFF_INTERVAL_HOURS}h, gap_grace=${GAP_RESOLVED_GRACE_SECONDS}s)"
+
+while true; do
+  watcher_iteration
+  sleep "$POLL_INTERVAL_SECONDS"
+done

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -170,6 +170,12 @@ PGBACKREST_SPOOL_DIR="$PGDATA/pgbackrest-spool"
 PITR_STAGING_FILE="$PGDATA/.pitr_staging"
 PITR_DONE_MARKER="$PGDATA/.pitr_configured"
 
+# Written by restore_from_pgbackrest_if_empty_volume after a successful
+# `pgbackrest restore` populates an empty volume. Tells configure_pgbackrest_recovery
+# to bail — pgbackrest restore already wrote recovery.signal + recovery params,
+# our conf.d/pgbackrest-recovery.conf path would duplicate them.
+PGBACKREST_RESTORED_MARKER="$PGDATA/.pgbackrest_restored"
+
 # Add `include_dir = 'conf.d'` to postgresql.conf if not already present.
 # postgresql.conf is not rewritten by Postgres at runtime (only auto.conf is,
 # by ALTER SYSTEM), so this single line is durable. Called from both the
@@ -280,6 +286,23 @@ render_pgbackrest_conf() {
     repo2_block="repo2-type=s3"$'\n'
   fi
 
+  # Retention knobs are written for whichever repo this service archives to.
+  # In standalone (REPO1 = archive bucket) → write under repo1.
+  # In dual-repo recovery mode (REPO1 = source / read, REPO2 = own archive)
+  # → write under repo2; repo1's source bucket has its own retention owned
+  # by the source service. pgbackrest expire runs after every backup and
+  # uses these to remove stale fulls/diffs and the WAL they pinned.
+  # repo*-retention-archive is left to pgBackRest's default (= retention-full),
+  # which keeps WAL needed for the most recent N fulls.
+  local retention_full="${WAL_BACKUP_RETENTION_FULL:-4}"
+  local retention_diff="${WAL_BACKUP_RETENTION_DIFF:-14}"
+  local retention_block=""
+  if [ -n "${PGBACKREST_REPO2_S3_BUCKET:-}" ]; then
+    retention_block="repo2-retention-full=${retention_full}"$'\n'"repo2-retention-diff=${retention_diff}"$'\n'
+  elif [ -n "${WAL_ARCHIVE_BUCKET:-}" ]; then
+    retention_block="repo1-retention-full=${retention_full}"$'\n'"repo1-retention-diff=${retention_diff}"$'\n'
+  fi
+
   cat > "$PGBACKREST_CONF_FILE" <<EOF
 [global]
 repo1-type=s3
@@ -292,7 +315,7 @@ spool-path=${PGBACKREST_SPOOL_DIR}
 compress-type=zst
 compress-level=3
 start-fast=y
-
+${retention_block}
 [global:archive-push]
 process-max=${push_max}
 
@@ -351,11 +374,17 @@ clear_pgbackrest_state_if_disabled() {
   local removed=0
   if [ -z "${WAL_ARCHIVE_BUCKET:-}" ]; then
     [ -f "$PGBACKREST_ARCHIVE_CONF" ] && rm -f "$PGBACKREST_ARCHIVE_CONF" && removed=1
+    # Backup-watcher state is scoped to a particular archive bucket — when
+    # the bucket goes away, drop the state so a future re-enable starts
+    # from NEEDS_INITIAL_BACKUP rather than a stale "last full was X" cache.
+    [ -f "$PGDATA/.pgbackrest_backup_state" ] && rm -f "$PGDATA/.pgbackrest_backup_state" && removed=1
+    [ -f "$PGDATA/.pgbackrest_gap_pending" ] && rm -f "$PGDATA/.pgbackrest_gap_pending" && removed=1
   fi
   if [ -z "${WAL_RECOVER_FROM_BUCKET:-}" ]; then
     [ -f "$PGBACKREST_RECOVERY_CONF" ] && rm -f "$PGBACKREST_RECOVERY_CONF" && removed=1
     [ -f "$PITR_STAGING_FILE" ] && rm -f "$PITR_STAGING_FILE" && removed=1
     [ -f "$PITR_DONE_MARKER" ] && rm -f "$PITR_DONE_MARKER" && removed=1
+    [ -f "$PGBACKREST_RESTORED_MARKER" ] && rm -f "$PGBACKREST_RESTORED_MARKER" && removed=1
   fi
   if [ -z "${WAL_ARCHIVE_BUCKET:-}" ] && [ -z "${WAL_RECOVER_FROM_BUCKET:-}" ]; then
     [ -f "$PGBACKREST_CONF_FILE" ] && rm -f "$PGBACKREST_CONF_FILE" && removed=1
@@ -450,6 +479,13 @@ configure_pgbackrest_recovery() {
   [ -z "$POSTGRES_RECOVERY_TARGET_TIME" ] && return 0
   [ ! -f "$POSTGRES_CONF_FILE" ] && return 0
 
+  # The pgbackrest-restore path (empty-volume restore) handles recovery
+  # staging itself — recovery.signal + recovery params come out of
+  # `pgbackrest restore`, not our conf.d include. Skip the include-write
+  # path so we don't end up with duplicate recovery_target_time settings.
+  if [ -f "$PGBACKREST_RESTORED_MARKER" ]; then
+    return 0
+  fi
 
   if [ -f "$PITR_DONE_MARKER" ]; then
     return 0
@@ -484,11 +520,58 @@ EOF
   echo "pgbackrest: PITR replay staged (target=${POSTGRES_RECOVERY_TARGET_TIME})"
 }
 
+# When a restored service is created with an empty volume + WAL_RECOVER_FROM_*
+# + POSTGRES_RECOVERY_TARGET_TIME, restore the data dir directly from the
+# source bucket via pgbackrest. Replaces v1's "snapshot replicate, then
+# archive-get during recovery" two-step. The restore command pulls the most
+# recent base backup ≤ T, applies WAL forward to T, writes recovery.signal +
+# recovery params; postmaster boots straight into recovery and promotes.
+#
+# The .pgbackrest_restored marker tells configure_pgbackrest_recovery to
+# stay out of the way (its conf.d include would duplicate what pgbackrest
+# restore already wrote).
+#
+# Container restart on an already-restored volume: $PGDATA is populated, so
+# the empty-PGDATA gate fails and we skip — Postgres starts normally.
+restore_from_pgbackrest_if_empty_volume() {
+  [ -z "${WAL_RECOVER_FROM_BUCKET:-}" ] && return 0
+  [ -z "${POSTGRES_RECOVERY_TARGET_TIME:-}" ] && return 0
+  [ -f "$PGDATA/PG_VERSION" ] && return 0
+  [ -f "$PGBACKREST_RESTORED_MARKER" ] && return 0
+
+  echo "pgbackrest: empty PGDATA + recovery target — restoring from source bucket (target=${POSTGRES_RECOVERY_TARGET_TIME})"
+
+  install -d -m 0700 -o postgres -g postgres "$PGDATA"
+
+  if ! gosu postgres pgbackrest --stanza=main --repo=1 restore \
+       --type=time --target="$POSTGRES_RECOVERY_TARGET_TIME" \
+       --target-action=promote; then
+    echo "pgbackrest: restore from source bucket failed; fix env vars (WAL_RECOVER_FROM_*, POSTGRES_RECOVERY_TARGET_TIME) and redeploy" >&2
+    exit 1
+  fi
+
+  touch "$PGBACKREST_RESTORED_MARKER"
+  chown postgres:postgres "$PGBACKREST_RESTORED_MARKER" 2>/dev/null || true
+  echo "pgbackrest: restore complete; postgres will replay forward to ${POSTGRES_RECOVERY_TARGET_TIME} and promote on first start"
+}
+
+# Fork the backup watcher. Subshell pattern matches bootstrap_pgbackrest_stanza
+# — gosu drops to postgres so the watcher's psql calls use peer auth via the
+# Unix socket and `pgbackrest backup` runs as the right uid. The watcher gates
+# itself on WAL_ARCHIVE_BUCKET / WAL_RECOVER_FROM_BUCKET internally, so the
+# fork is unconditional and cheap when archiving isn't on.
+fork_pgbackrest_backup_watcher() {
+  [ -z "${WAL_ARCHIVE_BUCKET:-}" ] && return 0
+  gosu postgres /usr/local/bin/pgbackrest-backup-watcher.sh &
+}
+
 render_pgbackrest_conf
+restore_from_pgbackrest_if_empty_volume
 clear_pgbackrest_state_if_disabled
 apply_pgbackrest_archive_conf
 configure_pgbackrest_recovery
 bootstrap_pgbackrest_stanza
+fork_pgbackrest_backup_watcher
 
 # unset PGHOST to force psql to use Unix socket path
 # this is specific to Railway and allows


### PR DESCRIPTION
## Summary

Drops PITR's dependency on block-level RBD snapshots. The image now takes its own pgBackRest base backups, triggered by archiving health, with no external coordination.

This implements the v2 extension to the [PITR for Postgres RFC](https://www.notion.so/railwayapp/PITR-for-Postgres-34a0e4c54563805f8f36c9c7b2dd5645) — the v2 section in that doc spells out the design.

### What changed

- **`pgbackrest-backup-watcher.sh`** — long-running daemon forked from `wrapper.sh` (same fork pattern as `bootstrap_pgbackrest_stanza`). Polls Postgres every 60s and runs `pgbackrest backup` on three triggers:
  - `NEEDS_INITIAL_BACKUP` — first `archive-push` success after enable. Anchors the PITR window from the first archived LSN forward. **Fixes the v1 "snapshot-then-archive race"**: pgBackRest's `pg_backup_start/stop` brackets the base in an LSN window, so base + WAL are LSN-coordinated by construction.
  - **Gap recovery** — either `pgbackrest-archive-push-wrapper.sh` dropped a segment (`$PGDATA/.pgbackrest_gap_pending`) OR `pg_stat_archiver.failed_count` grew since the last full. Once failures are quiescent for 5 minutes, runs a fresh full so the PITR window resumes from the new LSN.
  - **Periodic** — full every `WAL_BACKUP_FULL_INTERVAL_HOURS` (default 168h / weekly), diff every `WAL_BACKUP_DIFF_INTERVAL_HOURS` (default 24h). `0` disables either.

- **Archive-push wrapper** writes `$PGDATA/.pgbackrest_gap_pending` on hard-error drop so the watcher can seal the gap.

- **Restore-from-empty-volume path** — when `$PGDATA` is uninitialized AND `WAL_RECOVER_FROM_*` + `POSTGRES_RECOVERY_TARGET_TIME` are set, the wrapper runs `pgbackrest --repo=1 restore --type=time --target=<T> --target-action=promote` against the source bucket before `docker-entrypoint` touches anything. Replaces v1's "refuse to start without populated PGDATA" branch and the snapshot-replicate-then-archive-get two-step on backboard's side. The `.pgbackrest_restored` marker keeps `configure_pgbackrest_recovery` out of the way on subsequent boots.

- **Retention knobs** (`WAL_BACKUP_RETENTION_FULL=4`, `WAL_BACKUP_RETENTION_DIFF=14`) re-rendered into `pgbackrest.conf` so `pgbackrest expire` (runs automatically after each backup) is the WAL-retention authority. Bucket lifecycle TTL becomes a safety net only — backup manifests pin WAL.

- **HA**: every node runs the watcher; standbys exit early on `SELECT pg_is_in_recovery()`; only the leader runs backups. pgBackRest stanza locks are the second-line guarantee against double-trigger across a failover.

### State files

| File | Scope | Cleared when |
|---|---|---|
| `$PGDATA/.pgbackrest_backup_state` | bucket | `WAL_ARCHIVE_BUCKET` unset |
| `$PGDATA/.pgbackrest_gap_pending` | bucket | `WAL_ARCHIVE_BUCKET` unset OR cleared by watcher after gap-recovery full |
| `$PGDATA/.pgbackrest_restored` | recovery | `WAL_RECOVER_FROM_BUCKET` unset |

### Known gap (deferred follow-up)

pgBackRest's `archive-push-queue-max` trip drops segments without going through our wrapper *and* without incrementing `pg_stat_archiver.failed_count`, so neither gap signal fires. Until log parsing or LSN-lag detection lands, queue-max-trip gaps are sealed by the next periodic full rather than promptly.

### Out of scope

- `--backup-standby` (v1 of the watcher backs up from primary; standby-aware variant is a follow-up)
- backboard's `createServiceFromPITRWorkflow` change to skip snapshot replication (lives in `mono`)
- Backups UI surface for the new `pgbackrest info` listing (lives in `mono`)
- Migration of existing PITR-enabled services off block snapshots (one-shot in `mono`)

## Test plan

- [ ] Build each `Dockerfile.13`–`Dockerfile.18` succeeds and the new script lands at `/usr/local/bin/pgbackrest-backup-watcher.sh`
- [ ] Standalone Postgres + `WAL_ARCHIVE_*` set: watcher takes initial full once first WAL segment is archived, state file populated
- [ ] Force archive failure (rotate creds → wrapper drops segment → restore creds): watcher takes a fresh full after grace period, gap marker cleared
- [ ] Periodic backups: shrink intervals via env vars and confirm full + diff cadence
- [ ] HA: verify only leader runs backups (standbys exit on `pg_is_in_recovery`)
- [ ] Empty-volume restore: provision fresh service with `WAL_RECOVER_FROM_*` + `POSTGRES_RECOVERY_TARGET_TIME` against an existing PITR-enabled bucket, confirm `pgbackrest restore` populates `$PGDATA` and Postgres replays + promotes
- [ ] Retention: set `WAL_BACKUP_RETENTION_FULL=2` + small interval, confirm `pgbackrest expire` removes oldest fulls
- [ ] Disable: unset `WAL_ARCHIVE_BUCKET`, confirm `.pgbackrest_backup_state` and `.pgbackrest_gap_pending` are cleared