### PR TITLE
fix(pitr): unset PGHOST/PGPORT before forking pgbackrest subshells

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -702,19 +702,19 @@ restore_from_pgbackrest_if_empty_volume
 clear_pgbackrest_state_if_disabled
 apply_pgbackrest_archive_conf
 configure_pgbackrest_recovery
+
+# Unset PG* libpq env vars BEFORE forking pgbackrest's stanza-create / watcher
+# subshells. Customer-set PGHOST=${{ Postgres.RAILWAY_PRIVATE_DOMAIN }} (a
+# common app-side pattern) leaks into pgbackrest's libpq calls — pgbackrest
+# then tries to connect to itself via the privnet domain and times out
+# (`unable to find primary cluster`). A local-only connection is what we want
+# from inside the container; clearing PGHOST/PGPORT lets libpq fall back to
+# the Unix socket.
+unset PGHOST
+unset PGPORT
+
 bootstrap_pgbackrest_stanza
 fork_pgbackrest_backup_watcher
-
-# unset PGHOST to force psql to use Unix socket path
-# this is specific to Railway and allows
-# us to use PGHOST after the init
-unset PGHOST
-
-## unset PGPORT also specific to Railway
-## since postgres checks for validity of
-## the value in PGPORT we unset it in case
-## it ends up being empty
-unset PGPORT
 
 # Call the entrypoint script with the
 # appropriate PGHOST & PGPORT and redirect


### PR DESCRIPTION
## Summary

Railway customers commonly set \`PGHOST=\${{ Postgres.RAILWAY_PRIVATE_DOMAIN }}\` in their service variables — the app uses it to connect to its own database. That value leaks into pgbackrest's libpq calls inside the container, so \`stanza-create\` and the watcher's \`pgbackrest backup\` try to reach Postgres via the privnet domain instead of the local socket and time out:

\`\`\`
P00 WARN: unable to check pg1: [DbConnectError] unable to connect to 'dbname=postgres port=5432':
  connection to server at "postgres.railway.internal" (...), port 5432 failed: Connection timed out
P00 ERROR: [056]: unable to find primary cluster - cannot proceed
\`\`\`

After stanza-create fails, every WAL switch errors out with \`unable to find a valid repository\` (no archive.info, since stanza-create never wrote it). The cluster runs but PITR is broken.

## Fix

\`unset PGHOST\` was already at the bottom of \`wrapper.sh\` (\"to force psql to use Unix socket path\"), but it ran AFTER \`bootstrap_pgbackrest_stanza\` and \`fork_pgbackrest_backup_watcher\` had already forked — the subshells captured PGHOST at fork time. Move the unset above the forks so both subshells inherit a clean env. Same for \`PGPORT\` (already unset alongside PGHOST in the same block).

## Why now

Surfaced after the postgres-pitr composable template shipped (mono#28475) — the dashboard's \"Enable PITR\" button now applies WAL_ARCHIVE_* correctly, but the underlying image-side stanza-create has been broken whenever the customer had PGHOST in their service vars, which is essentially always.

## Test plan

- [ ] After image rebuild, redeploy a Postgres service that has \`PGHOST\` set in its variables, then click \"Enable PITR\" → \`stanza-create completed\` shows up in logs and \`archive-push completed successfully\` follows
- [ ] Existing image-level e2e harness still passes (the harness sets \`PGHOST\` via env on test containers; this fix doesn't regress that path because we still unset before exec into the postmaster)