### PR TITLE
chore: drop dead LOG_TO_STDOUT branch in wrapper.sh

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -798,11 +798,4 @@ unset PGPORT
 bootstrap_pgbackrest_stanza
 fork_pgbackrest_backup_watcher
 
-# Call the entrypoint script with the
-# appropriate PGHOST & PGPORT and redirect
-# the output to stdout if LOG_TO_STDOUT is true
-if [[ "$LOG_TO_STDOUT" == "true" ]]; then
-    /usr/local/bin/docker-entrypoint.sh "$@" 2>&1
-else
-    /usr/local/bin/docker-entrypoint.sh "$@"
-fi
+/usr/local/bin/docker-entrypoint.sh "$@"


### PR DESCRIPTION
## Summary

Mono never sets \`LOG_TO_STDOUT\`, no Dockerfile bakes it, and the only place the variable appears in this repo is the conditional itself in \`wrapper.sh\`. The two branches only differed in a \`2>&1\` redirect on the true side — irrelevant under Docker, which captures both streams via cgroup logging anyway.

Collapse to the unconditional invocation.

## Test plan
- [x] \`bash -n wrapper.sh\`
- [ ] image still boots: \`./test/e2e.sh\` smoke