### PR TITLE
Rebuild postgres-ssl images when main changes

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,13 @@ on:
   schedule:
     - cron: "0 0 * * 1"  # Every Monday at midnight UTC
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "Dockerfile.*"
+      - "*.sh"
+      - ".github/workflows/build-and-push.yml"
 
 env:
   LATEST_POSTGRES_MAJOR: 16  # Change this to update which version gets tagged as 'latest'


### PR DESCRIPTION
## Summary
- Rebuild and push postgres-ssl images on pushes to `main` that change Dockerfiles, shell entrypoints, or the workflow itself.
- This prevents code/image drift where PITR support exists in the repo but mutable version tags (e.g. `16.10`) still point at an older image without pgBackRest/watcher support until the next weekly/manual build.

## Context
Timo's service is running `ghcr.io/railwayapp-templates/postgres-ssl:16.10` at a digest whose `/usr/local/bin/wrapper.sh` has no pgBackRest/PITR code at all. The service snapshot has `WAL_ARCHIVE_*` vars, but the image cannot act on them. That explains `archived_count=0`, `failed_count=0`, objectCount=0, and no pgBackRest startup logs.

## Validation
- Inspected the published `16.10` image locally: wrapper contains no `WAL_ARCHIVE_BUCKET` / pgBackRest code.
- Compared with current repo: Dockerfile.16 copies pgBackRest scripts and current wrapper has PITR handling.