### PR TITLE
fix(pitr): seed track_commit_timestamp during initdb too

### DIFF
--- a/pgbackrest-init.sh
+++ b/pgbackrest-init.sh
@@ -43,10 +43,28 @@ mkdir -p "$PGDATA/conf.d"
 chmod 0750 "$PGDATA/conf.d"
 
 archive_timeout="${POSTGRES_ARCHIVE_TIMEOUT:-60}"
+# track_commit_timestamp lets pg_last_committed_xact() return the wall-clock
+# time of the last commit. The PITR picker uses that as its upper bound:
+# `recovery_target_time` only matches commit record timestamps, so on an idle
+# DB the archive head keeps ticking with empty WAL while the latest reachable
+# target stays pinned at the last commit. Without this GUC the picker falls
+# back to the last full backup's stop time and the user gets a window pinned
+# 24+ hours behind real time on the default diff cadence.
+#
+# Mirrors wrapper.sh's apply_pgbackrest_archive_conf — that function returns
+# early when postgresql.conf doesn't exist yet (fresh-init pre-postmaster),
+# so this initdb-phase write is the first chance to seed the GUC for the
+# very first postmaster start. Without this, fresh PITR-enabled clusters
+# would boot once with track_commit_timestamp=off, take the first base
+# backup with no commit-ts data, and only pick up the GUC on the second
+# boot when wrapper.sh's idempotent rewrite runs against an existing
+# postgresql.conf — leaving a window where the picker can't compute a
+# tight ceiling.
 cat > "$PGDATA/conf.d/pgbackrest.conf" <<EOF
 archive_mode = 'on'
 archive_command = '/usr/local/bin/pgbackrest-archive-push-wrapper.sh %p'
 archive_timeout = '${archive_timeout}'
+track_commit_timestamp = 'on'
 EOF
 chmod 0640 "$PGDATA/conf.d/pgbackrest.conf"
 


### PR DESCRIPTION
## Summary

Follow-up to #52. That PR added `track_commit_timestamp = 'on'` only to wrapper.sh's `apply_pgbackrest_archive_conf`, which short-circuits when `postgresql.conf` doesn't exist yet. On the fresh-init path the post-initdb hook runs **before** wrapper.sh's idempotent rewrite gets a chance to apply the GUC — so the very first postmaster start of a brand-new PITR-enabled cluster boots with `track_commit_timestamp=off`, takes its first base backup with no commit-ts data, and only picks up the GUC on the **second** boot.

That window is exactly where the PITR picker's reachable-target ceiling matters most — right after enabling, no commits past the first backup, the picker should already be able to ask `pg_last_committed_xact()` and get a real answer.

This change mirrors the GUC into `pgbackrest-init.sh`'s heredoc so first boot already has it. Existing clusters keep relying on wrapper.sh's idempotent rewrite — both files write the same value, no double-write conflict.

## Test plan

- [ ] Build the image, deploy a fresh PITR-enabled service.
- [ ] On the very first boot (before any restart), `psql -c "SHOW track_commit_timestamp"` returns `on`.
- [ ] After a write, `SELECT pg_last_committed_xact()` returns a non-null `(xid, timestamp)`.
- [ ] Existing clusters (already on the merged #52) continue to work — second boot already had the GUC, no behavior change for them.