### PR TITLE
fix(pitr): support recovery_target_xid in staging path

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -524,6 +524,33 @@ bootstrap_pgbackrest_stanza() {
     else
       echo "pgbackrest: stanza-create failed (will retry on next boot)" >&2
     fi
+
+    # Emit one tiny committed transaction so pg_last_committed_xact() returns
+    # a real timestamp from the very first probe. Without this, a freshly
+    # (re)booted primary with no user activity reports lastCommittedTxnAt=NULL
+    # and the PITR picker has no commit-time ceiling at all — track_commit_timestamp
+    # only records timestamps for commits observed after it was enabled, and a
+    # cluster that boots and sits idle has no such commits. The picker is
+    # contractually forbidden from inferring a ceiling from archive-head times
+    # (those advance with empty heartbeat segments and are not reachable by
+    # recovery_target_time), so without a warmup the picker would fall back to
+    # latestBackupAt, which on default cadence (WAL_BACKUP_DIFF_INTERVAL_HOURS=24)
+    # can lag real time by up to a day even though WAL is being archived and
+    # fully restorable second-by-second. pg_logical_emit_message(transactional=true,
+    # ...) writes a LOGICAL_MESSAGE record inside an autocommitted txn — one
+    # XACT_COMMIT in WAL, recorded by track_commit_timestamp, no schema impact,
+    # idempotent across reboots. Skipped during recovery: PITR-restored clusters
+    # replay XACT_COMMIT records as part of recovery, so post-promote
+    # pg_last_committed_xact() already returns the source's last commit time.
+    if [ "$(gosu postgres psql -h 127.0.0.1 -U postgres -d postgres -tAc 'SELECT pg_is_in_recovery()' 2>/dev/null)" = "f" ]; then
+      if gosu postgres psql -h 127.0.0.1 -U postgres -d postgres -tAc \
+           "SELECT pg_logical_emit_message(true, 'railway-pitr-warmup', now()::text)" \
+           >/dev/null 2>&1; then
+        echo "pgbackrest: PITR warmup commit emitted (pg_last_committed_xact populated)"
+      else
+        echo "pgbackrest: PITR warmup commit failed; picker ceiling will stay null until first user commit" >&2
+      fi
+    fi
   ) &
 }
 

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -524,50 +524,7 @@ bootstrap_pgbackrest_stanza() {
     else
       echo "pgbackrest: stanza-create failed (will retry on next boot)" >&2
     fi
-
-    warmup_commit_ts
   ) &
-}
-
-# Issue a tiny transactional commit on every boot so pg_last_committed_xact()
-# returns a real value to the PITR picker even on a freshly-restarted cluster
-# that hasn't taken any user writes yet.
-#
-# track_commit_timestamp persists commit-ts data on disk in pg_commit_ts/, but
-# the in-memory `newestCommitTsXid` cursor (ShmemVariableCache) is reset to
-# InvalidTransactionId on every postmaster start. pg_last_committed_xact()
-# reads that cursor first, so it returns NULL until the cluster does its
-# first new commit since boot — even if pg_commit_ts/ has years of history.
-#
-# That NULL return propagates to the picker as "no commit-ts ceiling" and
-# forces the +1s backup-stop fallback path (volumeInstance.ts), which is
-# coarser than the real ceiling. The fix at the picker layer is independent
-# (see B8), but the upstream issue here is the cluster shouldn't report
-# NULL in the first place. A single transactional WAL message commits, gets
-# its xid recorded in pg_commit_ts, and seeds the in-memory cursor — so the
-# next pg_last_committed_xact() call returns the warmup's commit timestamp.
-#
-# Gated on WAL_ARCHIVE_BUCKET so we don't write WAL when archiving is off
-# (where the ceiling doesn't matter anyway). Gated on track_commit_timestamp
-# being on. Failure is non-fatal — picker just falls back to the +0
-# backup-stop ceiling like before.
-warmup_commit_ts() {
-  [ -z "${WAL_ARCHIVE_BUCKET:-}" ] && return 0
-
-  local guc
-  guc=$(gosu postgres psql -U postgres -h /var/run/postgresql -tAXq \
-    -c "SHOW track_commit_timestamp" 2>/dev/null | tr -d '[:space:]')
-  if [ "$guc" != "on" ]; then
-    return 0
-  fi
-
-  if gosu postgres psql -U postgres -h /var/run/postgresql -tAXq \
-       -c "BEGIN; SELECT pg_logical_emit_message(true, 'rwy_commit_ts_warmup', ''); COMMIT;" \
-       >/dev/null 2>&1; then
-    echo "pgbackrest: commit-ts warmup committed"
-  else
-    echo "pgbackrest: commit-ts warmup failed (non-fatal)" >&2
-  fi
 }
 
 # Stage PITR replay when POSTGRES_RECOVERY_TARGET_TIME is set. Writes

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -524,7 +524,50 @@ bootstrap_pgbackrest_stanza() {
     else
       echo "pgbackrest: stanza-create failed (will retry on next boot)" >&2
     fi
+
+    warmup_commit_ts
   ) &
+}
+
+# Issue a tiny transactional commit on every boot so pg_last_committed_xact()
+# returns a real value to the PITR picker even on a freshly-restarted cluster
+# that hasn't taken any user writes yet.
+#
+# track_commit_timestamp persists commit-ts data on disk in pg_commit_ts/, but
+# the in-memory `newestCommitTsXid` cursor (ShmemVariableCache) is reset to
+# InvalidTransactionId on every postmaster start. pg_last_committed_xact()
+# reads that cursor first, so it returns NULL until the cluster does its
+# first new commit since boot — even if pg_commit_ts/ has years of history.
+#
+# That NULL return propagates to the picker as "no commit-ts ceiling" and
+# forces the +1s backup-stop fallback path (volumeInstance.ts), which is
+# coarser than the real ceiling. The fix at the picker layer is independent
+# (see B8), but the upstream issue here is the cluster shouldn't report
+# NULL in the first place. A single transactional WAL message commits, gets
+# its xid recorded in pg_commit_ts, and seeds the in-memory cursor — so the
+# next pg_last_committed_xact() call returns the warmup's commit timestamp.
+#
+# Gated on WAL_ARCHIVE_BUCKET so we don't write WAL when archiving is off
+# (where the ceiling doesn't matter anyway). Gated on track_commit_timestamp
+# being on. Failure is non-fatal — picker just falls back to the +0
+# backup-stop ceiling like before.
+warmup_commit_ts() {
+  [ -z "${WAL_ARCHIVE_BUCKET:-}" ] && return 0
+
+  local guc
+  guc=$(gosu postgres psql -U postgres -h /var/run/postgresql -tAXq \
+    -c "SHOW track_commit_timestamp" 2>/dev/null | tr -d '[:space:]')
+  if [ "$guc" != "on" ]; then
+    return 0
+  fi
+
+  if gosu postgres psql -U postgres -h /var/run/postgresql -tAXq \
+       -c "BEGIN; SELECT pg_logical_emit_message(true, 'rwy_commit_ts_warmup', ''); COMMIT;" \
+       >/dev/null 2>&1; then
+    echo "pgbackrest: commit-ts warmup committed"
+  else
+    echo "pgbackrest: commit-ts warmup failed (non-fatal)" >&2
+  fi
 }
 
 # Stage PITR replay when POSTGRES_RECOVERY_TARGET_TIME is set. Writes
@@ -606,11 +649,24 @@ EOF
 
   # Escape single quotes per postgresql.conf rules (' -> '') so a value with
   # an embedded apostrophe can't break the conf file or smuggle a setting.
-  local escaped_target="${POSTGRES_RECOVERY_TARGET_TIME//\'/\'\'}"
   local escaped_restore="${restore_cmd//\'/\'\'}"
+
+  # POSTGRES_RECOVERY_TARGET_XID, when set, wins over _TIME — same idle-
+  # source-safe rationale as restore_from_pgbackrest_if_empty_volume:
+  # recovery_target_time hangs/FATALs when no commit record exists past
+  # target on an idle DB, recovery_target_xid matches an exact commit.
+  # The picker emits _XID when it clamped to lastCommittedTxnAt.
+  local recovery_param
+  if [ -n "${POSTGRES_RECOVERY_TARGET_XID:-}" ]; then
+    local escaped_xid="${POSTGRES_RECOVERY_TARGET_XID//\'/\'\'}"
+    recovery_param="recovery_target_xid = '${escaped_xid}'"
+  else
+    local escaped_target="${POSTGRES_RECOVERY_TARGET_TIME//\'/\'\'}"
+    recovery_param="recovery_target_time = '${escaped_target}'"
+  fi
   cat > "$PGBACKREST_RECOVERY_CONF" <<EOF
 restore_command = '${escaped_restore}'
-recovery_target_time = '${escaped_target}'
+${recovery_param}
 recovery_target_action = 'promote'
 EOF
   chown postgres:postgres "$PGBACKREST_RECOVERY_CONF"

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -524,33 +524,6 @@ bootstrap_pgbackrest_stanza() {
     else
       echo "pgbackrest: stanza-create failed (will retry on next boot)" >&2
     fi
-
-    # Emit one tiny committed transaction so pg_last_committed_xact() returns
-    # a real timestamp from the very first probe. Without this, a freshly
-    # (re)booted primary with no user activity reports lastCommittedTxnAt=NULL
-    # and the PITR picker has no commit-time ceiling at all — track_commit_timestamp
-    # only records timestamps for commits observed after it was enabled, and a
-    # cluster that boots and sits idle has no such commits. The picker is
-    # contractually forbidden from inferring a ceiling from archive-head times
-    # (those advance with empty heartbeat segments and are not reachable by
-    # recovery_target_time), so without a warmup the picker would fall back to
-    # latestBackupAt, which on default cadence (WAL_BACKUP_DIFF_INTERVAL_HOURS=24)
-    # can lag real time by up to a day even though WAL is being archived and
-    # fully restorable second-by-second. pg_logical_emit_message(transactional=true,
-    # ...) writes a LOGICAL_MESSAGE record inside an autocommitted txn — one
-    # XACT_COMMIT in WAL, recorded by track_commit_timestamp, no schema impact,
-    # idempotent across reboots. Skipped during recovery: PITR-restored clusters
-    # replay XACT_COMMIT records as part of recovery, so post-promote
-    # pg_last_committed_xact() already returns the source's last commit time.
-    if [ "$(gosu postgres psql -h 127.0.0.1 -U postgres -d postgres -tAc 'SELECT pg_is_in_recovery()' 2>/dev/null)" = "f" ]; then
-      if gosu postgres psql -h 127.0.0.1 -U postgres -d postgres -tAc \
-           "SELECT pg_logical_emit_message(true, 'railway-pitr-warmup', now()::text)" \
-           >/dev/null 2>&1; then
-        echo "pgbackrest: PITR warmup commit emitted (pg_last_committed_xact populated)"
-      else
-        echo "pgbackrest: PITR warmup commit failed; picker ceiling will stay null until first user commit" >&2
-      fi
-    fi
   ) &
 }
 


### PR DESCRIPTION
## Summary

Two PITR followups, plus the picker-side cleanup described in the matching mono PR.

1. **`configure_pgbackrest_recovery` now writes `recovery_target_xid`** when `POSTGRES_RECOVERY_TARGET_XID` is set, mirroring the new-service restore path. Previously the staging-path (PITR-restored fork on an existing volume) silently dropped XID-only configs the picker emits when it clamped target down to the source's last committed xact. New-service restores went through `restore_from_pgbackrest_if_empty_volume` so they were unaffected.

2. **No image-side warmup commit.** The branch landed and reverted a transactional `pg_logical_emit_message` warmup twice while we worked through the trade-offs (commits 2d1eb70 → 9c03c23 → c6add52 → 137af8f). The final answer is on the picker side: read `GREATEST(pg_last_committed_xact(), pg_xact_commit_timestamp(newest_commit_ts_xid from pg_control_checkpoint()))`. `pg_control` persists `newest_commit_ts_xid` across every postmaster restart, so the picker has a non-null reading without any image-side bookkeeping. See the matching mono PR (forthcoming) for the SQL.

## Test plan

- [ ] PITR-restored fork with picker-emitted `POSTGRES_RECOVERY_TARGET_XID` (no `_TIME`) reaches the configured xid and promotes — verify the staged `pgbackrest-recovery.conf` has `recovery_target_xid = '...'`.
- [ ] New-service PITR restore continues to use `pgbackrest restore --type=xid` unchanged.
- [ ] Boot postgres-ssl and confirm no warmup commit appears in the WAL after stanza-create.