### PR TITLE
docs(README): pgBackRest expire is the sole WAL retention authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,13 +247,13 @@ removes fulls/diffs beyond `WAL_BACKUP_RETENTION_FULL` /
 
 #### Retention
 
-For PITR-enabled services, **`pgbackrest expire` is the source of truth
-for WAL retention**, not the bucket lifecycle policy. Backup manifests
-pin the WAL needed to make each backup restorable; expire removes them
-together when a backup ages out. The bucket's lifecycle TTL should be
-set as a safety net (≈ 2 × the longest pinned-WAL window) — looser than
-expire's effective horizon, so it never expires WAL out from under a
-live manifest.
+For PITR-enabled services, **`pgbackrest expire` is the sole WAL
+retention authority** — no bucket-side lifecycle policy. Backup
+manifests pin the WAL needed to make each backup restorable; expire
+releases both together when a backup ages out. Earlier iterations
+proposed a bucket-side TTL as a safety net but it's superfluous: any
+TTL shorter than expire's horizon would yank WAL out from under live
+manifests, and any TTL ≥ that horizon is redundant.
 
 The default retention (full=4, diff=14, weekly fulls + daily diffs)
 covers approximately a four-week PITR window before the oldest full


### PR DESCRIPTION
## Summary

Drops the "bucket lifecycle TTL as a safety net (≈ 2 × pinned-WAL window)"
guidance from the Retention section of the README. pgBackRest's `expire`
(auto-runs after each backup, releases backup manifests + their pinned WAL
together) handles WAL retention fully. Any bucket-side TTL would either match
expire (redundant) or run shorter (yank WAL out from under live manifests).

Brings the README in line with how the image actually behaves on master.

## Test plan

- [ ] Sanity-skim the rendered README on the PR diff to confirm the wording
      flows.