### PR TITLE
feat(pitr): periodic S3 catalog verification in backup watcher

### DIFF
--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -177,16 +177,19 @@ run_backup() {
   return 1
 }
 
-# Returns 0 if the S3 catalog for repo1 has at least one full backup; returns 1
-# if the catalog is empty or unreachable. Uses pgbackrest info --output=json so
-# no text-parsing heuristics are needed. A non-zero exit from pgbackrest itself
-# (stanza not yet created, S3 down, auth failure) is also treated as "can't tell"
-# and returns 1 — the caller only clears local state when the catalog explicitly
-# confirms no backup exists (exit 0 + empty backup list).
-catalog_has_backup() {
-  local info_out
-  info_out=$(timeout 60 pgbackrest --stanza=main --repo=1 info --output=json 2>/dev/null) || return 1
-  printf '%s' "$info_out" | grep -q '"type":"full"'
+# Probes the S3 catalog for repo1 via pgbackrest info --output=json.
+# No text-parsing heuristics needed. Returns three distinct states:
+#   0 — full backup confirmed present (pgbackrest exit 0 + "full" in output)
+#   1 — conclusively no full backup (pgbackrest exit 0, no "full" entry)
+#   2 — inconclusive (pgbackrest exited non-zero: S3 unreachable, auth failure,
+#       stanza not yet created, etc.) — caller must NOT clear local state
+catalog_check_backup() {
+  local info_out rc
+  info_out=$(timeout 60 pgbackrest --stanza=main --repo=1 info --output=json 2>/dev/null)
+  rc=$?
+  [ "$rc" -ne 0 ] && return 2
+  printf '%s' "$info_out" | grep -q '"type":"full"' && return 0
+  return 1
 }
 
 # Sets DECIDED_ACTION to "full"|"diff"|"" (no action). Runs in the caller's
@@ -233,8 +236,12 @@ decide_action() {
   if [ "$needs_verify" -eq 1 ]; then
     write_state_field last_catalog_verify_at "$now"
     log "verifying S3 catalog has full backup"
-    if catalog_has_backup; then
+    catalog_check_backup
+    local _crc=$?
+    if [ "$_crc" -eq 0 ]; then
       log "catalog verified — full backup present in S3"
+    elif [ "$_crc" -eq 2 ]; then
+      log "catalog check inconclusive (S3 unreachable or stanza not yet created); skipping"
     else
       log "catalog shows no full backup despite local state (last_full=${last_full}); clearing last_full_at to trigger new full"
       write_state_field last_full_at ""

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -68,6 +68,14 @@ GAP_RESOLVED_GRACE_SECONDS="${WAL_BACKUP_GAP_RESOLVED_GRACE_SECONDS:-300}"
 FULL_INTERVAL_HOURS="${WAL_BACKUP_FULL_INTERVAL_HOURS:-168}"
 DIFF_INTERVAL_HOURS="${WAL_BACKUP_DIFF_INTERVAL_HOURS:-24}"
 
+# How often to verify the S3 catalog actually contains a full backup (seconds).
+# Catches divergence between local state (last_full_at) and S3 reality — e.g.
+# the backup command returned exit 0 but the catalog write never completed, or a
+# volume survived a redeployment with stale state pointing at a different stanza
+# path. 0 disables periodic verification (NEEDS_INITIAL_BACKUP still fires on
+# fresh state). Default: 3600 (1 hour).
+CATALOG_VERIFY_INTERVAL_SECONDS="${WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS:-3600}"
+
 # Resolved cadence in seconds. WAL_BACKUP_FULL_INTERVAL_SECONDS overrides
 # the hours setting — bash arithmetic precludes fractional hours, so the
 # e2e harness needs a second-level knob to exercise retention rollover
@@ -169,6 +177,18 @@ run_backup() {
   return 1
 }
 
+# Returns 0 if the S3 catalog for repo1 has at least one full backup; returns 1
+# if the catalog is empty or unreachable. Uses pgbackrest info --output=json so
+# no text-parsing heuristics are needed. A non-zero exit from pgbackrest itself
+# (stanza not yet created, S3 down, auth failure) is also treated as "can't tell"
+# and returns 1 — the caller only clears local state when the catalog explicitly
+# confirms no backup exists (exit 0 + empty backup list).
+catalog_has_backup() {
+  local info_out
+  info_out=$(timeout 60 pgbackrest --stanza=main --repo=1 info --output=json 2>/dev/null) || return 1
+  printf '%s' "$info_out" | grep -q '"type":"full"'
+}
+
 # Sets DECIDED_ACTION to "full"|"diff"|"" (no action). Runs in the caller's
 # shell — not a subshell — so the diagnostic globals (LAST_FULL_DIAG,
 # GAP_MARKER_DIAG, LAST_FULL_FAILED_DIAG) survive for watcher_iteration to
@@ -194,6 +214,32 @@ decide_action() {
   # time on idle DBs (heartbeat → archive_timeout → archive-push cycle).
   if [ -z "$last_full" ]; then
     DECIDED_ACTION="full"; return 0
+  fi
+
+  # Catalog verification — periodically confirm S3 actually has a full backup.
+  # Catches divergence between local state and S3 reality: the backup command
+  # may have returned exit 0 without committing catalog metadata (S3 partial
+  # write, stanza-create race), or a volume survived a redeployment with stale
+  # state pointing at a different stanza/sysid path. Only clears state when the
+  # catalog explicitly confirms "no backup" (exit 0 + empty backup list); an
+  # unreachable S3 or missing stanza returns non-zero and is treated as
+  # inconclusive so we don't burn a full on every transient S3 hiccup.
+  local last_catalog_verify
+  last_catalog_verify=$(read_state last_catalog_verify_at)
+  local needs_verify=0
+  if [ -z "$last_catalog_verify" ] || [ $((now - last_catalog_verify)) -ge "$CATALOG_VERIFY_INTERVAL_SECONDS" ]; then
+    needs_verify=1
+  fi
+  if [ "$needs_verify" -eq 1 ]; then
+    write_state_field last_catalog_verify_at "$now"
+    log "verifying S3 catalog has full backup"
+    if catalog_has_backup; then
+      log "catalog verified — full backup present in S3"
+    else
+      log "catalog shows no full backup despite local state (last_full=${last_full}); clearing last_full_at to trigger new full"
+      write_state_field last_full_at ""
+      DECIDED_ACTION="full"; return 0
+    fi
   fi
 
   # Gap recovery — explicit drop marker OR failed_count grew since last full.

--- a/pgbackrest-init.sh
+++ b/pgbackrest-init.sh
@@ -23,6 +23,16 @@
 set -e
 
 if [ -z "${WAL_ARCHIVE_BUCKET:-}" ]; then
+  # If validate_wal_archive_bucket in wrapper.sh detected a junk bucket it
+  # exports PGBACKREST_BUCKET_INVALID_REASON and unsets WAL_ARCHIVE_BUCKET
+  # before calling docker-entrypoint.sh. Write the sentinel here (during
+  # initdb, AFTER PGDATA exists) so docker logs show the misconfiguration
+  # and the monitor can distinguish "never configured" from "misconfigured."
+  if [ -n "${PGBACKREST_BUCKET_INVALID_REASON:-}" ]; then
+    printf '%s\n' "${PGBACKREST_BUCKET_INVALID_REASON}" > "$PGDATA/.pgbackrest_invalid_bucket" 2>/dev/null || true
+    chmod 0640 "$PGDATA/.pgbackrest_invalid_bucket" 2>/dev/null || true
+    echo "pgbackrest: wrote invalid-bucket sentinel (reason=${PGBACKREST_BUCKET_INVALID_REASON})"
+  fi
   exit 0
 fi
 

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1269,15 +1269,24 @@ t_watcher_gap_recovery_full() {
   # gap-recovery branch on the next poll.
   docker exec -u postgres "$name" touch /var/lib/postgresql/data/.pgbackrest_gap_pending
 
+  # `cleared gap marker` is emitted right before `backup --type=full
+  # completed` in run_backup(). Wait on both signals inside the loop —
+  # checking them separately races against docker's stdout flush window
+  # (the two echoes can land in different `docker logs` snapshots even
+  # though the watcher emits them back-to-back in the same shell).
   local deadline=$(($(date +%s) + 30)) hit=0
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    local now_count
-    now_count=$(docker logs "$name" 2>&1 | grep -c "backup --type=full completed" || true)
-    if [ "$now_count" -gt "$before_count" ]; then hit=1; break; fi
+    local logs now_count
+    logs=$(docker logs "$name" 2>&1)
+    now_count=$(echo "$logs" | grep -c "backup --type=full completed" || true)
+    if [ "$now_count" -gt "$before_count" ] \
+       && echo "$logs" | grep -q "cleared gap marker"; then
+      hit=1; break
+    fi
     sleep 2
   done
   if [ "$hit" != "1" ]; then
-    ko t_watcher_gap_recovery_full "watcher did not take gap-recovery full"
+    ko t_watcher_gap_recovery_full "watcher did not take gap-recovery full or did not log 'cleared gap marker'"
     fail_dump t_watcher_gap_recovery_full "$name"
     return
   fi
@@ -1285,12 +1294,6 @@ t_watcher_gap_recovery_full() {
   # Marker should be cleared by run_backup() after the full lands.
   if docker exec "$name" test -f /var/lib/postgresql/data/.pgbackrest_gap_pending; then
     ko t_watcher_gap_recovery_full ".pgbackrest_gap_pending was not cleared after gap-recovery full"
-    return
-  fi
-
-  if ! docker logs "$name" 2>&1 | grep -q "cleared gap marker"; then
-    ko t_watcher_gap_recovery_full "expected 'cleared gap marker' log line"
-    fail_dump t_watcher_gap_recovery_full "$name"
     return
   fi
 

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -304,6 +304,59 @@ t_vanilla_boot() {
   docker volume rm "$vol" >/dev/null
 }
 
+t_invalid_bucket_skips_archive() {
+  # Sets WAL_ARCHIVE_BUCKET to junk shapes the upstream resolver might leak
+  # (unresolved Railway template ref + bucket-id UUID). The image guard must
+  # refuse to enable archiving rather than writing the junk into
+  # pgbackrest.conf and letting pgbackrest hard-fail every archive_command
+  # until pgbackrest-archive-push-wrapper.sh's 500 MiB threshold drops WAL.
+  for bad in '${{121ccc45-0912-457e-8dc0-76625fe644bb.BUCKET}}' '121ccc45-0912-457e-8dc0-76625fe644bb'; do
+    local name=t-badbucket-${PG_VERSION}
+    local vol=${name}-vol
+    new_volume "$vol"
+    docker rm -f "$name" >/dev/null 2>&1 || true
+    docker run -d --name "$name" --label postgres-ssl-e2e=1 --network "$NET" \
+      -e POSTGRES_PASSWORD=test \
+      -e "WAL_ARCHIVE_BUCKET=${bad}" \
+      -e "WAL_ARCHIVE_ENDPOINT=http://${MINIO}:9000" \
+      -e "WAL_ARCHIVE_REGION=us-east-1" \
+      -e "WAL_ARCHIVE_KEY=$MINIO_USER" \
+      -e "WAL_ARCHIVE_SECRET=$MINIO_PASS" \
+      -v "$vol:/var/lib/postgresql/data" \
+      "$IMAGE" >/dev/null
+    wait_for_pg "$name" || { ko t_invalid_bucket_skips_archive "postgres did not start with bucket=${bad}"; fail_dump t_invalid_bucket_skips_archive "$name"; return; }
+
+    local archive_mode
+    archive_mode=$(docker exec "$name" psql -U postgres -At -c "SHOW archive_mode")
+    assert_eq "$archive_mode" "off" "archive_mode should be off for invalid bucket (${bad})" || { ko t_invalid_bucket_skips_archive ""; fail_dump t_invalid_bucket_skips_archive "$name"; return; }
+
+    # The junk must NOT have landed in pgbackrest.conf — that's the whole
+    # point. clear_pgbackrest_state_if_disabled treats the unset vars as
+    # "archiving off" and tears down any stale config.
+    if docker exec "$name" test -f /etc/pgbackrest/pgbackrest.conf; then
+      ko t_invalid_bucket_skips_archive "pgbackrest.conf should not exist when bucket is invalid"; fail_dump t_invalid_bucket_skips_archive "$name"; return
+    fi
+    if docker exec "$name" test -f /var/lib/postgresql/data/conf.d/pgbackrest.conf; then
+      ko t_invalid_bucket_skips_archive "conf.d/pgbackrest.conf should not exist when bucket is invalid"; fail_dump t_invalid_bucket_skips_archive "$name"; return
+    fi
+
+    # Sentinel must be present so the dashboard can distinguish "PITR never
+    # enabled" from "PITR enabled but wired to junk." PGDATA in this image is
+    # /var/lib/postgresql/data directly (no pgdata sub-path).
+    if ! docker exec "$name" test -f /var/lib/postgresql/data/.pgbackrest_invalid_bucket; then
+      ko t_invalid_bucket_skips_archive "sentinel .pgbackrest_invalid_bucket missing under PGDATA"; fail_dump t_invalid_bucket_skips_archive "$name"; return
+    fi
+
+    if ! docker logs "$name" 2>&1 | grep -q "WAL_ARCHIVE_BUCKET.*looks invalid"; then
+      ko t_invalid_bucket_skips_archive "expected guard log line missing for bucket=${bad}"; fail_dump t_invalid_bucket_skips_archive "$name"; return
+    fi
+
+    docker rm -f "$name" >/dev/null
+    docker volume rm "$vol" >/dev/null
+  done
+  ok t_invalid_bucket_skips_archive
+}
+
 t_archiving_boot() {
   local name=t-arch-${PG_VERSION}
   local vol=${name}-vol
@@ -3073,6 +3126,7 @@ t_chain_restore_r1_to_r2() {
 
 ALL_TESTS=(
   t_vanilla_boot
+  t_invalid_bucket_skips_archive
   t_archiving_boot
   t_alter_system_survives_restart
   t_s3_unreachable_pg_stays_up

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1655,9 +1655,16 @@ t_watcher_gap_recovery_failed_count_path() {
   local before_count
   before_count=$(docker logs "$name" 2>&1 | grep -c "backup --type=full completed" || true)
 
-  # Disable the user → archive-push gets 403 → archive_command returns
-  # non-zero (wrapper threshold not met) → Postgres bumps failed_count.
-  mc "mc admin user disable local ${user}" >/dev/null
+  # Switch the user to read-only → PutObject fails with AccessDenied →
+  # archive_command returns non-zero (wrapper threshold not met) → Postgres
+  # bumps failed_count. Disabling the user entirely would produce
+  # InvalidAccessKeyId, which the archive-push wrapper instant-drops (exit 0)
+  # to avoid stacking failed_count on a bucket that's been deleted — keeping
+  # failed_count=0 and defeating this test's whole premise.
+  mc "
+    mc admin policy detach local readwrite --user ${user} 2>/dev/null || true
+    mc admin policy attach local readonly --user ${user} 2>/dev/null || true
+  " >/dev/null
   for i in 1 2 3 4 5; do
     docker exec "$name" psql -U postgres -c "INSERT INTO t SELECT g FROM generate_series(${i}00000, ${i}00100) g; SELECT pg_switch_wal();" >/dev/null 2>&1
     sleep 2
@@ -1678,9 +1685,12 @@ t_watcher_gap_recovery_failed_count_path() {
     return
   fi
 
-  # Re-enable the user → archive-push succeeds again → grace window starts
+  # Restore write access → archive-push succeeds again → grace window starts
   # from last_failed_time. Wait grace + a few polls.
-  mc "mc admin user enable local ${user}" >/dev/null
+  mc "
+    mc admin policy detach local readonly --user ${user} 2>/dev/null || true
+    mc admin policy attach local readwrite --user ${user} 2>/dev/null || true
+  " >/dev/null
 
   local deadline=$(($(date +%s) + 60)) hit=0
   while [ "$(date +%s)" -lt "$deadline" ]; do

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -222,10 +222,18 @@ validate_wal_archive_bucket() {
 
   if [ -n "$invalid" ]; then
     echo "pgbackrest: WAL_ARCHIVE_BUCKET=\"${val}\" looks invalid (${invalid}); refusing to enable archiving" >&2
-    mkdir -p "$(dirname "$PGBACKREST_INVALID_BUCKET_MARKER")"
-    printf '%s\n' "${invalid}" > "$PGBACKREST_INVALID_BUCKET_MARKER" 2>/dev/null || true
-    chown postgres:postgres "$PGBACKREST_INVALID_BUCKET_MARKER" 2>/dev/null || true
-    chmod 0640 "$PGBACKREST_INVALID_BUCKET_MARKER" 2>/dev/null || true
+    # Export so pgbackrest-init.sh can write the sentinel during initdb.
+    # Writing to PGDATA here would break initdb on a fresh volume:
+    # docker-entrypoint.sh skips initdb when `ls -A "$PGDATA"` is non-empty,
+    # even for hidden files — postgres then tries to start from uninitialized
+    # data and fails. On an already-initialized volume (PG_VERSION exists)
+    # initdb hooks don't run, so write the sentinel here instead.
+    export PGBACKREST_BUCKET_INVALID_REASON="$invalid"
+    if [ -f "$PGDATA/PG_VERSION" ]; then
+      printf '%s\n' "${invalid}" > "$PGBACKREST_INVALID_BUCKET_MARKER" 2>/dev/null || true
+      chown postgres:postgres "$PGBACKREST_INVALID_BUCKET_MARKER" 2>/dev/null || true
+      chmod 0640 "$PGBACKREST_INVALID_BUCKET_MARKER" 2>/dev/null || true
+    fi
     unset WAL_ARCHIVE_BUCKET WAL_ARCHIVE_KEY WAL_ARCHIVE_SECRET
     unset WAL_ARCHIVE_REGION WAL_ARCHIVE_ENDPOINT
     return 0

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -181,6 +181,60 @@ PGBACKREST_RESTORED_MARKER="$PGDATA/.pgbackrest_restored"
 # the user can browse and restore from.
 PGBACKREST_REPO_PATH_MARKER="$PGDATA/.pgbackrest_repo_path"
 
+# Sentinel: WAL_ARCHIVE_BUCKET was set to something we couldn't honor (an
+# unresolved Railway template ref, a bucket-id UUID, whitespace, …). The
+# monitor reads this to distinguish "PITR was never enabled" from "PITR is
+# enabled but wired to junk." Lives under PGDATA so it survives container
+# restarts and gets wiped with the volume.
+PGBACKREST_INVALID_BUCKET_MARKER="$PGDATA/.pgbackrest_invalid_bucket"
+
+# Screen WAL_ARCHIVE_BUCKET for known-bogus shapes before any code path
+# consumes it. If invalid, unset the WAL_ARCHIVE_* vars so every existing
+# `[ -z "${WAL_ARCHIVE_BUCKET:-}" ]` gate downstream treats archiving as
+# off — same behavior as "never enabled." Without this, an unresolved
+# `${{<bucket-id>.BUCKET}}` would land in /etc/pgbackrest/pgbackrest.conf
+# verbatim; pgBackRest would then hard-fail every archive_command and
+# pgbackrest-archive-push-wrapper.sh's 500 MiB WAL-drop threshold would
+# eventually trip — creating a real, unrecoverable PITR gap from what is
+# really an upstream wiring bug. The sentinel file lets the dashboard
+# surface this state distinctly from the no-config and unresolvable-creds
+# states.
+#
+# Caught shapes:
+#   - empty → already handled by existing gates; no-op here.
+#   - contains `${{` or `}}` → unresolved Railway template ref.
+#   - UUID 8-4-4-4-12 hex → almost certainly a raw bucket-id from a
+#     tombstoned bucket (resolver failed to map id → name).
+#   - whitespace or control chars → typo or shell-escape mishap.
+validate_wal_archive_bucket() {
+  local val="${WAL_ARCHIVE_BUCKET:-}"
+  [ -z "$val" ] && { rm -f "$PGBACKREST_INVALID_BUCKET_MARKER" 2>/dev/null || true; return 0; }
+
+  local invalid=""
+  case "$val" in
+    *'${{'*|*'}}'*) invalid="unresolved-template-ref" ;;
+    *[[:space:]]*) invalid="whitespace" ;;
+  esac
+  if [ -z "$invalid" ] \
+    && echo "$val" | grep -qE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'; then
+    invalid="uuid-shape"
+  fi
+
+  if [ -n "$invalid" ]; then
+    echo "pgbackrest: WAL_ARCHIVE_BUCKET=\"${val}\" looks invalid (${invalid}); refusing to enable archiving" >&2
+    mkdir -p "$(dirname "$PGBACKREST_INVALID_BUCKET_MARKER")"
+    printf '%s\n' "${invalid}" > "$PGBACKREST_INVALID_BUCKET_MARKER" 2>/dev/null || true
+    chown postgres:postgres "$PGBACKREST_INVALID_BUCKET_MARKER" 2>/dev/null || true
+    chmod 0640 "$PGBACKREST_INVALID_BUCKET_MARKER" 2>/dev/null || true
+    unset WAL_ARCHIVE_BUCKET WAL_ARCHIVE_KEY WAL_ARCHIVE_SECRET
+    unset WAL_ARCHIVE_REGION WAL_ARCHIVE_ENDPOINT
+    return 0
+  fi
+
+  rm -f "$PGBACKREST_INVALID_BUCKET_MARKER" 2>/dev/null || true
+}
+validate_wal_archive_bucket
+
 # Add `include_dir = 'conf.d'` to postgresql.conf if not already present.
 # postgresql.conf is not rewritten by Postgres at runtime (only auto.conf is,
 # by ALTER SYSTEM), so this single line is durable. Called from both the


### PR DESCRIPTION
Adds a periodic catalog check that runs `pgbackrest info --stanza=main --repo=1 --output=json` every hour (WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS, default 3600). When local state claims a full backup was taken but the catalog is empty, `last_full_at` is cleared so `NEEDS_INITIAL_BACKUP` fires on the next poll.

- Catches divergence where `pgbackrest backup` returned exit 0 but catalog metadata was never committed (S3 partial write, stanza-create race at failover promotion)
- Catches stale state from a volume surviving a redeployment where the new cluster has a different sysid/stanza path
- Non-zero pgbackrest exit (S3 unreachable, stanza missing, timeout) is treated as inconclusive — local state is not cleared — so transient failures don't burn extra full backups