### PR TITLE
feat(pitr): log restore-gate state on every boot

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -634,6 +634,10 @@ EOF
 # Container restart on an already-restored volume: $PGDATA is populated, so
 # the empty-PGDATA gate fails and we skip — Postgres starts normally.
 restore_from_pgbackrest_if_empty_volume() {
+  # Log gate state up front so post-mortems on "why did pgbackrest restore
+  # run when I expected it to be skipped" don't require guessing.
+  echo "pgbackrest: restore-gate WAL_RECOVER_FROM_BUCKET=${WAL_RECOVER_FROM_BUCKET:+set} POSTGRES_RECOVERY_TARGET_TIME=${POSTGRES_RECOVERY_TARGET_TIME:+set} PG_VERSION=$([ -f "$PGDATA/PG_VERSION" ] && echo present || echo missing) RESTORED_MARKER=$([ -f "$PGBACKREST_RESTORED_MARKER" ] && echo present || echo missing) PGDATA=$PGDATA"
+
   [ -z "${WAL_RECOVER_FROM_BUCKET:-}" ] && return 0
   [ -z "${POSTGRES_RECOVERY_TARGET_TIME:-}" ] && return 0
   [ -f "$PGDATA/PG_VERSION" ] && return 0


### PR DESCRIPTION
## Summary

Single-line diagnostic dump at the top of \`restore_from_pgbackrest_if_empty_volume\`. Pure observability — no behavior change. Records the four gate inputs (\`WAL_RECOVER_FROM_BUCKET\`, \`POSTGRES_RECOVERY_TARGET_TIME\`, \`PG_VERSION\` presence, \`RESTORED_MARKER\` presence) plus the resolved PGDATA path.

Motivated by the recent cron \`restoreTargetChange\` failure, where pgbackrest restore ran with target=2099 on what looked like a redeploy. Without this log line, "did the marker get written?" / "is PGDATA preserved across redeploys?" / "is the env var being clobbered?" requires container-side investigation; with it, one log line answers all three.

## Test plan

- [ ] Fresh service: log shows \`PG_VERSION=missing RESTORED_MARKER=missing\`, restore proceeds
- [ ] Restored service redeploy: log shows \`PG_VERSION=present RESTORED_MARKER=present\`, restore skipped
- [ ] Service with archive bucket cleared: log shows \`WAL_RECOVER_FROM_BUCKET=\`, restore skipped early