### PR TITLE
fix(pitr): unstick crash-loops when target is past archive head

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -582,8 +582,43 @@ fork_pgbackrest_backup_watcher() {
   gosu postgres /usr/local/bin/pgbackrest-backup-watcher.sh &
 }
 
+# Crash-loop escape hatch for unreachable PITR targets. pgbackrest restore
+# bakes recovery_target_time into postgresql.auto.conf; if T is past the
+# last archived WAL, postgres replays end-of-WAL and FATALs with "recovery
+# ended before configured recovery target was reached" — every container
+# start hits the same wall, forever. Backboard's restore mutation now
+# rejects T > lastArchivedAt at submit time, but volumes restored before
+# that guard landed (or via stale clients) can still get stuck. Track
+# consecutive boots; after a few failed attempts strip the target so
+# postgres promotes at end-of-WAL on the next start. Idempotent — once
+# stripped, the marker prevents re-stripping after a clean boot.
+maybe_strip_unreachable_recovery_target() {
+  [ ! -f "$PGBACKREST_RESTORED_MARKER" ] && return 0
+  [ -f "$PGDATA/.pitr_target_stripped" ] && return 0
+  local auto_conf="$PGDATA/postgresql.auto.conf"
+  [ ! -f "$auto_conf" ] && return 0
+  grep -qE "^[[:space:]]*recovery_target_time" "$auto_conf" || return 0
+
+  local attempts_file="$PGDATA/.pitr_recovery_attempts"
+  local attempts
+  attempts=$(cat "$attempts_file" 2>/dev/null || echo 0)
+  attempts=$((attempts + 1))
+  echo "$attempts" > "$attempts_file"
+  chown postgres:postgres "$attempts_file" 2>/dev/null || true
+
+  local threshold=3
+  if [ "$attempts" -ge "$threshold" ]; then
+    echo "wrapper.sh: PITR recovery has crash-looped ${attempts}x — target is likely past end of available WAL. Stripping recovery_target_time so postgres promotes at end-of-WAL on next start (T may have been after the source's last archived transaction)." >&2
+    sed -i.bak "/^[[:space:]]*recovery_target_time/d" "$auto_conf"
+    touch "$PGDATA/.pitr_target_stripped"
+    chown postgres:postgres "$PGDATA/.pitr_target_stripped" 2>/dev/null || true
+    rm -f "$attempts_file"
+  fi
+}
+
 render_pgbackrest_conf
 restore_from_pgbackrest_if_empty_volume
+maybe_strip_unreachable_recovery_target
 clear_pgbackrest_state_if_disabled
 apply_pgbackrest_archive_conf
 configure_pgbackrest_recovery


### PR DESCRIPTION
## Summary
Wrapper-side escape hatch: when a PITR restore's recovery_target_time is past the last archived WAL, postgres FATALs forever (`recovery ended before configured recovery target was reached`). After 3 failed boots strip recovery_target_time so postgres promotes at end-of-WAL.

## Why
Caught restoring a PITR target on develop:

```
last completed transaction was at log time 2026-04-30 14:06:10.861123+00
FATAL: recovery ended before configured recovery target was reached
```

Source DB went idle at 14:06:10. User picked target 14:06:23 — 13s into the idle period, no covering WAL ever existed. Container hit max-retries every cycle, postgres never promoted, volume stayed unrecoverable.

Backboard's `volumeInstancePITRRestore` mutation now rejects T > lastArchivedAt at submit time, but a volume restored before that guard landed (or via a stale client) is still stuck — the recovery params are baked into postgresql.auto.conf inside the volume.

## Test plan
- [ ] After republish, redeploy a stuck PITR-restored container; observe wrapper.sh log "PITR recovery has crash-looped 3x — stripping recovery_target_time"
- [ ] Confirm postgres promotes at end-of-WAL on the 4th boot
- [ ] Confirm `.pitr_target_stripped` marker prevents re-stripping on subsequent restarts