### PR TITLE
feat(pitr): per-cluster archive paths so wipe + reuse-bucket preserves both

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,40 @@ local file is a cache that survives restarts. A wiped volume re-derives
 from a single redundant initial full — pgBackRest's stanza locks
 prevent concurrent backups across cluster nodes.
 
+#### Per-cluster archive paths
+
+Each cluster archives under a sub-prefix derived from its
+`system_identifier`:
+`${WAL_ARCHIVE_PATH}/cluster-<system_identifier>`. The path is
+persisted in `$PGDATA/.pgbackrest_repo_path` so the archive-push
+wrapper, the backup watcher, and `pgbackrest stanza-create` all
+converge on the same value.
+
+Why per-cluster: a wipe-and-reuse-bucket cycle (operator drops the
+data volume, redeploys the service against the same `WAL_ARCHIVE_BUCKET`)
+produces a brand-new `system_identifier` from `initdb`. Without
+discrimination, pgBackRest's stanza-create would refuse the new
+cluster on system-id mismatch and the new cluster's WAL would never
+land — silent data loss for any operator who didn't notice. With
+per-cluster paths, the new cluster lands at
+`cluster-<new_sysid>`, the previous cluster's archive stays put at
+`cluster-<old_sysid>`, and both histories coexist. The bucket
+becomes a multi-history store: list its `cluster-*` sub-prefixes to
+enumerate every cluster that ever archived to it; pick a subprefix
+to restore from.
+
+Backward compat: if the legacy path (`${WAL_ARCHIVE_PATH}` directly,
+without a `cluster-*` sub-prefix) already holds an `archive.info`
+matching our `system_identifier`, the marker is written with the
+legacy path and we keep using it. Existing PITR-enabled services
+from before per-cluster pathing aren't asked to migrate.
+
+`WAL_RECOVER_FROM_PATH` on a restored service must point at the
+specific source-side `cluster-<sysid>` sub-prefix the user wants to
+restore from — `pgbackrest restore` reads from one path. Backboard
+discovers per-cluster sub-prefixes by listing the bucket and
+surfaces them as separate "histories" in the restore UI.
+
 In HA, every Postgres node runs the watcher and standbys exit early on
 `SELECT pg_is_in_recovery()` — only the leader performs backups. v1 of
 the watcher backs up from the primary; `--backup-standby` is a

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ target, restore from a fresh volume snapshot (or, advanced: remove
 `$PGDATA/.pitr_configured` before the next start).
 
 When `POSTGRES_RECOVERY_TARGET_TIME` is set on a brand-new container
-(no `$PGDATA/PG_VERSION`), the wrapper runs `pgbackrest --repo=1 restore
+(no `$PGDATA/PG_VERSION`), the wrapper runs `pgbackrest --repo=2 restore
 --type=time --target=<T> --target-action=promote` against the source
 bucket *before* `docker-entrypoint` initializes anything. pgBackRest
 pulls the most recent base backup ≤ T plus the WAL chain forward into
@@ -191,14 +191,6 @@ pulls the most recent base backup ≤ T plus the WAL chain forward into
 boots straight into archive recovery. A `.pgbackrest_restored` marker is
 written on success; `configure_pgbackrest_recovery` defers to the
 restore's own settings on subsequent starts of the same volume.
-
-If `$PGDATA` is already populated (the legacy snapshot-based restore
-flow), the conf.d-include path is used as before — `recovery_target_time`
-+ `restore_command` are written to `$PGDATA/conf.d/pgbackrest-recovery.conf`,
-`recovery.signal` is touched, and Postgres replays WAL from the source
-bucket via `archive-get`. The two paths share the same env contract
-(`WAL_RECOVER_FROM_*` + `POSTGRES_RECOVERY_TARGET_TIME`) and only differ
-on the initial-volume question.
 
 #### Image-owned base backups
 
@@ -250,12 +242,6 @@ per-cluster paths, the new cluster lands at
 becomes a multi-history store: list its `cluster-*` sub-prefixes to
 enumerate every cluster that ever archived to it; pick a subprefix
 to restore from.
-
-Backward compat: if the legacy path (`${WAL_ARCHIVE_PATH}` directly,
-without a `cluster-*` sub-prefix) already holds an `archive.info`
-matching our `system_identifier`, the marker is written with the
-legacy path and we keep using it. Existing PITR-enabled services
-from before per-cluster pathing aren't asked to migrate.
 
 `WAL_RECOVER_FROM_PATH` on a restored service must point at the
 specific source-side `cluster-<sysid>` sub-prefix the user wants to

--- a/README.md
+++ b/README.md
@@ -71,14 +71,18 @@ The image reads a tool-agnostic `WAL_ARCHIVE_*` / `WAL_RECOVER_FROM_*`
 env contract and translates internally to pgBackRest's native
 `PGBACKREST_REPO{1,2}_S3_*`, so swapping pgBackRest for another archiver
 in the future is a wrapper change rather than a cross-repo rewrite.
-Three modes:
 
-- `WAL_ARCHIVE_*` only → standalone archiving service. `repo1` = archive bucket.
-- `WAL_RECOVER_FROM_*` only → PITR-restored service, no ongoing archiving.
-  `repo1` = source's bucket (read-only during recovery).
-- `WAL_ARCHIVE_*` + `WAL_RECOVER_FROM_*` → restored service that has been
-  re-enabled for archiving. `repo1` = source (read), `repo2` = own
-  archive bucket (write).
+Invariant: `repo1` is always "this service's own destination bucket" —
+the only place this service writes WAL. `repo2`, when present, is a
+read-only recovery source. No two services ever share a destination
+bucket. Two modes:
+
+- `WAL_ARCHIVE_*` only → standalone archiving service. `repo1` = own bucket.
+- `WAL_ARCHIVE_*` + `WAL_RECOVER_FROM_*` → PITR-restored fork. `repo1` =
+  fork's own fresh bucket (writes from boot), `repo2` = source's bucket
+  (read-only during recovery; ignored after promote, the fork's new
+  timeline doesn't exist there). The fork archives to its own bucket
+  from day one — no separate "re-enable PITR after restore" step.
 
 `archive_command` points at `/usr/local/bin/pgbackrest-archive-push-wrapper.sh`
 rather than calling `pgbackrest archive-push` directly. The wrapper tries the
@@ -114,7 +118,7 @@ Operator-facing env contract:
 | `WAL_ARCHIVE_REGION` | bucket region |
 | `WAL_ARCHIVE_KEY` / `WAL_ARCHIVE_SECRET` | bucket credentials |
 | `WAL_ARCHIVE_PATH` | path prefix where archive-push writes (default `/pgbackrest`) |
-| `WAL_RECOVER_FROM_BUCKET` / `_ENDPOINT` / `_REGION` / `_KEY` / `_SECRET` / `_PATH` | source-bucket coordinates on a PITR-restored service; `archive-get` reads source WAL from here during replay. Set by backboard on restore; not normally a manual knob. |
+| `WAL_RECOVER_FROM_BUCKET` / `_ENDPOINT` / `_REGION` / `_KEY` / `_SECRET` / `_PATH` | source-bucket coordinates on a PITR-restored fork; mounted as `repo2` (read-only) so `archive-get` and the empty-volume `pgbackrest restore` can pull source WAL during replay. Set by backboard on restore; not normally a manual knob. |
 | `POSTGRES_RECOVERY_TARGET_TIME` | ISO 8601 timestamp; stages archive-recovery replay on next start |
 | `POSTGRES_ARCHIVE_TIMEOUT` | seconds Postgres waits before forcing a WAL switch (default `60`) |
 | `WAL_BACKUP_FULL_INTERVAL_HOURS` | image-owned full base-backup cadence (default `168` = weekly; `0` disables periodic fulls). Initial / gap-recovery fulls fire regardless. |
@@ -143,15 +147,15 @@ default. The `PGBACKREST_*_PROCESS_MAX` env vars (table above) are
 escape hatches for workloads that disprove the heuristic. On vertical
 autoscale, the new values take effect on the next container restart.
 
-Stanza initialization (`pgbackrest stanza-create`) runs automatically the
-first time the container boots with `WAL_ARCHIVE_BUCKET` set: a
-background task waits for Postgres to accept connections, then writes the
-stanza metadata into the bucket. The command is idempotent and runs on
-every subsequent boot — already-correct repo metadata is a no-op; a
-mismatch (e.g. `WAL_ARCHIVE_PATH` pointing at another cluster's repo)
-errors loudly, which is the safety we want. Stanza-create only runs
-against the service's own archive bucket, never against a
-`WAL_RECOVER_FROM_*` source repo (which is read-only during recovery).
+Stanza initialization (`pgbackrest stanza-create --repo=1`) runs
+automatically the first time the container boots with `WAL_ARCHIVE_BUCKET`
+set: a background task waits for Postgres to accept connections, then
+writes the stanza metadata into the bucket. The command is idempotent
+and runs on every subsequent boot — already-correct repo metadata is a
+no-op; a mismatch (e.g. `WAL_ARCHIVE_PATH` pointing at another cluster's
+repo) errors loudly, which is the safety we want. The `--repo=1` scope
+keeps stanza-create off `repo2` on a fork, where source already owns the
+stanza and we have read-only intent.
 
 All Postgres-side config the image manages (archive settings, recovery
 settings) is written to `$PGDATA/conf.d/*.conf`, with a one-time

--- a/pgbackrest-archive-push-wrapper.sh
+++ b/pgbackrest-archive-push-wrapper.sh
@@ -65,16 +65,12 @@ if [ -f "$PGDATA/.pgbackrest_repo_path" ]; then
   export PGBACKREST_REPO1_PATH
 fi
 
-# When two repos are configured (restored service: repo1=recover-from,
-# repo2=archive), pin archive-push to repo2 so post-promote WAL doesn't
-# spray into the source bucket. Standalone services have only repo1 set
-# and skip the flag entirely.
-REPO_FLAG=""
-if [ -n "${PGBACKREST_REPO2_S3_BUCKET:-}" ]; then
-  REPO_FLAG="--repo=2"
-fi
-
-pgbackrest --stanza=main $REPO_FLAG archive-push "$WAL_FILE"
+# Pin archive-push to repo1 unconditionally. REPO1 is always this service's
+# own destination bucket (invariant set in wrapper.sh's env translation).
+# On a fork, repo2 is the source's read-only bucket — pgBackRest's default
+# archive-push targets all configured repos, so without the pin the fork
+# would spray its post-promote WAL into source's bucket.
+pgbackrest --stanza=main --repo=1 archive-push "$WAL_FILE"
 PGB_RC=$?
 if [ "$PGB_RC" -eq 0 ]; then
   exit 0

--- a/pgbackrest-archive-push-wrapper.sh
+++ b/pgbackrest-archive-push-wrapper.sh
@@ -56,10 +56,10 @@ PGWAL_THRESHOLD_BYTES=$(( PGWAL_THRESHOLD_MB * 1024 * 1024 ))
 
 # Per-cluster repo-path: read the marker written by pgbackrest-init.sh /
 # wrapper.sh's bootstrap subshell. Without this, every archive-push would
-# go to the legacy ${WAL_ARCHIVE_PATH} root and a wipe-and-reuse-bucket
-# scenario would collide on stanza identity. With it, fresh clusters land
-# at ${WAL_ARCHIVE_PATH}/cluster-<sysid>; existing clusters whose marker
-# was written to the legacy path keep using it (backward compat).
+# go to the ${WAL_ARCHIVE_PATH} root and a wipe-and-reuse-bucket scenario
+# would collide on stanza identity. With it, archive-push targets
+# ${WAL_ARCHIVE_PATH}/cluster-<sysid> and post-wipe clusters get their own
+# sub-prefix instead of trying to overwrite the predecessor's repo.
 if [ -f "$PGDATA/.pgbackrest_repo_path" ]; then
   PGBACKREST_REPO1_PATH=$(cat "$PGDATA/.pgbackrest_repo_path")
   export PGBACKREST_REPO1_PATH

--- a/pgbackrest-archive-push-wrapper.sh
+++ b/pgbackrest-archive-push-wrapper.sh
@@ -54,6 +54,17 @@ PGDATA="${PGDATA:-/var/lib/postgresql/data}"
 PGWAL_THRESHOLD_MB="${WAL_DROP_THRESHOLD_MB:-500}"
 PGWAL_THRESHOLD_BYTES=$(( PGWAL_THRESHOLD_MB * 1024 * 1024 ))
 
+# Per-cluster repo-path: read the marker written by pgbackrest-init.sh /
+# wrapper.sh's bootstrap subshell. Without this, every archive-push would
+# go to the legacy ${WAL_ARCHIVE_PATH} root and a wipe-and-reuse-bucket
+# scenario would collide on stanza identity. With it, fresh clusters land
+# at ${WAL_ARCHIVE_PATH}/cluster-<sysid>; existing clusters whose marker
+# was written to the legacy path keep using it (backward compat).
+if [ -f "$PGDATA/.pgbackrest_repo_path" ]; then
+  PGBACKREST_REPO1_PATH=$(cat "$PGDATA/.pgbackrest_repo_path")
+  export PGBACKREST_REPO1_PATH
+fi
+
 # When two repos are configured (restored service: repo1=recover-from,
 # repo2=archive), pin archive-push to repo2 so post-promote WAL doesn't
 # spray into the source bucket. Standalone services have only repo1 set

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -127,7 +127,10 @@ gap_recovered() {
 run_backup() {
   local type="$1"
   log "running pgbackrest backup --type=$type"
-  if pgbackrest --stanza=main backup --type="$type"; then
+  # --repo=1 scopes backup + post-backup expire to this service's own bucket.
+  # On a fork repo2 is source's read-only bucket; without the pin pgBackRest
+  # would default to writing the new base into both repos.
+  if pgbackrest --stanza=main --repo=1 backup --type="$type"; then
     local now; now=$(date +%s)
     case "$type" in
       full)
@@ -222,16 +225,10 @@ watcher_iteration() {
 }
 
 # wrapper.sh forks us unconditionally; bail silently if archiving isn't on.
+# A fork has both WAL_ARCHIVE_* (own bucket / repo1) and WAL_RECOVER_FROM_*
+# (source bucket / repo2). The watcher targets only repo1 (run_backup pins
+# --repo=1), so the fork archives normally from boot — no skip path.
 [ -z "${WAL_ARCHIVE_BUCKET:-}" ] && exit 0
-
-# In dual-repo recovery mode (WAL_RECOVER_FROM_* + WAL_ARCHIVE_*), backups
-# would target both repos by default, including source's read-only repo1.
-# The standard PITR-enable flow on a restored service clears WAL_RECOVER_FROM_*
-# before adding WAL_ARCHIVE_*; until then, skip.
-if [ -n "${WAL_RECOVER_FROM_BUCKET:-}" ]; then
-  log "skipping — both WAL_RECOVER_FROM_* and WAL_ARCHIVE_* are set; clear the recover-from vars to enable backups"
-  exit 0
-fi
 
 # Per-cluster repo-path: read the marker (written by pgbackrest-init.sh
 # during initdb, or by wrapper.sh's bootstrap subshell on existing volumes).

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -50,12 +50,15 @@ PGDATA="${PGDATA:-/var/lib/postgresql/data}"
 STATE_FILE="$PGDATA/.pgbackrest_backup_state"
 GAP_MARKER="$PGDATA/.pgbackrest_gap_pending"
 
-POLL_INTERVAL_SECONDS=60
+# POLL_INTERVAL_SECONDS / GAP_RESOLVED_GRACE_SECONDS are env-overridable so
+# the e2e harness can exercise gap-recovery in <1 min instead of 5+. The
+# defaults are conservative; nothing user-facing advertises these knobs.
+POLL_INTERVAL_SECONDS="${WAL_BACKUP_POLL_INTERVAL_SECONDS:-60}"
 
 # Failures must have been quiescent for this long before a gap-recovery backup
 # fires. Hard failures often resolve and re-fail (intermittent S3, half-rotated
 # creds); without the grace the watcher burns one full per flap.
-GAP_RESOLVED_GRACE_SECONDS=300
+GAP_RESOLVED_GRACE_SECONDS="${WAL_BACKUP_GAP_RESOLVED_GRACE_SECONDS:-300}"
 
 FULL_INTERVAL_HOURS="${WAL_BACKUP_FULL_INTERVAL_HOURS:-168}"
 DIFF_INTERVAL_HOURS="${WAL_BACKUP_DIFF_INTERVAL_HOURS:-24}"
@@ -230,9 +233,26 @@ if [ -n "${WAL_RECOVER_FROM_BUCKET:-}" ]; then
   exit 0
 fi
 
-log "starting (poll=${POLL_INTERVAL_SECONDS}s, full=${FULL_INTERVAL_HOURS}h, diff=${DIFF_INTERVAL_HOURS}h, gap_grace=${GAP_RESOLVED_GRACE_SECONDS}s)"
+# Per-cluster repo-path: read the marker (written by pgbackrest-init.sh
+# during initdb, or by wrapper.sh's bootstrap subshell on existing volumes).
+# pgbackrest backup needs to target the same path that archive-push is
+# pushing to, otherwise stanza-create / backup land at the wrong prefix.
+# The marker may not exist yet on the very first watcher iteration (we're
+# forked from wrapper.sh before exec'ing docker-entrypoint), so the loop
+# below re-reads it on every iteration as a cheap fallback.
+sync_repo_path_from_marker() {
+  if [ -f "$PGDATA/.pgbackrest_repo_path" ]; then
+    PGBACKREST_REPO1_PATH=$(cat "$PGDATA/.pgbackrest_repo_path")
+    export PGBACKREST_REPO1_PATH
+  fi
+}
+
+sync_repo_path_from_marker
+
+log "starting (poll=${POLL_INTERVAL_SECONDS}s, full=${FULL_INTERVAL_HOURS}h, diff=${DIFF_INTERVAL_HOURS}h, gap_grace=${GAP_RESOLVED_GRACE_SECONDS}s, repo1-path=${PGBACKREST_REPO1_PATH:-unset})"
 
 while true; do
+  sync_repo_path_from_marker
   watcher_iteration
   sleep "$POLL_INTERVAL_SECONDS"
 done

--- a/pgbackrest-init.sh
+++ b/pgbackrest-init.sh
@@ -51,3 +51,19 @@ EOF
 chmod 0640 "$PGDATA/conf.d/pgbackrest.conf"
 
 echo "pgbackrest: archive config written to ${PGDATA}/conf.d/pgbackrest.conf during initdb"
+
+# Write the per-cluster repo-path marker now that pg_control exists. Doing
+# it here (during initdb's post-initdb hook phase, BEFORE the real postmaster
+# launches) means the very first archive_command invocation reads the
+# correct PGBACKREST_REPO1_PATH from the marker — no race with the bootstrap
+# subshell in wrapper.sh, no archive-push fired against the wrong path.
+if [ ! -f "$PGDATA/.pgbackrest_repo_path" ] && [ -f "$PGDATA/global/pg_control" ]; then
+  sysid=$(pg_controldata "$PGDATA" 2>/dev/null \
+    | awk -F: '/Database system identifier/ { gsub(/[ \t]/,"",$2); print $2 }')
+  if [ -n "$sysid" ]; then
+    cluster_path="${WAL_ARCHIVE_PATH:-/pgbackrest}/cluster-${sysid}"
+    echo "$cluster_path" > "$PGDATA/.pgbackrest_repo_path"
+    chmod 0640 "$PGDATA/.pgbackrest_repo_path"
+    echo "pgbackrest: per-cluster repo path = ${cluster_path}"
+  fi
+fi

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -176,6 +176,16 @@ PITR_DONE_MARKER="$PGDATA/.pitr_configured"
 # our conf.d/pgbackrest-recovery.conf path would duplicate them.
 PGBACKREST_RESTORED_MARKER="$PGDATA/.pgbackrest_restored"
 
+# Per-cluster archive sub-path: the effective repo1-path, persisted inside
+# PGDATA so the watcher, archive-push wrapper, and stanza-create subshell
+# all converge on the same value. Per-cluster pathing means a wipe-and-
+# reuse-bucket cycle (volume wiped, container redeployed against the same
+# WAL_ARCHIVE_BUCKET) lets the new cluster's history coexist with the old
+# at distinct sub-prefixes — no system-id collision, no orphaned data, no
+# silent overwrite. Mono surfaces all sub-paths as separate "histories"
+# the user can browse and restore from.
+PGBACKREST_REPO_PATH_MARKER="$PGDATA/.pgbackrest_repo_path"
+
 # Add `include_dir = 'conf.d'` to postgresql.conf if not already present.
 # postgresql.conf is not rewritten by Postgres at runtime (only auto.conf is,
 # by ALTER SYSTEM), so this single line is durable. Called from both the
@@ -194,6 +204,75 @@ ensure_pg_includes_confd() {
   fi
   echo "include_dir = 'conf.d'" >> "$POSTGRES_CONF_FILE"
   echo "pgbackrest: enabled include_dir 'conf.d' in postgresql.conf"
+}
+
+# Read Postgres' system_identifier from pg_control. Empty when pg_control
+# isn't on disk yet (fresh volume, pre-initdb).
+read_postgres_sysid() {
+  [ ! -f "$PGDATA/global/pg_control" ] && return 0
+  pg_controldata "$PGDATA" 2>/dev/null \
+    | awk -F: '/Database system identifier/ { gsub(/[ \t]/,"",$2); print $2 }'
+}
+
+# Resolve the effective repo1-path for archiving. Three paths in priority order:
+#
+#   1. Marker file present → trust it (chosen on a previous boot, possibly
+#      via path 2 or 3 below). Idempotent across boots; survives container
+#      restarts; wiped along with the volume.
+#   2. pg_control exists, marker absent, legacy path (`${WAL_ARCHIVE_PATH}`
+#      directly) holds an archive.info matching our system_identifier →
+#      stick with the legacy path. Backward compat for clusters that
+#      enabled PITR before per-cluster pathing shipped; their data isn't
+#      stranded at a now-orphaned path.
+#   3. Marker absent and legacy path doesn't claim our system_identifier →
+#      use `${WAL_ARCHIVE_PATH}/cluster-<sysid>`. Fresh clusters always
+#      land here. Old/colliding stanza data at the legacy path stays put.
+#
+# The marker is written under PGDATA so a volume wipe drops it. That's the
+# point: after wipe-and-reuse-bucket, the new cluster (different sysid)
+# gets a fresh marker pointing at a fresh `cluster-<new_sysid>` path. The
+# previous cluster's data at `cluster-<old_sysid>` is untouched and
+# remains visible to the bucket lister (mono UI).
+derive_pgbackrest_repo_path() {
+  local user_path="${WAL_ARCHIVE_PATH:-/pgbackrest}"
+
+  if [ -f "$PGBACKREST_REPO_PATH_MARKER" ]; then
+    cat "$PGBACKREST_REPO_PATH_MARKER"
+    return 0
+  fi
+
+  local sysid
+  sysid=$(read_postgres_sysid)
+  if [ -z "$sysid" ]; then
+    # Pre-initdb: no system_identifier yet. Fall back to user_path; the marker
+    # gets written by pgbackrest-init.sh post-initdb (or by the bootstrap
+    # subshell once Postgres is up), so subsequent reads converge.
+    echo "$user_path"
+    return 0
+  fi
+
+  # Backward-compat probe: peek at the legacy path. If its archive.info
+  # records our system_identifier, this is an existing PITR-enabled service
+  # from before per-cluster pathing — keep using the legacy path so its
+  # accumulated backup history isn't stranded.
+  if PGBACKREST_REPO1_PATH="$user_path" \
+       pgbackrest --stanza=main info --output=json 2>/dev/null \
+       | grep -qE "\"system-id\":[[:space:]]*\"?${sysid}[\",}]"; then
+    write_pgbackrest_repo_path_marker "$user_path"
+    echo "$user_path"
+    return 0
+  fi
+
+  local cluster_path="${user_path%/}/cluster-${sysid}"
+  write_pgbackrest_repo_path_marker "$cluster_path"
+  echo "$cluster_path"
+}
+
+write_pgbackrest_repo_path_marker() {
+  local path="$1"
+  echo "$path" > "$PGBACKREST_REPO_PATH_MARKER"
+  chown postgres:postgres "$PGBACKREST_REPO_PATH_MARKER" 2>/dev/null || true
+  chmod 0640 "$PGBACKREST_REPO_PATH_MARKER" 2>/dev/null || true
 }
 
 # Detect the container's effective CPU allocation. Reads cgroup v2 cpu.max
@@ -443,6 +522,14 @@ bootstrap_pgbackrest_stanza() {
       fi
       sleep 2
     done
+
+    # Re-derive the repo path now that pg_control is on disk. This is the
+    # canonical first chance to do it on a fresh-cluster path: pgbackrest-init.sh
+    # may also have written the marker during initdb, in which case derive
+    # just reads it.
+    repo_path=$(derive_pgbackrest_repo_path)
+    export PGBACKREST_REPO1_PATH="$repo_path"
+    echo "pgbackrest: using repo1-path=${repo_path}"
 
     if gosu postgres pgbackrest --stanza=main stanza-create; then
       echo "pgbackrest: stanza-create completed"

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -209,25 +209,21 @@ read_postgres_sysid() {
     | awk -F: '/Database system identifier/ { gsub(/[ \t]/,"",$2); print $2 }'
 }
 
-# Resolve the effective repo1-path for archiving. Three paths in priority order:
+# Resolve the effective repo1-path for archiving:
 #
-#   1. Marker file present → trust it (chosen on a previous boot, possibly
-#      via path 2 or 3 below). Idempotent across boots; survives container
-#      restarts; wiped along with the volume.
-#   2. pg_control exists, marker absent, legacy path (`${WAL_ARCHIVE_PATH}`
-#      directly) holds an archive.info matching our system_identifier →
-#      stick with the legacy path. Backward compat for clusters that
-#      enabled PITR before per-cluster pathing shipped; their data isn't
-#      stranded at a now-orphaned path.
-#   3. Marker absent and legacy path doesn't claim our system_identifier →
-#      use `${WAL_ARCHIVE_PATH}/cluster-<sysid>`. Fresh clusters always
-#      land here. Old/colliding stanza data at the legacy path stays put.
+#   1. Marker file present → trust it. Idempotent across boots; survives
+#      container restarts; wiped with the volume.
+#   2. pg_control exists, marker absent → derive
+#      `${WAL_ARCHIVE_PATH}/cluster-<sysid>`, write marker.
+#   3. Pre-initdb (no pg_control) → return `${WAL_ARCHIVE_PATH}` as a
+#      placeholder; the marker gets written by pgbackrest-init.sh's
+#      post-initdb hook or by the bootstrap subshell once Postgres is up,
+#      so subsequent reads converge.
 #
-# The marker is written under PGDATA so a volume wipe drops it. That's the
-# point: after wipe-and-reuse-bucket, the new cluster (different sysid)
-# gets a fresh marker pointing at a fresh `cluster-<new_sysid>` path. The
-# previous cluster's data at `cluster-<old_sysid>` is untouched and
-# remains visible to the bucket lister (mono UI).
+# After wipe-and-reuse-bucket, the new cluster (different sysid) gets a
+# fresh marker pointing at a fresh `cluster-<new_sysid>` path. The previous
+# cluster's data at `cluster-<old_sysid>` is untouched and remains visible
+# to the bucket lister (mono UI).
 derive_pgbackrest_repo_path() {
   local user_path="${WAL_ARCHIVE_PATH:-/pgbackrest}"
 
@@ -239,21 +235,6 @@ derive_pgbackrest_repo_path() {
   local sysid
   sysid=$(read_postgres_sysid)
   if [ -z "$sysid" ]; then
-    # Pre-initdb: no system_identifier yet. Fall back to user_path; the marker
-    # gets written by pgbackrest-init.sh post-initdb (or by the bootstrap
-    # subshell once Postgres is up), so subsequent reads converge.
-    echo "$user_path"
-    return 0
-  fi
-
-  # Backward-compat probe: peek at the legacy path. If its archive.info
-  # records our system_identifier, this is an existing PITR-enabled service
-  # from before per-cluster pathing — keep using the legacy path so its
-  # accumulated backup history isn't stranded.
-  if PGBACKREST_REPO1_PATH="$user_path" \
-       pgbackrest --stanza=main info --output=json 2>/dev/null \
-       | grep -qE "\"system-id\":[[:space:]]*\"?${sysid}[\",}]"; then
-    write_pgbackrest_repo_path_marker "$user_path"
     echo "$user_path"
     return 0
   fi

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -80,29 +80,24 @@ fi
 # WAL archiving + PITR (tool-agnostic env contract)
 #
 # Backboard / frontend / template speak `WAL_ARCHIVE_*` (this service's own
-# archive bucket) and `WAL_RECOVER_FROM_*` (only on restored services, points
-# at source's bucket for read-during-recovery). The translation below maps
-# that contract onto pgBackRest's native `PGBACKREST_REPO{1,2}_S3_*` so the
-# rest of this script can stay pgBackRest-shaped.
+# destination bucket — write-only for this service) and `WAL_RECOVER_FROM_*`
+# (only on PITR-restored forks, points at source's bucket for read-during-
+# recovery). The translation below maps that contract onto pgBackRest's
+# native `PGBACKREST_REPO{1,2}_S3_*` so the rest of this script can stay
+# pgBackRest-shaped.
 #
-# Three modes:
-#   - WAL_ARCHIVE_* only → standalone archiving service. REPO1 = archive.
-#   - WAL_RECOVER_FROM_* only → restored service, no ongoing archiving. REPO1
-#     = source bucket (read for archive-get during recovery). After promote
-#     no archive_command runs; user enables PITR via the standard flow if
-#     they want continued archiving (which provisions a fresh bucket then).
-#   - WAL_ARCHIVE_* + WAL_RECOVER_FROM_* → restored service that already has
-#     PITR re-enabled. REPO1 = recover-from, REPO2 = archive; the archive-
-#     push wrapper adds --repo=2 so post-promote WAL never sprays into the
-#     source bucket.
-if [ -n "${WAL_RECOVER_FROM_BUCKET:-}" ]; then
-  export PGBACKREST_REPO1_S3_BUCKET="$WAL_RECOVER_FROM_BUCKET"
-  export PGBACKREST_REPO1_S3_KEY="$WAL_RECOVER_FROM_KEY"
-  export PGBACKREST_REPO1_S3_KEY_SECRET="$WAL_RECOVER_FROM_SECRET"
-  export PGBACKREST_REPO1_S3_REGION="$WAL_RECOVER_FROM_REGION"
-  export PGBACKREST_REPO1_S3_ENDPOINT="$WAL_RECOVER_FROM_ENDPOINT"
-  export PGBACKREST_REPO1_PATH="${WAL_RECOVER_FROM_PATH:-/pgbackrest}"
-elif [ -n "${WAL_ARCHIVE_BUCKET:-}" ]; then
+# Invariant: REPO1 = "where this service writes its WAL", always its own
+# bucket. REPO2, when present, = "read-only recovery source" only. No two
+# services ever share a destination bucket.
+#
+# Two modes:
+#   - WAL_ARCHIVE_* only → standalone archiving service. REPO1 = own bucket.
+#   - WAL_ARCHIVE_* + WAL_RECOVER_FROM_* → PITR-restored fork, archives from
+#     boot to its own fresh bucket. REPO1 = own bucket (write), REPO2 =
+#     source bucket (read for archive-get during recovery). After promote
+#     REPO2 is unused (the fork's new timeline doesn't exist there) but
+#     stays configured — harmless, removing it would require a restart.
+if [ -n "${WAL_ARCHIVE_BUCKET:-}" ]; then
   export PGBACKREST_REPO1_S3_BUCKET="$WAL_ARCHIVE_BUCKET"
   export PGBACKREST_REPO1_S3_KEY="$WAL_ARCHIVE_KEY"
   export PGBACKREST_REPO1_S3_KEY_SECRET="$WAL_ARCHIVE_SECRET"
@@ -111,13 +106,13 @@ elif [ -n "${WAL_ARCHIVE_BUCKET:-}" ]; then
   export PGBACKREST_REPO1_PATH="${WAL_ARCHIVE_PATH:-/pgbackrest}"
 fi
 
-if [ -n "${WAL_RECOVER_FROM_BUCKET:-}" ] && [ -n "${WAL_ARCHIVE_BUCKET:-}" ]; then
-  export PGBACKREST_REPO2_S3_BUCKET="$WAL_ARCHIVE_BUCKET"
-  export PGBACKREST_REPO2_S3_KEY="$WAL_ARCHIVE_KEY"
-  export PGBACKREST_REPO2_S3_KEY_SECRET="$WAL_ARCHIVE_SECRET"
-  export PGBACKREST_REPO2_S3_REGION="$WAL_ARCHIVE_REGION"
-  export PGBACKREST_REPO2_S3_ENDPOINT="$WAL_ARCHIVE_ENDPOINT"
-  export PGBACKREST_REPO2_PATH="${WAL_ARCHIVE_PATH:-/pgbackrest}"
+if [ -n "${WAL_RECOVER_FROM_BUCKET:-}" ]; then
+  export PGBACKREST_REPO2_S3_BUCKET="$WAL_RECOVER_FROM_BUCKET"
+  export PGBACKREST_REPO2_S3_KEY="$WAL_RECOVER_FROM_KEY"
+  export PGBACKREST_REPO2_S3_KEY_SECRET="$WAL_RECOVER_FROM_SECRET"
+  export PGBACKREST_REPO2_S3_REGION="$WAL_RECOVER_FROM_REGION"
+  export PGBACKREST_REPO2_S3_ENDPOINT="$WAL_RECOVER_FROM_ENDPOINT"
+  export PGBACKREST_REPO2_PATH="${WAL_RECOVER_FROM_PATH:-/pgbackrest}"
 fi
 
 # Helpers gate on whichever role is active. PGBACKREST_REPO1_S3_BUCKET acts
@@ -356,29 +351,25 @@ render_pgbackrest_conf() {
 
   echo "pgbackrest: detected ${cpus} vCPU; process-max push=${push_max} get=${get_max} backup=${backup_max} restore=${restore_max}"
 
-  # Two-repo mode: REPO1 reads source's WAL (archive-get during recovery),
-  # REPO2 receives the restored cluster's post-promote pushes. The
-  # archive-push wrapper picks the right repo at command time via --repo;
-  # here we just declare repo2 so pgBackRest reads the corresponding env vars.
+  # Two-repo mode (PITR-restored fork): REPO1 = own bucket (writes from boot),
+  # REPO2 = source bucket (read-only during recovery). archive-push pins
+  # --repo=1 so post-promote WAL lands only in REPO1; restore_command pins
+  # --repo=2 so archive-get reads from source. Here we just declare repo2's
+  # type so pgBackRest reads the corresponding env vars.
   local repo2_block=""
   if [ -n "${PGBACKREST_REPO2_S3_BUCKET:-}" ]; then
     repo2_block="repo2-type=s3"$'\n'
   fi
 
-  # Retention knobs are written for whichever repo this service archives to.
-  # In standalone (REPO1 = archive bucket) → write under repo1.
-  # In dual-repo recovery mode (REPO1 = source / read, REPO2 = own archive)
-  # → write under repo2; repo1's source bucket has its own retention owned
-  # by the source service. pgbackrest expire runs after every backup and
-  # uses these to remove stale fulls/diffs and the WAL they pinned.
-  # repo*-retention-archive is left to pgBackRest's default (= retention-full),
-  # which keeps WAL needed for the most recent N fulls.
+  # Retention is always scoped to REPO1 — every service writes only to its
+  # own bucket. REPO2 (source bucket on a fork) is read-only for this
+  # service; source owns its own retention. pgbackrest expire runs after
+  # every backup. repo1-retention-archive is left to pgBackRest's default
+  # (= retention-full), which keeps WAL needed for the most recent N fulls.
   local retention_full="${WAL_BACKUP_RETENTION_FULL:-4}"
   local retention_diff="${WAL_BACKUP_RETENTION_DIFF:-14}"
   local retention_block=""
-  if [ -n "${PGBACKREST_REPO2_S3_BUCKET:-}" ]; then
-    retention_block="repo2-retention-full=${retention_full}"$'\n'"repo2-retention-diff=${retention_diff}"$'\n'
-  elif [ -n "${WAL_ARCHIVE_BUCKET:-}" ]; then
+  if [ -n "${WAL_ARCHIVE_BUCKET:-}" ]; then
     retention_block="repo1-retention-full=${retention_full}"$'\n'"repo1-retention-diff=${retention_diff}"$'\n'
   fi
 
@@ -497,19 +488,10 @@ clear_pgbackrest_state_if_disabled() {
 # real postmaster binds TCP. If we time out, first WAL push fails until
 # the next boot retries — recoverable, but louder than necessary.
 bootstrap_pgbackrest_stanza() {
-  # stanza-create only runs when this service archives to its own bucket
-  # AND there is no in-flight recovery from another bucket. pgBackRest's
-  # stanza-create operates against all configured repos and doesn't accept
-  # --repo, so in dual-repo mode (WAL_RECOVER_FROM_* + WAL_ARCHIVE_*) it
-  # would target source's repo1 too — wrong. The standard PITR-enable flow
-  # on a restored service should clear WAL_RECOVER_FROM_* before adding
-  # WAL_ARCHIVE_* (post-promote env-var cleanup); until that lands, the
-  # operator runs stanza-create manually after the recover-from vars come off.
+  # stanza-create runs against repo1 (this service's own bucket). On a fork
+  # repo2 is the source's bucket — already has a stanza, owned by source —
+  # so we explicitly scope to --repo=1 to avoid touching it.
   [ -z "${WAL_ARCHIVE_BUCKET:-}" ] && return 0
-  if [ -n "${WAL_RECOVER_FROM_BUCKET:-}" ]; then
-    echo "pgbackrest: skipping stanza-create — both WAL_RECOVER_FROM_* and WAL_ARCHIVE_* are set; clear the recover-from vars then restart" >&2
-    return 0
-  fi
 
   (
     # No `local` here: subshells are their own scope so it's redundant, and
@@ -531,7 +513,7 @@ bootstrap_pgbackrest_stanza() {
     export PGBACKREST_REPO1_PATH="$repo_path"
     echo "pgbackrest: using repo1-path=${repo_path}"
 
-    if gosu postgres pgbackrest --stanza=main stanza-create; then
+    if gosu postgres pgbackrest --stanza=main --repo=1 stanza-create; then
       echo "pgbackrest: stanza-create completed"
     else
       echo "pgbackrest: stanza-create failed (will retry on next boot)" >&2
@@ -556,11 +538,10 @@ bootstrap_pgbackrest_stanza() {
 # .pitr_staging behind WITHOUT .pitr_configured — the operator can fix env
 # vars and restart, and the next boot will re-stage cleanly.
 #
-# restore_command pulls from repo1, which under the new-service restore
-# design is the source service's bucket (translated from `WAL_RECOVER_FROM_*`
-# at the top of this script). Post-promote archive_command writes to repo2
-# (the restored service's own bucket) — see archive-push-repo in the
-# rendered pgbackrest.conf.
+# restore_command pulls from repo2, which is the source service's bucket
+# (translated from `WAL_RECOVER_FROM_*` at the top of this script). Post-
+# promote archive_command writes to repo1 (this fork's own bucket) — see
+# the archive-push wrapper's --repo=1 pin.
 configure_pgbackrest_recovery() {
   [ -z "${WAL_RECOVER_FROM_BUCKET:-}" ] && return 0
   [ -z "$POSTGRES_RECOVERY_TARGET_TIME" ] && return 0
@@ -589,7 +570,7 @@ configure_pgbackrest_recovery() {
   ensure_pg_includes_confd
   install -d -m 0750 -o postgres -g postgres "$PGBACKREST_CONFD_DIR"
 
-  local restore_cmd="pgbackrest --stanza=main --repo=1 archive-get %f %p"
+  local restore_cmd="pgbackrest --stanza=main --repo=2 archive-get %f %p"
 
   # Escape single quotes per postgresql.conf rules (' -> '') so a value with
   # an embedded apostrophe can't break the conf file or smuggle a setting.
@@ -630,7 +611,7 @@ restore_from_pgbackrest_if_empty_volume() {
 
   install -d -m 0700 -o postgres -g postgres "$PGDATA"
 
-  if ! gosu postgres pgbackrest --stanza=main --repo=1 restore \
+  if ! gosu postgres pgbackrest --stanza=main --repo=2 restore \
        --type=time --target="$POSTGRES_RECOVERY_TARGET_TIME" \
        --target-action=promote; then
     echo "pgbackrest: restore from source bucket failed; fix env vars (WAL_RECOVER_FROM_*, POSTGRES_RECOVERY_TARGET_TIME) and redeploy" >&2


### PR DESCRIPTION
## Summary

When an operator wipes a data volume and redeploys against the same `WAL_ARCHIVE_BUCKET`, `initdb` produces a brand-new `system_identifier`. Before this change, `pgbackrest stanza-create` refused the mismatch and `archive-push` failed every WAL switch — the new cluster's WAL never landed, while the previous cluster's data sat intact (silent data loss for any operator who didn't notice the loud failure).

This change discriminates by sub-prefix. Each cluster archives under `${WAL_ARCHIVE_PATH}/cluster-<system_identifier>`; the value is persisted in `$PGDATA/.pgbackrest_repo_path` so the archive-push wrapper, the watcher, and `stanza-create` all converge on the same sub-path. A wipe-and-reuse cycle produces a different sub-path for the new cluster, and both histories coexist in the bucket — backboard lists the `cluster-*` sub-prefixes and surfaces them as separate restorable histories in the UI.

## How it works

| When | What |
|---|---|
| Fresh volume, `initdb` runs | `pgbackrest-init.sh` reads `pg_control.system_identifier` and writes the marker post-initdb so the very first `archive_command` invocation sees the right path. |
| Existing populated volume, marker missing | `wrapper.sh`'s bootstrap subshell probes `${WAL_ARCHIVE_PATH}` (legacy) for an `archive.info` matching our `system_identifier`. Match → write marker with legacy path (back-compat). No match → write marker with `cluster-<sysid>` path. |
| Subsequent boots | All callers read the marker. Idempotent. |
| Wipe volume + redeploy same bucket | Marker gone, new `initdb` → new `system_identifier` → new sub-path. Previous cluster's data at the old sub-path stays put. |

## Backward compat

Existing PITR-enabled services from before per-cluster pathing aren't asked to migrate. The probe path uses `pgbackrest info --output=json` and matches the cluster's `system_identifier` against the legacy path's `archive.info`. If that matches, the marker is written with the legacy path and we keep using it.

## What this change does NOT cover (mono-side follow-ups, opened separately)

- **Backboard restore UI**: needs to list `cluster-*` sub-prefixes under `WAL_ARCHIVE_PATH`, surface each as a separate history, pass the chosen sub-prefix as `WAL_RECOVER_FROM_PATH` on the restored service.
- **PR #38 e2e harness**: ~15 tests in that branch hardcode `WAL_RECOVER_FROM_PATH=/pgbackrest`. They need to read from the source service's marker file.

## Test plan

- [ ] Verified end-to-end: cluster A archives + takes initial full at `pgbackrest/cluster-<sysid_A>`. Wipe volume, redeploy same `WAL_ARCHIVE_BUCKET`. New cluster C archives + takes initial full at `pgbackrest/cluster-<sysid_C>`. Bucket has both `cluster-<sysid_A>/archive/main/archive.info` and `cluster-<sysid_C>/archive/main/archive.info`; both clusters' fulls are visible at their own paths.
- [ ] Verified backward-compat probe: marker absent on a populated volume, legacy path's `archive.info` matches our `system_identifier` → marker written with legacy path, archive continues at legacy path.
- [ ] No archive-push failures on cluster C (different sysid no longer collides).