### PR TITLE
test(e2e): fix t_watcher_gap_recovery_full race

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1269,15 +1269,24 @@ t_watcher_gap_recovery_full() {
   # gap-recovery branch on the next poll.
   docker exec -u postgres "$name" touch /var/lib/postgresql/data/.pgbackrest_gap_pending
 
+  # `cleared gap marker` is emitted right before `backup --type=full
+  # completed` in run_backup(). Wait on both signals inside the loop —
+  # checking them separately races against docker's stdout flush window
+  # (the two echoes can land in different `docker logs` snapshots even
+  # though the watcher emits them back-to-back in the same shell).
   local deadline=$(($(date +%s) + 30)) hit=0
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    local now_count
-    now_count=$(docker logs "$name" 2>&1 | grep -c "backup --type=full completed" || true)
-    if [ "$now_count" -gt "$before_count" ]; then hit=1; break; fi
+    local logs now_count
+    logs=$(docker logs "$name" 2>&1)
+    now_count=$(echo "$logs" | grep -c "backup --type=full completed" || true)
+    if [ "$now_count" -gt "$before_count" ] \
+       && echo "$logs" | grep -q "cleared gap marker"; then
+      hit=1; break
+    fi
     sleep 2
   done
   if [ "$hit" != "1" ]; then
-    ko t_watcher_gap_recovery_full "watcher did not take gap-recovery full"
+    ko t_watcher_gap_recovery_full "watcher did not take gap-recovery full or did not log 'cleared gap marker'"
     fail_dump t_watcher_gap_recovery_full "$name"
     return
   fi
@@ -1285,12 +1294,6 @@ t_watcher_gap_recovery_full() {
   # Marker should be cleared by run_backup() after the full lands.
   if docker exec "$name" test -f /var/lib/postgresql/data/.pgbackrest_gap_pending; then
     ko t_watcher_gap_recovery_full ".pgbackrest_gap_pending was not cleared after gap-recovery full"
-    return
-  fi
-
-  if ! docker logs "$name" 2>&1 | grep -q "cleared gap marker"; then
-    ko t_watcher_gap_recovery_full "expected 'cleared gap marker' log line"
-    fail_dump t_watcher_gap_recovery_full "$name"
     return
   fi
 


### PR DESCRIPTION
## Summary

\`cleared gap marker\` and \`backup --type=full completed\` are emitted back-to-back by \`run_backup()\` in the same shell function, but Docker's stdout flush window can split them across separate \`docker logs\` snapshots. The old loop broke on seeing the new "completed" count and then re-queried for "cleared gap marker" — racing the flush.

This flake hit PR #72 (LOG_TO_STDOUT cleanup) — surfaced as "expected 'cleared gap marker' log line"; the rerun passed unchanged.

Capture \`docker logs\` once per iteration and require BOTH signals before declaring success. The "marker file is gone" assertion stays after the loop since it reads the filesystem, not stdout.

## Test plan
- [x] \`bash -n test/e2e.sh\`
- [ ] \`./test/e2e.sh t_watcher_gap_recovery_full\` passes
- [ ] Full suite green