### PR TITLE
feat(pitr): make WAL heartbeat commit-bearing so PITR window stays tight

### DIFF
--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -200,14 +200,25 @@ decide_action() {
   fi
 }
 
-# Emits a few bytes of WAL with no table side-effects so archive_timeout=60
-# has something to flush on idle DBs. transactional=false bypasses txn
-# context — non-blocking, cheap. Failure is non-fatal: a temporarily blocked
-# emit just postpones the next segment switch by one tick.
+# Emits a tiny COMMIT record into WAL on each tick so:
+#   1. archive_timeout=60 has something to flush on idle DBs (the original
+#      reason for this heartbeat — keeps lastArchivedAt fresh).
+#   2. recovery_target_time has a stop point at most ~60s behind on idle
+#      DBs. recovery_target_time only matches commit/abort record
+#      timestamps; without a steady stream of commits, "restore to now"
+#      on an idle DB is unreachable and aborts recovery. A transactional
+#      heartbeat creates one commit per tick, so the latest reachable
+#      target stays within ~60s of wall-clock.
+#
+# `pg_logical_emit_message(transactional=true, ...)` runs the emit inside
+# an implicit transaction, producing a commit record with a real
+# timestamp. ~24 bytes of WAL per tick, ~1440 xids/day at the 60s default
+# — negligible against the 2B-xid wraparound budget. Failure is non-fatal:
+# a blocked emit just postpones the next stop point by one tick.
 emit_wal_heartbeat() {
   [ "${WAL_HEARTBEAT_DISABLED:-0}" = "1" ] && return 0
   psql -U postgres -tAXq -c \
-    "SELECT pg_logical_emit_message(false, 'rwy_pitr_heartbeat', '')" \
+    "SELECT pg_logical_emit_message(true, 'rwy_pitr_heartbeat', '')" \
     >/dev/null 2>&1 || true
 }
 


### PR DESCRIPTION
## Summary

Closes the idle-DB gap in the PITR window. The current heartbeat uses \`pg_logical_emit_message(false, ...)\` — non-transactional — so it emits WAL bytes but no commit/abort record. Postgres \`recovery_target_time\` only matches commit/abort record timestamps; non-transactional WAL is invisible to it. So on an idle DB, the watcher's heartbeat keeps \`lastArchivedAt\` fresh but the latest *reachable* recovery target stays pinned at the last real customer commit. Picker offers up-to-now, mutation accepts, recovery FATALs.

Flip \`transactional\` → \`true\`. Each tick now produces a tiny commit record (~24 bytes of WAL, 1 xid). \`pg_last_committed_xact()\` advances every 60s, the picker's bound is always within ~60s of wall-clock, and "restore to now" on an idle DB always has a stop point.

## Why this is the right fix (vs. backend probe shenanigans)

We considered an in-mono \`pg_waldump\` probe (#28525, closed) to find the last commit regardless of GUC state. That was over-engineering: real customer DBs commit constantly, so \`lastCommittedTxnAt\` is fresh anyway. The only DBs that need this fix are idle ones — and they already have an idle-tick mechanism (the heartbeat), so the right place to fix it is there. One boolean flip vs. ~200 lines of cross-cutting probe glue.

## Cost

- ~24 bytes of WAL per tick (was a few bytes for the non-transactional emit)
- 1 xid per tick → ~1440/day at the 60s default. 2B-xid wraparound budget; autovacuum reclaims xids well before that. Negligible.

## Test plan

- [ ] On a freshly-deployed PITR-enabled service that has no customer writes, \`SELECT pg_last_committed_xact()\` returns a row whose timestamp is within ~2 min of \`now()\`
- [ ] Picker \`maxRestoreTime\` advances with each heartbeat tick on idle DBs
- [ ] Restore to "now" succeeds on an idle service (recovery has a stop point at the latest heartbeat commit)
- [ ] Setting \`WAL_HEARTBEAT_DISABLED=1\` still bypasses the heartbeat (existing behavior preserved)