### PR TITLE
feat(pitr): recovery_target=immediate for in-snapshot target xid

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -2698,6 +2698,122 @@ t_pitr_target_xid_routes_xid_through_stack() {
   docker volume rm "$src_vol" "$rest_vol" >/dev/null
 }
 
+# I3. POSTGRES_RECOVERY_TARGET_TYPE=immediate routes through wrapper +
+# pgbackrest + postgresql.auto.conf without leaking recovery_target_xid /
+# recovery_target_time.
+#
+# Picker emits TYPE=immediate when the clamped target xid lives INSIDE the
+# most recent base backup (lastCommittedTxnAt ≤ latestBackupAt, e.g. an
+# idle source with only pre-backup commits). recovery_target_xid would
+# FATAL "requested recovery stop point is before consistent recovery
+# point" because target xid's commit LSN < min_recovery_lsn. The image
+# fix: stop recovery at the earliest consistent point (= backup_end LSN)
+# via pgBackRest --type=immediate.
+#
+# Pins the same four observation points as the xid test:
+#   1. wrapper logs "using recovery_target=immediate"
+#   2. pgbackrest restore line shows "--type=immediate" (no --target)
+#   3. postgresql.auto.conf carries `recovery_target = 'immediate'` and
+#      NEITHER recovery_target_xid NOR recovery_target_time
+#   4. postgres logs the immediate-mode recovery start ("starting
+#      archive recovery"; immediate target doesn't log a target value)
+#
+# What this does NOT pin: recovery actually promotes at backup_end LSN
+# with the row contract honored. End-to-end immediate-mode success is
+# exercised by test-postgres-pitr's idleRestore flow once the picker fix
+# lands; the image only owns routing.
+t_pitr_target_immediate_routes_through_stack() {
+  setup_pitr_source >&2 || { ko t_pitr_target_immediate_routes_through_stack "setup_pitr_source failed"; return; }
+  read -r src_name src_vol < "/tmp/pitr-source-${PG_VERSION}"
+  local target; target=$(cat "/tmp/pitr-target-${PG_VERSION}")
+  local src_path; src_path=$(pitr_source_path)
+  local rest_name=t-imm-route-${PG_VERSION}
+  local rest_vol=${rest_name}-vol
+
+  # Picker emits TYPE=immediate alongside the originally-clamped TIME +
+  # XID — TIME stays the wrapper's "this is a restore" sentinel and the
+  # XID is preserved for diagnostics, but TYPE wins the priority compare
+  # and both should be suppressed from the rendered recovery params.
+  local target_xid
+  target_xid=$(docker exec "$src_name" psql -U postgres -At -c \
+    "SELECT xmin::text::bigint FROM pitrtest WHERE id=1")
+  if [ -z "$target_xid" ] || [ "$target_xid" = "0" ]; then
+    ko t_pitr_target_immediate_routes_through_stack "captured xid empty/zero (got '$target_xid')"
+    return
+  fi
+
+  new_volume "$rest_vol"
+  docker rm -f "$rest_name" >/dev/null 2>&1 || true
+  docker run -d --name "$rest_name" --label postgres-ssl-e2e=1 --network "$NET" \
+    -e POSTGRES_PASSWORD=test \
+    -e "WAL_RECOVER_FROM_BUCKET=$BUCKET" \
+    -e "WAL_RECOVER_FROM_ENDPOINT=http://${MINIO}:9000" \
+    -e WAL_RECOVER_FROM_REGION=us-east-1 \
+    -e WAL_RECOVER_FROM_KEY=$MINIO_USER \
+    -e WAL_RECOVER_FROM_SECRET=$MINIO_PASS \
+    -e "WAL_RECOVER_FROM_PATH=$src_path" \
+    -e PGBACKREST_REPO1_S3_URI_STYLE=path \
+    -e "POSTGRES_RECOVERY_TARGET_TIME=$target" \
+    -e "POSTGRES_RECOVERY_TARGET_XID=$target_xid" \
+    -e POSTGRES_RECOVERY_TARGET_TYPE=immediate \
+    -v "$rest_vol:/var/lib/postgresql/data" \
+    "$IMAGE" >/dev/null
+
+  local deadline=$(($(date +%s) + 30)) saw_wrapper=0 saw_pgbackrest=0 saw_postgres=0
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    local logs
+    logs=$(docker logs "$rest_name" 2>&1)
+    echo "$logs" | grep -q "using recovery_target=immediate"            && saw_wrapper=1
+    echo "$logs" | grep -qE "pgbackrest .*--type=immediate"             && saw_pgbackrest=1
+    echo "$logs" | grep -qE "starting archive recovery"                 && saw_postgres=1
+    [ "$saw_wrapper" = 1 ] && [ "$saw_pgbackrest" = 1 ] && [ "$saw_postgres" = 1 ] && break
+    sleep 2
+  done
+  if [ "$saw_wrapper" != 1 ]; then
+    ko t_pitr_target_immediate_routes_through_stack "wrapper did not log 'using recovery_target=immediate'"
+    fail_dump t_pitr_target_immediate_routes_through_stack "$rest_name"
+    return
+  fi
+  if [ "$saw_pgbackrest" != 1 ]; then
+    ko t_pitr_target_immediate_routes_through_stack "pgbackrest restore not invoked with --type=immediate"
+    fail_dump t_pitr_target_immediate_routes_through_stack "$rest_name"
+    return
+  fi
+  if [ "$saw_postgres" != 1 ]; then
+    ko t_pitr_target_immediate_routes_through_stack "postgres did not log archive recovery start"
+    fail_dump t_pitr_target_immediate_routes_through_stack "$rest_name"
+    return
+  fi
+
+  local auto_conf
+  auto_conf=$(docker run --rm -v "${rest_vol}:/data" alpine cat /data/postgresql.auto.conf 2>/dev/null || echo "")
+  if [ -z "$auto_conf" ]; then
+    ko t_pitr_target_immediate_routes_through_stack "postgresql.auto.conf missing or unreadable"
+    return
+  fi
+  if ! echo "$auto_conf" | grep -qE "^recovery_target = 'immediate'$"; then
+    ko t_pitr_target_immediate_routes_through_stack "auto.conf missing 'recovery_target = immediate'"
+    echo "  auto.conf:"
+    echo "$auto_conf" | sed 's/^/    /'
+    return
+  fi
+  # Both _xid and _time MUST be absent — picker's TYPE=immediate signals
+  # "ignore the other knobs"; leaking either would make postgres apply
+  # conflicting targets (recovery_target_xid wins over recovery_target,
+  # which would re-trigger the in-snapshot FATAL).
+  if echo "$auto_conf" | grep -qE "^recovery_target_(xid|time) = "; then
+    ko t_pitr_target_immediate_routes_through_stack "auto.conf carries recovery_target AND recovery_target_xid/time — wrapper did not suppress xid/time when TYPE=immediate"
+    echo "  auto.conf:"
+    echo "$auto_conf" | sed 's/^/    /'
+    return
+  fi
+
+  ok t_pitr_target_immediate_routes_through_stack
+  note "wrapper → pgbackrest → auto.conf (recovery_target='immediate') → postgres all routed IMMEDIATE; xid/time suppressed; recovery termination covered upstream"
+  docker rm -f "$src_name" "$rest_name" >/dev/null
+  docker volume rm "$src_vol" "$rest_vol" >/dev/null
+}
+
 # G3. Restore over a WAL gap → loud refuse.
 # Mirrors test-postgres-pitr/gaps at the image level. Custom setup (not
 # setup_pitr_source) so we have tight control over which segment contains
@@ -3164,6 +3280,7 @@ ALL_TESTS=(
   # mutation-driven e2e flows)
   t_pitr_idle_source_target_time_fatals
   t_pitr_target_xid_routes_xid_through_stack
+  t_pitr_target_immediate_routes_through_stack
   t_pitr_missing_wal_segment_fatals
   t_lifecycle_enable_disable_reenable
   t_chain_restore_r1_to_r2

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -608,13 +608,19 @@ EOF
   # an embedded apostrophe can't break the conf file or smuggle a setting.
   local escaped_restore="${restore_cmd//\'/\'\'}"
 
-  # POSTGRES_RECOVERY_TARGET_XID, when set, wins over _TIME — same idle-
-  # source-safe rationale as restore_from_pgbackrest_if_empty_volume:
-  # recovery_target_time hangs/FATALs when no commit record exists past
-  # target on an idle DB, recovery_target_xid matches an exact commit.
-  # The picker emits _XID when it clamped to lastCommittedTxnAt.
+  # Pick the recovery target same way restore_from_pgbackrest_if_empty_volume
+  # does — three modes in priority order:
+  #   1. _TYPE=immediate: stop at earliest consistent point (= backup_end
+  #      LSN). Used when the clamped xid lives inside the most recent base
+  #      backup; recovery_target_xid would FATAL "before consistent recovery
+  #      point" because target xid's commit LSN < min_recovery_lsn.
+  #   2. _XID set: exact-commit match; idle-source-safe.
+  #   3. _TIME: arbitrary historical time; source had post-target commits in
+  #      WAL so postgres observes the timestamp cross.
   local recovery_param
-  if [ -n "${POSTGRES_RECOVERY_TARGET_XID:-}" ]; then
+  if [ "${POSTGRES_RECOVERY_TARGET_TYPE:-}" = "immediate" ]; then
+    recovery_param="recovery_target = 'immediate'"
+  elif [ -n "${POSTGRES_RECOVERY_TARGET_XID:-}" ]; then
     local escaped_xid="${POSTGRES_RECOVERY_TARGET_XID//\'/\'\'}"
     recovery_param="recovery_target_xid = '${escaped_xid}'"
   else
@@ -694,22 +700,34 @@ EOF
   # bucket without touching the default config.
   local recovery_restore_cmd="pgbackrest --config=${PGBACKREST_RECOVERY_S3_CONF} --stanza=main archive-get %f %p"
 
-  # Pick the recovery target type. POSTGRES_RECOVERY_TARGET_XID, when set,
-  # wins over _TIME because it's the only target type postgres can match
-  # exactly on an idle source. recovery_target_time requires postgres to
-  # observe a WAL record with timestamp > target before declaring "target
-  # reached" and firing recovery_target_action=promote; on an idle DB no
-  # such record exists, so recovery FATALs with "recovery ended before
-  # configured recovery target was reached" and the cluster either loops
-  # the FATAL or hangs in hot_standby read-only mode. recovery_target_xid
-  # matches an exact transaction ID — applying the target xid's commit
-  # is unambiguously "target reached." The picker (mono's
-  # createServiceFromPITR mutation) sets _XID when it clamped target
-  # down to lastCommittedTxnAt, leaves it unset for arbitrary
-  # historical times.
+  # Pick the recovery target type. Three modes, in priority order:
+  #
+  #   1. POSTGRES_RECOVERY_TARGET_TYPE=immediate — picker detected the
+  #      clamped target xid lives INSIDE the most recent base backup
+  #      (lastCommittedTxnAt ≤ latestBackupAt: no commits since the snapshot
+  #      began). recovery_target_xid would FATAL with "requested recovery
+  #      stop point is before consistent recovery point" because the xid's
+  #      commit LSN < min_recovery_lsn from the backup's stop checkpoint.
+  #      The snapshot already captures the user's desired state, so stop
+  #      recovery at the earliest consistent point (= backup_end LSN) by
+  #      passing pgBackRest --type=immediate.
+  #
+  #   2. POSTGRES_RECOVERY_TARGET_XID — picker clamped to lastCommittedTxnAt
+  #      and the xid lives in WAL forward of the most recent backup. Exact
+  #      transaction match; idle-source-safe (recovery_target_time would
+  #      FATAL with "recovery ended before configured recovery target was
+  #      reached" because no WAL record has a timestamp > target on an
+  #      idle DB).
+  #
+  #   3. POSTGRES_RECOVERY_TARGET_TIME — arbitrary historical time. Source
+  #      had post-target commits in WAL, so postgres can observe the cross.
   local restore_type="time"
   local restore_target="$POSTGRES_RECOVERY_TARGET_TIME"
-  if [ -n "${POSTGRES_RECOVERY_TARGET_XID:-}" ]; then
+  if [ "${POSTGRES_RECOVERY_TARGET_TYPE:-}" = "immediate" ]; then
+    restore_type="immediate"
+    restore_target=""
+    echo "pgbackrest: using recovery_target=immediate (picker detected target xid is in-snapshot; promotion at backup_end LSN matches user's idle-source target)"
+  elif [ -n "${POSTGRES_RECOVERY_TARGET_XID:-}" ]; then
     restore_type="xid"
     restore_target="$POSTGRES_RECOVERY_TARGET_XID"
     echo "pgbackrest: using recovery_target_xid=${POSTGRES_RECOVERY_TARGET_XID} (idle-source-safe; target-time fallback would FATAL on no-record-after-target)"
@@ -717,14 +735,22 @@ EOF
 
   # --pg1-path is taken from $PGDATA so this works in restore-only mode too,
   # where render_pgbackrest_conf has been called but didn't include repo2.
+  # --target only makes sense for type=time/xid/lsn/name; immediate has no
+  # target so omit the flag entirely.
+  local -a target_args=()
+  if [ "$restore_type" = "immediate" ]; then
+    target_args=("--type=immediate")
+  else
+    target_args=("--type=$restore_type" "--target=$restore_target")
+  fi
   if ! gosu postgres pgbackrest --config="$PGBACKREST_RECOVERY_S3_CONF" \
        --stanza=main \
        --pg1-path="$PGDATA" \
        --recovery-option=restore_command="$recovery_restore_cmd" \
        restore \
-       --type="$restore_type" --target="$restore_target" \
+       "${target_args[@]}" \
        --target-action=promote; then
-    echo "pgbackrest: restore from source bucket failed; fix env vars (WAL_RECOVER_FROM_*, POSTGRES_RECOVERY_TARGET_TIME, POSTGRES_RECOVERY_TARGET_XID) and redeploy" >&2
+    echo "pgbackrest: restore from source bucket failed; fix env vars (WAL_RECOVER_FROM_*, POSTGRES_RECOVERY_TARGET_TIME, POSTGRES_RECOVERY_TARGET_XID, POSTGRES_RECOVERY_TARGET_TYPE) and redeploy" >&2
     exit 1
   fi
 


### PR DESCRIPTION
## Summary
- Adds `POSTGRES_RECOVERY_TARGET_TYPE=immediate` as a third recovery mode for the case where mono's picker detects the clamped target xid lives INSIDE the most recent base backup. Recovery_target_xid FATALs ("requested recovery stop point is before consistent recovery point") because the xid's commit LSN < min_recovery_lsn — the snapshot already captures the user's desired state.
- wrapper.sh: pgBackRest restore with `--type=immediate` (no `--target`); auto.conf gets `recovery_target = 'immediate'` instead of `_xid`/`_time`.
- Forward-compatible: mono not emitting TYPE falls through to the existing xid → time priority.
- Adds `t_pitr_target_immediate_routes_through_stack` mirroring the xid routing test.

## Why image-first
Mono picker change (TBD, separate PR) needs the image's TYPE=immediate handling. Shipping image first since it's additive.

## Test plan
- [ ] Image-level e2e (`test/e2e.sh`) PASSes the new test on PG 17/18
- [ ] xid routing test still PASSes (no regression on existing path)
- [ ] mono picker PR (follow-up) wires `pitrTargetType: 'immediate'` into `stageInitialPITRRestorePatch`'s env vars
- [ ] test-postgres-pitr `idleRestore` flow un-SKIPped after both PRs land