### PR TITLE
fix(pitr): write per-cluster repo path into pgbackrest.conf

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -497,6 +497,17 @@ bootstrap_pgbackrest_stanza() {
     # just reads it.
     repo_path=$(derive_pgbackrest_repo_path)
     export PGBACKREST_REPO1_PATH="$repo_path"
+
+    # Update the rendered pgbackrest.conf so SSH-driven pgbackrest invocations
+    # (mono's probePgbackrestInfo runs `gosu postgres pgbackrest info` over
+    # SSH and inherits no shell env from this subshell) see the per-cluster
+    # path. Without this rewrite the probe would read the conf's bootstrap
+    # path (=$WAL_ARCHIVE_PATH), find no backups under it, and fail the
+    # restore mutation with "No base backup has been taken yet".
+    if [ -f "$PGBACKREST_CONF_FILE" ]; then
+      sed -i "s|^repo1-path=.*|repo1-path=${repo_path}|" "$PGBACKREST_CONF_FILE"
+    fi
+
     echo "pgbackrest: using repo1-path=${repo_path}"
 
     if gosu postgres pgbackrest --stanza=main stanza-create; then


### PR DESCRIPTION
## Summary

\`bootstrap_pgbackrest_stanza\` derives the per-cluster archive sub-prefix (\`/pgbackrest/cluster-<sysid>\`) and exports \`PGBACKREST_REPO1_PATH\` locally, but \`render_pgbackrest_conf\` writes the bootstrap (= \`WAL_ARCHIVE_PATH\`, default \`/pgbackrest\`) into \`/etc/pgbackrest/pgbackrest.conf\`. The mismatch is invisible inside the container — \`pgbackrest-archive-push-wrapper.sh\` and the watcher both read the marker file directly and override \`PGBACKREST_REPO1_PATH\` for their own subprocesses — but it breaks any \`pgbackrest\` invocation that reads the conf without the env override.

The mono backend's \`probePgbackrestInfo\` runs \`gosu postgres pgbackrest info\` over SSH. The SSH command inherits no shell env from wrapper subshells, so it reads only the conf's \`repo1-path\`. It looks under the bootstrap path, finds no backups, and \`volumeInstancePITRRestore\` rejects with \"No base backup has been taken yet\" — even after the watcher has successfully written a full to the per-cluster path.

This is what the prod test-postgres-pitr cron run surfaced after PR #49 shipped: archive-push and watcher backup completed cleanly (no more \`--repo\` errors), but every \`happy\` flow's restore mutation rejected.

## Fix

Once the per-cluster path is known in the bootstrap subshell, \`sed\`-rewrite \`repo1-path\` in the rendered conf so SSH-driven invocations agree with the runtime overrides.

## Test plan

- [ ] Image-level e2e: 28/28 still passes
- [ ] After image rebuild, prod test-postgres-pitr cron's \`happy\` flow gets past the restore mutation