### PR TITLE
feat(pitr): enable track_commit_timestamp on PITR-enabled clusters

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -404,10 +404,19 @@ apply_pgbackrest_archive_conf() {
   install -d -m 0750 -o postgres -g postgres "$PGBACKREST_CONFD_DIR"
 
   local archive_timeout="${POSTGRES_ARCHIVE_TIMEOUT:-60}"
+  # track_commit_timestamp lets pg_last_committed_xact() return the wall-clock
+  # time of the last commit. The PITR picker uses that as its upper bound:
+  # `recovery_target_time` only matches commit record timestamps, so on an
+  # idle DB the archive head keeps ticking with empty WAL while the latest
+  # reachable target stays pinned at the last commit. Without this GUC the
+  # picker falls back to lastArchivedAt and the user can pick an
+  # unreachable target. Requires a restart to take effect; the entrypoint
+  # rewrites this file on every boot, so first archive-enable picks it up.
   cat > "$PGBACKREST_ARCHIVE_CONF" <<EOF
 archive_mode = 'on'
 archive_command = '/usr/local/bin/pgbackrest-archive-push-wrapper.sh %p'
 archive_timeout = '${archive_timeout}'
+track_commit_timestamp = 'on'
 EOF
   chown postgres:postgres "$PGBACKREST_ARCHIVE_CONF"
   chmod 0640 "$PGBACKREST_ARCHIVE_CONF"


### PR DESCRIPTION
## Summary

Adds `track_commit_timestamp = 'on'` to `conf.d/pgbackrest.conf` so `pg_last_committed_xact()` returns the wall-clock time of the most recent commit. The PITR picker uses that as its upper bound.

### Why

Postgres `recovery_target_time` only matches commit/abort record timestamps in WAL — never empty-segment switches or checkpoints (`xlogrecovery.c::getRecoveryStopReason`). On an idle DB, `archive_timeout=60` keeps pushing empty WAL forever, so `pg_stat_archiver.last_archived_time` keeps advancing past the last reachable target. Without this GUC the picker has no way to distinguish "archive head" from "last commit time," and the user can pick a target that makes recovery FATAL with `recovery ended before configured recovery target was reached`. Hit on the prod test project today.

### Scope

Only written when `WAL_ARCHIVE_BUCKET` is set, so non-PITR services are untouched. Requires a restart to take effect — the wrapper rewrites this file on every boot, so first archive-enable picks it up.

Companion mono PR: railwayapp/mono#28497 — reads the value from a third pipe-separated column on the pgbackrest probe; uses it for both picker upper bound and mutation pre-validation. Mono falls back to `lastArchivedAt` until images deployed with this PR redeploy.

## Test plan

- [ ] On a fresh PITR-enabled service, `psql -c "SHOW track_commit_timestamp"` returns `on`
- [ ] After one commit, `psql -c "SELECT pg_last_committed_xact()"` returns a non-empty `(xid, timestamp, roident)` row
- [ ] Picker `maxRestoreTime` reflects the last commit, not the last archived WAL
- [ ] Restoring to a target between earliestBackupAt and lastCommittedTxnAt still succeeds end-to-end