### PR TITLE
fix(pitr): drop --repo from commands pgBackRest 2.58 rejects

### DIFF
--- a/pgbackrest-archive-push-wrapper.sh
+++ b/pgbackrest-archive-push-wrapper.sh
@@ -65,12 +65,11 @@ if [ -f "$PGDATA/.pgbackrest_repo_path" ]; then
   export PGBACKREST_REPO1_PATH
 fi
 
-# Pin archive-push to repo1 unconditionally. REPO1 is always this service's
-# own destination bucket (invariant set in wrapper.sh's env translation).
-# On a fork, repo2 is the source's read-only bucket — pgBackRest's default
-# archive-push targets all configured repos, so without the pin the fork
-# would spray its post-promote WAL into source's bucket.
-pgbackrest --stanza=main --repo=1 archive-push "$WAL_FILE"
+# pgBackRest 2.58 rejects --repo on archive-push (it pushes to whatever
+# repos are configured). Multi-repo scoping for forks is enforced upstream
+# by ensuring repo2 is dropped from the rendered config post-promote, not
+# at the archive-push call site.
+pgbackrest --stanza=main archive-push "$WAL_FILE"
 PGB_RC=$?
 if [ "$PGB_RC" -eq 0 ]; then
   exit 0

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -332,13 +332,15 @@ render_pgbackrest_conf() {
 
   echo "pgbackrest: detected ${cpus} vCPU; process-max push=${push_max} get=${get_max} backup=${backup_max} restore=${restore_max}"
 
-  # Two-repo mode (PITR-restored fork): REPO1 = own bucket (writes from boot),
-  # REPO2 = source bucket (read-only during recovery). archive-push pins
-  # --repo=1 so post-promote WAL lands only in REPO1; restore_command pins
-  # --repo=2 so archive-get reads from source. Here we just declare repo2's
-  # type so pgBackRest reads the corresponding env vars.
+  # REPO2 (source bucket, read-only) is only needed while the fork is in
+  # recovery — restore_command pulls WAL via archive-get --repo=2. After
+  # promote (.pitr_configured marker), archive_command fires and pgBackRest
+  # 2.58's archive-push fans out to every configured repo with no way to
+  # scope; if repo2 stays in the config, every push tries source's read-only
+  # bucket and fails. Drop repo2 once recovery is done to keep push targeting
+  # only REPO1.
   local repo2_block=""
-  if [ -n "${PGBACKREST_REPO2_S3_BUCKET:-}" ]; then
+  if [ -n "${PGBACKREST_REPO2_S3_BUCKET:-}" ] && [ ! -f "$PGDATA/.pitr_configured" ]; then
     repo2_block="repo2-type=s3"$'\n'
   fi
 
@@ -469,9 +471,11 @@ clear_pgbackrest_state_if_disabled() {
 # real postmaster binds TCP. If we time out, first WAL push fails until
 # the next boot retries — recoverable, but louder than necessary.
 bootstrap_pgbackrest_stanza() {
-  # stanza-create runs against repo1 (this service's own bucket). On a fork
-  # repo2 is the source's bucket — already has a stanza, owned by source —
-  # so we explicitly scope to --repo=1 to avoid touching it.
+  # pgBackRest 2.58 rejects --repo on stanza-create. In single-repo mode
+  # there's nothing to scope; in dual-repo (fork) mode the source's repo2
+  # already has a stanza so stanza-create on it is a no-op-or-mismatch
+  # anyway — neither outcome wants this command to fan out, so we keep the
+  # call vanilla and rely on dual-repo configs being post-promote-only.
   [ -z "${WAL_ARCHIVE_BUCKET:-}" ] && return 0
 
   (
@@ -494,7 +498,7 @@ bootstrap_pgbackrest_stanza() {
     export PGBACKREST_REPO1_PATH="$repo_path"
     echo "pgbackrest: using repo1-path=${repo_path}"
 
-    if gosu postgres pgbackrest --stanza=main --repo=1 stanza-create; then
+    if gosu postgres pgbackrest --stanza=main stanza-create; then
       echo "pgbackrest: stanza-create completed"
     else
       echo "pgbackrest: stanza-create failed (will retry on next boot)" >&2


### PR DESCRIPTION
## Summary

- pgBackRest 2.58 (Bookworm) only accepts \`--repo\` on \`backup\`, \`restore\`, \`expire\`, \`archive-get\`, \`info\`, \`verify\`, and \`stanza-delete\`. It rejects \`--repo\` on \`archive-push\`, \`stanza-create\`, \`stanza-upgrade\`, and \`check\`.
- The image was passing \`--repo=1\` to \`archive-push\` and \`stanza-create\`. Every PITR-enabled service failed stanza creation at boot and then failed every WAL switch with \`ERROR: [031]: option 'repo' not valid for command\`. The first prod run of the test-postgres-pitr harness surfaced this immediately — the source service's logs were spamming the error every WAL push, and the mutation's \`pgbackrest info\` pre-check refused with \"Could not probe pgBackRest\".
- Dropped \`--repo=1\` from the two rejecting calls.
- \`archive-push\` in 2.58 has no per-call repo scoping at all — it pushes to every configured repo. Forks declare both REPO1 (own writable bucket) and REPO2 (source's read-only bucket) during recovery, so leaving REPO2 in the config post-promote would mean every WAL push tries source's bucket and fails. Gated the \`repo2-type=s3\` block in the rendered \`pgbackrest.conf\` on the absence of \`.pitr_configured\` so post-promote configs only include REPO1.

## Why this wasn't caught earlier

\`test/e2e.sh\` exists on feature branches but was never merged to \`main\` — the published image had no automated regression coverage of the live archive path. test-postgres-pitr (which exercises the full Railway-mutation flow against a real published image) caught it on first contact.

## Test plan

- [ ] Pull the rebuilt image, set \`WAL_ARCHIVE_*\` on a fresh service, watch \`stanza-create\` succeed and \`archive-push\` push WAL on every switch
- [ ] Run a PITR restore end-to-end: workflow stages REPO2, recovery completes, post-promote \`archive_command\` writes only to REPO1
- [ ] Confirm \`.pitr_configured\` flips the rendered \`pgbackrest.conf\` to single-repo on the next boot