### PR TITLE
fix(pitr): regenerate SSL certs after pgbackrest restore

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -716,6 +716,41 @@ clear_pgbackrest_state_if_disabled
 apply_pgbackrest_archive_conf
 configure_pgbackrest_recovery
 
+# After a pgbackrest restore the volume's certs/ dir is empty: pgbackrest only
+# backs up PGDATA (`/var/lib/postgresql/data/pgdata`), and certs live one
+# directory up at `/var/lib/postgresql/data/certs`. The cert-generation block
+# at the top of this script ran before restore — at that point PGDATA was
+# empty, so its "postgresql.conf exists AND cert missing → regenerate" branch
+# didn't fire. Re-check now that the volume is in its final state. We only
+# regenerate cert files; postgresql.conf is already restored from source and
+# already references these paths, so we don't re-run init-ssl.sh (which would
+# append duplicate ssl_*_file lines and clobber any custom
+# shared_preload_libraries with `'pg_stat_statements'`).
+if [ -f "$POSTGRES_CONF_FILE" ] && [ ! -f "$SSL_DIR/server.crt" ]; then
+  echo "Generating SSL certs after restore (cert files were not in pgbackrest backup)..."
+  sudo mkdir -p "$SSL_DIR"
+  sudo chown postgres:postgres "$SSL_DIR"
+  openssl req -new -x509 -days "${SSL_CERT_DAYS:-820}" -nodes -text \
+    -out "$SSL_DIR/root.crt" -keyout "$SSL_DIR/root.key" -subj "/CN=root-ca"
+  chmod og-rwx "$SSL_DIR/root.key"
+  openssl req -new -nodes -text \
+    -out "$SSL_DIR/server.csr" -keyout "$SSL_DIR/server.key" -subj "/CN=localhost"
+  chown postgres:postgres "$SSL_DIR/server.key"
+  chmod og-rwx "$SSL_DIR/server.key"
+  cat >| "$SSL_DIR/v3.ext" <<EOF
+[v3_req]
+authorityKeyIdentifier = keyid, issuer
+basicConstraints = critical, CA:TRUE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = DNS:localhost
+EOF
+  openssl x509 -req -in "$SSL_DIR/server.csr" -extfile "$SSL_DIR/v3.ext" \
+    -extensions v3_req -text -days "${SSL_CERT_DAYS:-820}" \
+    -CA "$SSL_DIR/root.crt" -CAkey "$SSL_DIR/root.key" -CAcreateserial \
+    -out "$SSL_DIR/server.crt"
+  chown postgres:postgres "$SSL_DIR/server.crt"
+fi
+
 # Unset PG* libpq env vars BEFORE forking pgbackrest's stanza-create / watcher
 # subshells. Customer-set PGHOST=${{ Postgres.RAILWAY_PRIVATE_DOMAIN }} (a
 # common app-side pattern) leaks into pgbackrest's libpq calls — pgbackrest


### PR DESCRIPTION
## Summary

The `certs/` dir lives at `/var/lib/postgresql/data/certs`, ONE DIRECTORY UP from `$PGDATA = /var/lib/postgresql/data/pgdata`. pgbackrest only backs up PGDATA, so a PITR-restored volume has an empty `certs/` dir. Postgres then FATALs on first start with `could not load server certificate file`.

The wrapper's existing cert-generation block at the top of the script runs ONCE per boot, BEFORE `restore_from_pgbackrest_if_empty_volume`. At that point the volume is empty so the "postgresql.conf exists AND cert missing → regenerate" branch is skipped. After restore the volume has data but the certs are still missing — and the cert block has already run.

Fix: re-check certs AFTER restore. We inline the cert generation rather than calling `init-ssl.sh` because the latter would append duplicate `ssl_*_file` directives to postgresql.conf and overwrite any custom `shared_preload_libraries` with `'pg_stat_statements'`. The restored postgresql.conf already references the standard cert paths, so we only need to materialize the cert files.

## Caught by

The test-postgres-pitr cron's `happy` flow on deployment `c50f7aa8`. Postgres on the restored cluster:

\`\`\`
FATAL: could not load server certificate file "/var/lib/postgresql/data/certs/server.crt": No such file or directory
Connection matched file "/var/lib/postgresql/data/pgdata/pg_hba.conf" line 128: "host all all all scram-sha-256"
\`\`\`

Harness saw 30× ECONNRESET and FAILed.

## Test plan

- [ ] Build new postgres-ssl:18 image and pin in template
- [ ] Re-run cron's e2e suite — expect `happy` (and the other restore-touching flows) to PASS