### PR TITLE
ci(e2e): run pgBackRest archive + PITR harness on PRs and main

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pg_version: [17, 18]
+        pg_version: [18]
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,69 @@
+name: E2E
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: [17, 18]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build test image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.${{ matrix.pg_version }}
+          platforms: linux/amd64
+          tags: postgres-ssl-pitr:${{ matrix.pg_version }}
+          load: true
+          cache-from: type=gha,scope=pg${{ matrix.pg_version }}
+          cache-to: type=gha,scope=pg${{ matrix.pg_version }},mode=max
+
+      - name: Run e2e harness
+        env:
+          PG_VERSION: ${{ matrix.pg_version }}
+        run: |
+          ./test/e2e.sh 2>&1 | tee "e2e-pg${PG_VERSION}.log"
+
+      - name: Collect failure diagnostics
+        if: failure()
+        env:
+          PG_VERSION: ${{ matrix.pg_version }}
+        run: |
+          mkdir -p failure-artifacts
+          mv "e2e-pg${PG_VERSION}.log" failure-artifacts/ 2>/dev/null || true
+          docker ps -a > failure-artifacts/docker-ps.txt 2>&1 || true
+          docker volume ls > failure-artifacts/docker-volumes.txt 2>&1 || true
+          for c in $(docker ps -aq --filter "label=postgres-ssl-e2e=1"); do
+            name=$(docker inspect -f '{{.Name}}' "$c" | sed 's|^/||')
+            docker logs --tail 200 "$c" > "failure-artifacts/container-${name}.log" 2>&1 || true
+          done
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-logs-pg${{ matrix.pg_version }}
+          path: failure-artifacts
+          retention-days: 14


### PR DESCRIPTION
Wires `test/e2e.sh` into GitHub Actions on a PG 17/18 matrix so regressions in the archive + PITR flow surface in CI instead of only when the harness is run by hand.

- Triggers on `pull_request` and push to `main`, with concurrency cancellation per ref so PR re-pushes don't pile up runs.
- Pre-builds the per-version image with buildx + GHA cache under the tag `postgres-ssl-pitr:${PG_VERSION}`; the harness's `ensure_image()` then short-circuits, so no fork of `test/e2e.sh` is needed.
- 120 min job timeout (worst-case full suite is ~45–90 min).
- On failure only, uploads tee'd harness output and surviving container logs as an artifact with 14-day retention.