### PR TITLE
fix(pitr): also match InvalidAccessKeyId when bucket credentials are revoked

### DIFF
--- a/pgbackrest-archive-push-wrapper.sh
+++ b/pgbackrest-archive-push-wrapper.sh
@@ -86,11 +86,14 @@ if [ "$PGB_RC" -eq 0 ]; then
   exit 0
 fi
 
-# Bucket deleted: NoSuchBucket is the S3 error for a bucket that no longer
-# exists. No retry will ever succeed without operator action, so drop the
-# segment immediately rather than accumulating WAL up to the threshold.
-if printf '%s\n' "$pgb_out" | grep -q 'NoSuchBucket'; then
-  echo "pgbackrest-wrapper: bucket does not exist (NoSuchBucket); dropping ${WAL_FILE} immediately" >&2
+# Bucket deleted: when the bucket no longer exists Tigris returns NoSuchBucket
+# on read paths, but validates credentials before checking bucket existence on
+# write paths (archive-push is a PUT). Railway revokes the bucket credentials
+# when the bucket is deleted, so in practice pgBackRest sees InvalidAccessKeyId
+# on the PUT. Both errors mean no recovery without operator action — drop
+# immediately rather than accumulating WAL up to the threshold.
+if printf '%s\n' "$pgb_out" | grep -qE 'NoSuchBucket|InvalidAccessKeyId'; then
+  echo "pgbackrest-wrapper: bucket gone or credentials revoked; dropping ${WAL_FILE} immediately" >&2
   touch "$PGDATA/.pgbackrest_gap_pending" 2>/dev/null || true
   exit 0
 fi


### PR DESCRIPTION
## Summary

Extends the bucket-deleted immediate-drop logic (landed in #77) to also match `InvalidAccessKeyId`.

## Why InvalidAccessKeyId and not just NoSuchBucket

Direct API probing against Tigris showed that the two S3 error codes apply to different request types:

- **GET** to a non-existent bucket (any auth): `404 NoSuchBucket` — Tigris checks bucket existence before credentials on reads.
- **PUT** to a non-existent bucket with invalid/revoked credentials: `403 InvalidAccessKeyId` — Tigris validates credentials before bucket existence on writes.

Since `archive-push` is a PUT, and Railway revokes the bucket credentials when the bucket is deleted, pgBackRest would see `InvalidAccessKeyId` in practice — not `NoSuchBucket`. This PR adds that pattern to the grep so both are caught.

## What happens when the bucket comes back / a redeploy points at a new bucket

Both recovery paths work the same way:

1. **Bucket re-created or credentials restored**: pgBackRest's next `archive-push` succeeds. The wrapper returns 0 normally — the `NoSuchBucket`/`InvalidAccessKeyId` branch is never taken. The `.pgbackrest_gap_pending` sentinel left by the drop path is still on disk; the backup watcher picks it up on its next poll and takes a fresh full backup. That full backup becomes the new recovery base, so the PITR window restarts cleanly from the point archiving recovered.

2. **Redeploy with a new bucket** (`WAL_ARCHIVE_BUCKET` updated): `wrapper.sh` rewrites `/etc/pgbackrest/pgbackrest.conf` with the new bucket on boot and runs `stanza-create`. First `archive-push` to the new bucket succeeds. Same as above — `gap_pending` is already set, the watcher takes a full, PITR window starts fresh.

In both cases the gap itself (the segments dropped while the bucket was gone) is unrestorable — that's inherent to dropping them — but everything from the first successful archive after recovery is fully covered.

## Edge case: credential rotation redeploy

`InvalidAccessKeyId` would also fire for a few seconds if the old key is revoked before the new container is live during a normal credential rotation. That creates a tiny archiving gap (~seconds of WAL vs. the previous 500 MiB accumulation). It's a better tradeoff in Railway's model where bucket deletion is permanent and immediate drops are the right response.