### PR TITLE
feat(pitr): bulletproof gap-recovery — state machine + supervisor

### DIFF
--- a/Dockerfile.13
+++ b/Dockerfile.13
@@ -4,7 +4,7 @@ FROM postgres:${POSTGRES_VERSION}
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
-RUN apt-get update && apt-get install -y openssl sudo ca-certificates pgbackrest postgresql-13-pgvector \
+RUN apt-get update && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-13-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.14
+++ b/Dockerfile.14
@@ -4,7 +4,7 @@ FROM postgres:${POSTGRES_VERSION}
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
-RUN apt-get update && apt-get install -y openssl sudo ca-certificates pgbackrest postgresql-14-pgvector \
+RUN apt-get update && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-14-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.15
+++ b/Dockerfile.15
@@ -4,7 +4,7 @@ FROM postgres:${POSTGRES_VERSION}
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
-RUN apt-get update && apt-get install -y openssl sudo ca-certificates pgbackrest postgresql-15-pgvector \
+RUN apt-get update && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-15-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.16
+++ b/Dockerfile.16
@@ -4,7 +4,7 @@ FROM postgres:${POSTGRES_VERSION}
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
-RUN apt-get update && apt-get install -y openssl sudo ca-certificates pgbackrest postgresql-16-pgvector \
+RUN apt-get update && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-16-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.17
+++ b/Dockerfile.17
@@ -4,7 +4,7 @@ FROM postgres:${POSTGRES_VERSION}
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
-RUN apt-get update && apt-get install -y openssl sudo ca-certificates pgbackrest postgresql-17-pgvector \
+RUN apt-get update && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-17-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.18
+++ b/Dockerfile.18
@@ -4,7 +4,7 @@ FROM postgres:${POSTGRES_VERSION}
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
-RUN apt-get update && apt-get install -y openssl sudo ca-certificates pgbackrest postgresql-18-pgvector \
+RUN apt-get update && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-18-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -9,14 +9,28 @@
 #      v1's "immediate snapshot on enable" race: pgbackrest backup brackets
 #      the base in pg_backup_start/stop so the LSN window of the base and
 #      the WAL covering it are the same thing — no coordination gap.
-#   2. Gap recovery — archive-push had hard failures since the last full
-#      (any of: pgbackrest-archive-push-wrapper.sh dropped a segment and
-#      touched .pgbackrest_gap_pending, pg_stat_archiver.failed_count grew
-#      since the last full's checkpoint, or the LSN-lag probe found
-#      pg_stat_archiver.last_archived_wal more than
-#      WAL_LAG_GAP_THRESHOLD_SEGMENTS ahead of the S3 catalog's high-water).
-#      Once failures are decisively over, runs a fresh full so PITR window
-#      resumes from this base forward.
+#   2. Gap recovery — a state machine that fires whenever WAL coverage is
+#      diverging from the S3 catalog, regardless of cause. Entry conditions
+#      (any of):
+#        - pgbackrest-archive-push-wrapper.sh dropped a segment and touched
+#          .pgbackrest_gap_pending (bucket gone, hard archive-push failure)
+#        - LSN-lag probe found pg_stat_archiver.last_archived_wal more than
+#          WAL_LAG_GAP_THRESHOLD_SEGMENTS ahead of the catalog max (async
+#          worker silently wedged — queue-max-trip or hung connection)
+#      Recovery flow once in the state:
+#        - Wait GAP_RECOVERY_BACKOFF_SECONDS (default 10 min) for natural
+#          async recovery. Most short Tigris/S3 hiccups self-heal here.
+#        - Still no catalog progress → pkill the async daemon. Foreground
+#          archive-push respawns it on the next WAL switch. Cycle repeats
+#          every GAP_RECOVERY_BACKOFF_SECONDS until catalog advances OR
+#          the postgres process exits.
+#        - Catalog max > catalog max at detection (proof async pushed to S3
+#          successfully) → take a diff backup to re-anchor latestRestorableAt,
+#          then clear the gap marker.
+#      Diff (not full) is enough because the customer-visible state is
+#      "latestRestorableAt is fresh", which a diff produces in seconds.
+#      Historical missing segments stay missing in the old chain; retention
+#      eventually rolls them off.
 #   3. Periodic — full every WAL_BACKUP_FULL_INTERVAL_HOURS, diff every
 #      WAL_BACKUP_DIFF_INTERVAL_HOURS.
 #
@@ -48,14 +62,15 @@
 # accepting WAL (foreground returns 0) while the S3 catalog stays frozen.
 # archive-push-queue-max eventually drops segments and ALSO returns 0 to
 # Postgres — so pg_stat_archiver.failed_count never increments and the
-# archive-push wrapper never sees a non-zero exit. Both other gap signals
-# (failed_count growth, wrapper-touched marker) miss this entirely. The
-# LSN-lag probe re-uses the same comparison the admin monitor performs on
-# the backboard side: `pgbackrest info`'s archive max segment per timeline
-# against pg_stat_archiver.last_archived_wal. Threshold matches the
-# monitor's WAL_ARCHIVE_LAG_CRIT_SEGMENTS (64 segments ≈ 1 GiB) so the
-# in-image self-heal fires at the same point the dashboard surfaces the
-# warning.
+# archive-push wrapper never sees a non-zero exit.
+#
+# Detection: every iteration, compare pg_stat_archiver.last_archived_wal
+# against the catalog max from `pgbackrest info --output=json` (parsed with
+# jq for robustness — earlier grep+sort+sed extraction had a silent catch-all
+# that collapsed unparseable output into "lag=0", missing real wedges). When
+# lag ≥ WAL_LAG_GAP_THRESHOLD_SEGMENTS (default 32 ≈ 512 MiB) the watcher
+# enters the gap-recovery state machine — see the "Gap recovery" entry in
+# the file header for the full flow.
 
 set -u
 
@@ -63,8 +78,8 @@ PGDATA="${PGDATA:-/var/lib/postgresql/data}"
 STATE_FILE="$PGDATA/.pgbackrest_backup_state"
 GAP_MARKER="$PGDATA/.pgbackrest_gap_pending"
 
-# POLL_INTERVAL_SECONDS / GAP_RESOLVED_GRACE_SECONDS are env-overridable so
-# the e2e harness can exercise gap-recovery in <1 min instead of 5+. The
+# POLL_INTERVAL_SECONDS / GAP_RECOVERY_BACKOFF_SECONDS are env-overridable so
+# the e2e harness can exercise gap-recovery in <1 min instead of 10+. The
 # defaults are conservative; nothing user-facing advertises these knobs.
 POLL_INTERVAL_SECONDS="${WAL_BACKUP_POLL_INTERVAL_SECONDS:-60}"
 
@@ -73,10 +88,11 @@ POLL_INTERVAL_SECONDS="${WAL_BACKUP_POLL_INTERVAL_SECONDS:-60}"
 # bind) doesn't cost a full minute per retry. After that, normal cadence.
 INITIAL_POLL_SECONDS="${WAL_BACKUP_INITIAL_POLL_SECONDS:-5}"
 
-# Failures must have been quiescent for this long before a gap-recovery backup
-# fires. Hard failures often resolve and re-fail (intermittent S3, half-rotated
-# creds); without the grace the watcher burns one full per flap.
-GAP_RESOLVED_GRACE_SECONDS="${WAL_BACKUP_GAP_RESOLVED_GRACE_SECONDS:-300}"
+# Cooldown between gap-recovery actions. After initial detection, the state
+# machine waits this long for natural async recovery before kicking the async
+# daemon. Each subsequent pkill cycle also waits this long before the next
+# pkill. Catalog advance breaks out of the wait immediately.
+GAP_RECOVERY_BACKOFF_SECONDS="${WAL_BACKUP_GAP_RECOVERY_BACKOFF_SECONDS:-600}"
 
 FULL_INTERVAL_HOURS="${WAL_BACKUP_FULL_INTERVAL_HOURS:-168}"
 DIFF_INTERVAL_HOURS="${WAL_BACKUP_DIFF_INTERVAL_HOURS:-24}"
@@ -89,14 +105,14 @@ DIFF_INTERVAL_HOURS="${WAL_BACKUP_DIFF_INTERVAL_HOURS:-24}"
 # fresh state). Default: 3600 (1 hour).
 CATALOG_VERIFY_INTERVAL_SECONDS="${WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS:-3600}"
 
-# LSN-lag detection — see file header. Threshold matches the admin monitor's
-# WAL_ARCHIVE_LAG_CRIT_SEGMENTS. Probe cadence is the dominant cost (one
-# `pgbackrest info` S3 round-trip per probe; ~50-200ms typical), so don't run
-# it every iteration. Default 300s (5min) gives ~5 min worst-case detection
-# latency, fast enough that the gap-recovery grace then the resulting full
-# happen well within an hour of the underlying break.
-WAL_LAG_GAP_THRESHOLD_SEGMENTS="${WAL_LAG_GAP_THRESHOLD_SEGMENTS:-64}"
-WAL_LAG_PROBE_INTERVAL_SECONDS="${WAL_LAG_PROBE_INTERVAL_SECONDS:-300}"
+# LSN-lag detection — see file header. Detection runs every iteration (no
+# probe throttle): `pgbackrest info` is local-to-S3 round-trip, ~50-200ms,
+# cheap enough to call every minute. 32 segments ≈ 512 MiB — far enough above
+# the steady-state hand-off-vs-upload skew to avoid false positives, far
+# enough below archive-push-queue-max (default 5 GiB / 320 segments) to leave
+# headroom for the recovery state machine to act before the queue actually
+# trips and drops segments.
+WAL_LAG_GAP_THRESHOLD_SEGMENTS="${WAL_LAG_GAP_THRESHOLD_SEGMENTS:-32}"
 
 # Resolved cadence in seconds. WAL_BACKUP_FULL_INTERVAL_SECONDS overrides
 # the hours setting — bash arithmetic precludes fractional hours, so the
@@ -116,7 +132,11 @@ log() { echo "pgbackrest-watcher: $*"; }
 #   last_diff_at=<epoch>             — last successful diff/incr backup
 #   last_full_failed_count=<int>     — pg_stat_archiver.failed_count after last full
 #   last_catalog_verify_at=<epoch>   — last S3 catalog probe (catalog_check_backup)
-#   last_lag_detected_at=<epoch>     — when LSN-lag first crossed threshold this cycle
+#   last_lag_detected_at=<epoch>     — when current gap-recovery cycle started
+#   catalog_max_at_detection=<wal>   — catalog max segment at detection (recovery
+#                                       proof is "current catalog_max > this")
+#   last_force_recovery_at=<epoch>   — last time we pkill'd the async daemon
+#   force_attempts=<int>             — pkill cycles this gap-recovery cycle
 read_state() {
   local field="$1"
   [ ! -f "$STATE_FILE" ] && return 0
@@ -173,24 +193,6 @@ is_standby() {
   [ "$r" = "t" ]
 }
 
-# Returns 0 if archive failures look decisively over. Considers both the
-# pg_stat_archiver.last_failed_time epoch AND the LSN-lag detection epoch
-# (last_lag_detected_at). Either signal still within grace blocks recovery;
-# both signals quiescent (or never tripped) clears for a fresh full.
-gap_recovered() {
-  local now="$1" last_fail="$2"
-  local last_lag
-  last_lag=$(read_state last_lag_detected_at)
-  : "${last_lag:=0}"
-  if [ "$last_fail" -gt 0 ] && [ $((now - last_fail)) -lt "$GAP_RESOLVED_GRACE_SECONDS" ]; then
-    return 1
-  fi
-  if [ "$last_lag" -gt 0 ] && [ $((now - last_lag)) -lt "$GAP_RESOLVED_GRACE_SECONDS" ]; then
-    return 1
-  fi
-  return 0
-}
-
 run_backup() {
   local type="$1"
   log "running pgbackrest backup --type=$type"
@@ -225,12 +227,7 @@ run_backup() {
       # next iteration would see growth and re-trigger immediately.
       refresh_archiver_stats || true
       write_state_field last_full_failed_count "$FAILED_COUNT"
-      # last_lag_detected_at is gap-recovery state same as last_failed_count;
-      # clearing alongside the gap marker keeps gap_recovered's next-round
-      # grace window honest. Without this, a fresh detection right after a
-      # successful full would still see the stale epoch.
-      write_state_field last_lag_detected_at 0
-      [ -f "$GAP_MARKER" ] && rm -f "$GAP_MARKER" && log "cleared gap marker"
+      clear_gap_recovery_state "cleared by full backup"
       ;;
     diff|incr)
       write_state_field last_diff_at "$now"
@@ -256,12 +253,11 @@ catalog_check_backup() {
   return 1
 }
 
-# LSN-lag probe state. LAST_LAG_PROBE_AT throttles probe_archive_lag to
-# WAL_LAG_PROBE_INTERVAL_SECONDS; LAST_OBSERVED_LAG_SEGMENTS surfaces the
-# most recent observation for the watcher_iteration diagnostic log.
-LAST_LAG_PROBE_AT=0
+# LAST_OBSERVED_LAG_SEGMENTS / LAST_LAG_REPO_MAX surface the most recent
+# observation to watcher_iteration's diagnostic log line.
 LAST_OBSERVED_LAG_SEGMENTS=0
 LAST_LAG_REPO_MAX=""
+GAP_STATE_DIAG="clear"
 
 # 24-char hex WAL filename → absolute segment count (256 segments per log
 # file under the default 16 MiB wal_segment_size). Echoes empty on malformed
@@ -280,77 +276,169 @@ segment_to_number() {
   echo $((log * 256 + seg))
 }
 
-# Run `pgbackrest info` and extract the highest archived WAL segment on the
-# same timeline as LAST_ARCHIVED_WAL, then compute lag against
-# pg_stat_archiver's handoff high-water. Updates LAST_OBSERVED_LAG_SEGMENTS
-# and LAST_LAG_REPO_MAX. Returns 0 on a successful probe (even when lag is
-# 0); returns 1 on transient failure so callers leave prior state in place
-# rather than acting on noise.
-#
-# The JSON is text-parsed because jq isn't in the base image and `pgbackrest
-# info`'s archive section has a stable schema: each archive entry has a
-# "max":"<24-hex>" key per timeline. Filtering by the leading 8 hex chars
-# (timeline ID) picks the right entry without a full parser.
-probe_archive_lag() {
-  [ -z "$LAST_ARCHIVED_WAL" ] && { LAST_OBSERVED_LAG_SEGMENTS=0; return 0; }
-  local handed_off_n; handed_off_n=$(segment_to_number "$LAST_ARCHIVED_WAL")
-  [ -z "$handed_off_n" ] && return 1
-
+# Echoes the highest archived WAL segment on the same timeline as
+# LAST_ARCHIVED_WAL ("" if the catalog has no max for that timeline yet).
+# Returns 0 on a successful probe (including empty-result), 1 on transient
+# failure (pgbackrest info errored, JSON unparseable). The previous version
+# silently collapsed unparseable output into "lag=0" — that's the bug that
+# masked Nexa/Postgres-2xa1 and ERP-3.0 at 250+ segments lag while the
+# watcher reported lag=0. jq either parses or fails loudly; no quiet zero.
+probe_catalog_max() {
+  [ -z "$LAST_ARCHIVED_WAL" ] && { echo ""; return 0; }
   local info_out
   info_out=$(timeout 30 pgbackrest --stanza=main --repo=1 info --output=json 2>/dev/null) || return 1
   [ -z "$info_out" ] && return 1
 
   local tl="${LAST_ARCHIVED_WAL:0:8}"
   local repo_max
-  repo_max=$(printf '%s' "$info_out" \
-    | grep -oE "\"max\":\"${tl}[0-9A-Fa-f]{16}\"" \
-    | sort -u | tail -1 \
-    | sed -E 's/.*"([0-9A-Fa-f]{24})".*/\1/')
-  if [ -z "$repo_max" ]; then
-    # Same timeline not in catalog yet (fresh stanza, no archived WAL).
-    # Treat as zero lag — NEEDS_INITIAL_BACKUP / stanza-create paths cover
-    # the empty-catalog cases without our help.
-    LAST_OBSERVED_LAG_SEGMENTS=0
-    LAST_LAG_REPO_MAX=""
-    return 0
-  fi
+  repo_max=$(printf '%s' "$info_out" | jq -r --arg tl "$tl" '
+    [ .[]?.archive[]?.max // empty
+      | select(type == "string")
+      | select(length == 24)
+      | select(startswith($tl))
+    ] | max // ""
+  ' 2>/dev/null)
+  local jq_rc=$?
+  [ "$jq_rc" -ne 0 ] && return 1
 
-  local repo_max_n; repo_max_n=$(segment_to_number "$repo_max")
-  [ -z "$repo_max_n" ] && return 1
-  local lag=$((handed_off_n - repo_max_n))
-  [ "$lag" -lt 0 ] && lag=0
-  LAST_OBSERVED_LAG_SEGMENTS="$lag"
-  LAST_LAG_REPO_MAX="$repo_max"
+  echo "$repo_max"
   return 0
 }
 
-# Throttled wrapper around probe_archive_lag that writes the gap marker +
-# last_lag_detected_at state field when observed lag crosses the threshold.
-# Idempotent: re-detecting an already-marked gap only refreshes the log
-# breadcrumb, never re-stamps last_lag_detected_at (that would make
-# gap_recovered's grace check sticky and prevent the gap from ever clearing).
-check_lsn_lag_and_mark_gap() {
+# Clears all gap-recovery state (marker file + state fields). Called after a
+# successful diff (recovery confirmed) or full (re-anchors the baseline).
+clear_gap_recovery_state() {
+  local reason="${1:-cleared}"
+  write_state_field last_lag_detected_at 0
+  write_state_field catalog_max_at_detection ""
+  write_state_field last_force_recovery_at 0
+  write_state_field force_attempts 0
+  if [ -f "$GAP_MARKER" ]; then
+    rm -f "$GAP_MARKER"
+    log "gap-recovery: ${reason}"
+  fi
+}
+
+# Kicks the async daemon. Foreground archive-push respawns it on the next
+# WAL switch (heartbeat + archive_timeout=60 guarantees one within ~60s).
+# Crashed-daemon case: pkill is a no-op, respawn happens regardless.
+# Hung-daemon case: pkill removes the stuck process so respawn can succeed.
+# Spool is safe to disrupt — pgBackRest re-uploads from pg_wal on respawn.
+kick_async_daemon() {
+  pkill -f 'pgbackrest .* archive-push .* --archive-async' 2>/dev/null || true
+}
+
+# Recovery state machine. Replaces the old "wait for grace then take a full"
+# path with: detect → wait 10 min → pkill → wait 10 min → pkill → … →
+# (catalog advances) → take diff → clear. Repeats pkill every backoff window
+# during an extended upstream outage; the diff fires the instant the catalog
+# actually advances past the detection point, which is the only conclusive
+# proof async has resumed pushing to S3.
+#
+# Called every iteration. Idempotent: re-entering the function while already
+# in recovery just advances the timers / inspects current catalog max.
+#
+# Returns 0 always — the caller's decide_action checks the gap marker to
+# avoid racing periodic-full/diff on top of an in-flight recovery.
+gap_recovery_step() {
   local now; now=$(date +%s)
-  if [ $((now - LAST_LAG_PROBE_AT)) -lt "$WAL_LAG_PROBE_INTERVAL_SECONDS" ]; then
+
+  local catalog_max
+  catalog_max=$(probe_catalog_max)
+  local probe_rc=$?
+  if [ "$probe_rc" -ne 0 ]; then
+    GAP_STATE_DIAG="probe-failed"
+    log "gap-recovery: pgbackrest info probe failed; leaving state unchanged"
     return 0
   fi
-  LAST_LAG_PROBE_AT="$now"
+  LAST_LAG_REPO_MAX="$catalog_max"
 
-  if ! probe_archive_lag; then
-    log "lag probe inconclusive (pgbackrest info failed or malformed); leaving prior state"
+  # Lag (postgres handoff minus catalog max). 0 if either side missing.
+  local lag=0
+  if [ -n "$LAST_ARCHIVED_WAL" ] && [ -n "$catalog_max" ]; then
+    local h_n c_n
+    h_n=$(segment_to_number "$LAST_ARCHIVED_WAL")
+    c_n=$(segment_to_number "$catalog_max")
+    if [ -n "$h_n" ] && [ -n "$c_n" ]; then
+      lag=$((h_n - c_n))
+      [ "$lag" -lt 0 ] && lag=0
+    fi
+  fi
+  LAST_OBSERVED_LAG_SEGMENTS="$lag"
+
+  # In recovery? Marker is the truth — either we set it on a previous lag
+  # detection or the archive-push wrapper touched it on a hard failure.
+  if [ -f "$GAP_MARKER" ]; then
+    local detected_at catalog_at_detection last_force force_attempts
+    detected_at=$(read_state last_lag_detected_at); : "${detected_at:=0}"
+    catalog_at_detection=$(read_state catalog_max_at_detection); : "${catalog_at_detection:=}"
+    last_force=$(read_state last_force_recovery_at); : "${last_force:=0}"
+    force_attempts=$(read_state force_attempts); : "${force_attempts:=0}"
+
+    # Back-fill state when the wrapper touched the marker but the watcher
+    # hasn't entered the state machine yet. Treat now as detection time and
+    # the current catalog max as the baseline to beat.
+    if [ "$detected_at" -eq 0 ]; then
+      detected_at="$now"
+      write_state_field last_lag_detected_at "$now"
+    fi
+    if [ -z "$catalog_at_detection" ]; then
+      catalog_at_detection="$catalog_max"
+      write_state_field catalog_max_at_detection "$catalog_at_detection"
+    fi
+
+    # Recovery proof: catalog advanced past where it was when we entered
+    # the state machine. This means the async daemon successfully pushed
+    # at least one segment to S3 — async is working again.
+    if [ -n "$catalog_max" ] && [ -n "$catalog_at_detection" ] && [ "$catalog_max" != "$catalog_at_detection" ]; then
+      local c_n_curr c_n_det
+      c_n_curr=$(segment_to_number "$catalog_max")
+      c_n_det=$(segment_to_number "$catalog_at_detection")
+      if [ -n "$c_n_curr" ] && [ -n "$c_n_det" ] && [ "$c_n_curr" -gt "$c_n_det" ]; then
+        GAP_STATE_DIAG="recovering"
+        log "gap-recovery: catalog advanced (${catalog_at_detection} → ${catalog_max}, ${force_attempts} pkill cycles) — taking diff to anchor restore point"
+        if run_backup diff; then
+          clear_gap_recovery_state "cleared by gap-recovery diff"
+          GAP_STATE_DIAG="clear"
+        else
+          log "gap-recovery: diff failed; retry on next iteration"
+        fi
+        return 0
+      fi
+    fi
+
+    # No catalog advance yet. Check if it's time to kick (or kick again).
+    local last_action_at="$detected_at"
+    [ "$last_force" -gt "$last_action_at" ] && last_action_at="$last_force"
+    local since_action=$((now - last_action_at))
+
+    if [ "$since_action" -ge "$GAP_RECOVERY_BACKOFF_SECONDS" ]; then
+      force_attempts=$((force_attempts + 1))
+      local stuck_min=$(( (now - detected_at) / 60 ))
+      log "gap-recovery: catalog frozen at ${catalog_at_detection} for ${stuck_min}min (handoff=${LAST_ARCHIVED_WAL}, lag=${lag}) — pkill async (attempt #${force_attempts})"
+      kick_async_daemon
+      write_state_field last_force_recovery_at "$now"
+      write_state_field force_attempts "$force_attempts"
+      GAP_STATE_DIAG="forced"
+    else
+      local wait_remaining=$(( GAP_RECOVERY_BACKOFF_SECONDS - since_action ))
+      GAP_STATE_DIAG="waiting"
+      log "gap-recovery: catalog still at ${catalog_at_detection} (lag=${lag}, attempts=${force_attempts}, ${wait_remaining}s until next pkill)"
+    fi
     return 0
   fi
 
-  if [ "$LAST_OBSERVED_LAG_SEGMENTS" -lt "$WAL_LAG_GAP_THRESHOLD_SEGMENTS" ]; then
-    return 0
-  fi
-
-  if [ ! -f "$GAP_MARKER" ]; then
+  # Not in recovery. New detection?
+  if [ "$lag" -ge "$WAL_LAG_GAP_THRESHOLD_SEGMENTS" ]; then
     touch "$GAP_MARKER"
     write_state_field last_lag_detected_at "$now"
-    log "LSN-lag gap detected (handoff=${LAST_ARCHIVED_WAL}, repo_max=${LAST_LAG_REPO_MAX:-?}, lag=${LAST_OBSERVED_LAG_SEGMENTS} segments ≥ threshold ${WAL_LAG_GAP_THRESHOLD_SEGMENTS}) — marking gap_pending"
+    write_state_field catalog_max_at_detection "$catalog_max"
+    write_state_field last_force_recovery_at 0
+    write_state_field force_attempts 0
+    GAP_STATE_DIAG="detected"
+    log "gap-recovery: lag=${lag} segments ≥ threshold ${WAL_LAG_GAP_THRESHOLD_SEGMENTS} (handoff=${LAST_ARCHIVED_WAL}, catalog_max=${catalog_max}) — entering recovery; first pkill in ${GAP_RECOVERY_BACKOFF_SECONDS}s if catalog hasn't advanced"
   else
-    log "LSN-lag persists (handoff=${LAST_ARCHIVED_WAL}, repo_max=${LAST_LAG_REPO_MAX:-?}, lag=${LAST_OBSERVED_LAG_SEGMENTS} segments)"
+    GAP_STATE_DIAG="clear"
   fi
 }
 
@@ -411,20 +499,13 @@ decide_action() {
     fi
   fi
 
-  # Gap recovery — drop marker (touched by archive-push wrapper on hard
-  # failure OR by check_lsn_lag_and_mark_gap when async-side queue-max-trip
-  # is inferred from LSN lag) OR failed_count grew since last full. Any of
-  # the three indicates archive-push had problems since the last
-  # LSN-coordinated baseline, so a fresh full re-anchors the PITR window.
-  local has_gap=0
-  [ -f "$GAP_MARKER" ] && has_gap=1
-  [ "$FAILED_COUNT" -gt "$last_full_failed" ] && has_gap=1
-
-  if [ "$has_gap" -eq 1 ]; then
-    if gap_recovered "$now" "$LAST_FAILED_EPOCH"; then
-      DECIDED_ACTION="full"; return 0
-    fi
-    return 0  # gap still open, waiting for grace
+  # Gap-recovery state machine owns the .pgbackrest_gap_pending marker. While
+  # the marker is present, decide_action stays silent — gap_recovery_step
+  # already ran this iteration and either took a diff, kicked the async
+  # daemon, or is waiting on the backoff. Racing a periodic full on top of
+  # an in-flight recovery would burn a full at the worst time (mid-outage).
+  if [ -f "$GAP_MARKER" ]; then
+    return 0
   fi
 
   # Periodic full. FULL_INTERVAL_SECONDS=0 disables the periodic full while
@@ -498,18 +579,17 @@ watcher_iteration() {
     return 0
   fi
 
-  # Detect silent async failure modes (queue-max-trip with no failed_count
-  # bump, stuck async worker holding the lock, …) by comparing the WAL
-  # segment Postgres handed off against the S3 catalog high-water. Throttled
-  # internally to WAL_LAG_PROBE_INTERVAL_SECONDS so we don't S3-round-trip
-  # every iteration.
-  check_lsn_lag_and_mark_gap
+  # Gap-recovery state machine — detects WAL/catalog divergence and drives
+  # the kick-and-diff sequence. Runs every iteration; pgbackrest info is
+  # cheap enough that throttling isn't worth the false-negative window the
+  # earlier throttled version introduced.
+  gap_recovery_step
 
   decide_action
   if [ -z "$DECIDED_ACTION" ]; then
     # Surface why decide_action stayed silent so post-mortems on "watcher
     # ran for N minutes and never took a backup" don't require guessing.
-    log "iteration: no action (last_full=${LAST_FULL_DIAG:-?}, archived=${ARCHIVED_COUNT:-?}, failed=${FAILED_COUNT:-?}, gap_marker=${GAP_MARKER_DIAG:-?}, last_full_failed=${LAST_FULL_FAILED_DIAG:-?}, lag=${LAST_OBSERVED_LAG_SEGMENTS:-?})"
+    log "iteration: no action (last_full=${LAST_FULL_DIAG:-?}, archived=${ARCHIVED_COUNT:-?}, failed=${FAILED_COUNT:-?}, gap_marker=${GAP_MARKER_DIAG:-?}, gap_state=${GAP_STATE_DIAG:-?}, last_full_failed=${LAST_FULL_FAILED_DIAG:-?}, lag=${LAST_OBSERVED_LAG_SEGMENTS:-?})"
     return 0
   fi
 
@@ -538,7 +618,7 @@ sync_repo_path_from_marker() {
 
 sync_repo_path_from_marker
 
-log "starting (poll=${POLL_INTERVAL_SECONDS}s, initial_poll=${INITIAL_POLL_SECONDS}s, full=${FULL_INTERVAL_SECONDS}s, diff=${DIFF_INTERVAL_SECONDS}s, gap_grace=${GAP_RESOLVED_GRACE_SECONDS}s, lag_probe=${WAL_LAG_PROBE_INTERVAL_SECONDS}s, lag_threshold=${WAL_LAG_GAP_THRESHOLD_SEGMENTS} segments, repo1-path=${PGBACKREST_REPO1_PATH:-unset})"
+log "starting (poll=${POLL_INTERVAL_SECONDS}s, initial_poll=${INITIAL_POLL_SECONDS}s, full=${FULL_INTERVAL_SECONDS}s, diff=${DIFF_INTERVAL_SECONDS}s, gap_backoff=${GAP_RECOVERY_BACKOFF_SECONDS}s, lag_threshold=${WAL_LAG_GAP_THRESHOLD_SEGMENTS} segments, repo1-path=${PGBACKREST_REPO1_PATH:-unset})"
 
 while true; do
   sync_repo_path_from_marker

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -634,9 +634,20 @@ sync_repo_path_from_marker
 
 log "starting (poll=${POLL_INTERVAL_SECONDS}s, initial_poll=${INITIAL_POLL_SECONDS}s, full=${FULL_INTERVAL_SECONDS}s, diff=${DIFF_INTERVAL_SECONDS}s, gap_backoff=${GAP_RECOVERY_BACKOFF_SECONDS}s, lag_threshold=${WAL_LAG_GAP_THRESHOLD_SEGMENTS} segments, repo1-path=${PGBACKREST_REPO1_PATH:-unset})"
 
+# Crash-isolate each iteration in a subshell so a future refactor accident
+# (set -u trip on an unbound var, an unexpected non-zero exit, a libpq
+# environment quirk, …) doesn't terminate the outer loop. The state file +
+# .pgbackrest_gap_pending live on disk and survive across iterations, so a
+# subshell that exits mid-recovery just resumes on the next tick. This is
+# the watcher's own supervisor — keeping it inside the script (rather than
+# in wrapper.sh) means we don't fork a new PID every iteration, which
+# avoids racing postgres's stale-postmaster.pid check on container
+# restarts.
 while true; do
-  sync_repo_path_from_marker
-  watcher_iteration
+  (
+    sync_repo_path_from_marker
+    watcher_iteration
+  ) || log "iteration subshell exited non-zero, continuing"
   if [ -z "$(read_state last_full_at)" ]; then
     sleep "$INITIAL_POLL_SECONDS"
   else

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -222,11 +222,9 @@ run_backup() {
     full)
       write_state_field last_full_at "$now"
       write_state_field last_diff_at "$now"
-      # Re-read failed_count *after* the backup so a failure during the
-      # backup itself is folded into the high-water mark; otherwise the
-      # next iteration would see growth and re-trigger immediately.
-      refresh_archiver_stats || true
-      write_state_field last_full_failed_count "$FAILED_COUNT"
+      # clear_gap_recovery_state refreshes pg_stat_archiver and writes
+      # last_full_failed_count itself — folds failures-during-backup into
+      # the anchor so the next iteration doesn't re-fire detection.
       clear_gap_recovery_state "cleared by full backup"
       ;;
     diff|incr)
@@ -307,8 +305,14 @@ probe_catalog_max() {
 
 # Clears all gap-recovery state (marker file + state fields). Called after a
 # successful diff (recovery confirmed) or full (re-anchors the baseline).
+# Re-reads pg_stat_archiver to fold any failed pushes during the backup we
+# just ran into the failed_count anchor — without this the next iteration
+# would see FAILED_COUNT > last_full_failed_count and immediately re-fire
+# detection.
 clear_gap_recovery_state() {
   local reason="${1:-cleared}"
+  refresh_archiver_stats || true
+  write_state_field last_full_failed_count "${FAILED_COUNT:-0}"
   write_state_field last_lag_detected_at 0
   write_state_field catalog_max_at_detection ""
   write_state_field last_force_recovery_at 0
@@ -428,15 +432,25 @@ gap_recovery_step() {
     return 0
   fi
 
-  # Not in recovery. New detection?
-  if [ "$lag" -ge "$WAL_LAG_GAP_THRESHOLD_SEGMENTS" ]; then
+  # Not in recovery. Two independent entry conditions, both meaning
+  # "WAL coverage is diverging from the catalog":
+  #   - LSN lag ≥ threshold (async wedge / queue-max-trip — postgres
+  #     keeps handing off, async doesn't drain to S3)
+  #   - failed_count grew since the last full's anchor (foreground hard
+  #     failure — archive_command returning non-zero so postgres never
+  #     hands off; lag stays at 0 but archiving is broken just the same)
+  local last_full_failed; last_full_failed=$(read_state last_full_failed_count); : "${last_full_failed:=0}"
+  local failed_grew=0
+  [ "${FAILED_COUNT:-0}" -gt "$last_full_failed" ] && failed_grew=1
+
+  if [ "$lag" -ge "$WAL_LAG_GAP_THRESHOLD_SEGMENTS" ] || [ "$failed_grew" -eq 1 ]; then
     touch "$GAP_MARKER"
     write_state_field last_lag_detected_at "$now"
     write_state_field catalog_max_at_detection "$catalog_max"
     write_state_field last_force_recovery_at 0
     write_state_field force_attempts 0
     GAP_STATE_DIAG="detected"
-    log "gap-recovery: lag=${lag} segments ≥ threshold ${WAL_LAG_GAP_THRESHOLD_SEGMENTS} (handoff=${LAST_ARCHIVED_WAL}, catalog_max=${catalog_max}) — entering recovery; first pkill in ${GAP_RECOVERY_BACKOFF_SECONDS}s if catalog hasn't advanced"
+    log "gap-recovery: entering recovery (lag=${lag}, failed_count=${FAILED_COUNT:-0} vs anchor ${last_full_failed}, handoff=${LAST_ARCHIVED_WAL}, catalog_max=${catalog_max}) — first pkill in ${GAP_RECOVERY_BACKOFF_SECONDS}s if catalog hasn't advanced"
   else
     GAP_STATE_DIAG="clear"
   fi

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -328,8 +328,18 @@ clear_gap_recovery_state() {
 # Crashed-daemon case: pkill is a no-op, respawn happens regardless.
 # Hung-daemon case: pkill removes the stuck process so respawn can succeed.
 # Spool is safe to disrupt — pgBackRest re-uploads from pg_wal on respawn.
+#
+# Target: the literal substring "archive-push:async" in the cmdline.
+# pgBackRest spawns the async daemon via cfgExecParam(cfgCmdArchivePush,
+# cfgCmdRoleAsync, ...) and cfgParseCommandRoleName (src/config/parse.c)
+# encodes the role with a colon — argv[1] of the spawned process becomes
+# "archive-push:async". The foreground caller (which runs as
+# archive_command and exits in ~300ms) has "archive-push" *without* a
+# colon, so the colon disambiguates: pkill matches the long-lived async
+# daemon but never the short-lived foreground invocation. Verify in a
+# running container with `pgrep -af archive-push:async`.
 kick_async_daemon() {
-  pkill -f 'pgbackrest .* archive-push .* --archive-async' 2>/dev/null || true
+  pkill -f 'archive-push:async' 2>/dev/null || true
 }
 
 # Recovery state machine. Replaces the old "wait for grace then take a full"
@@ -386,7 +396,13 @@ gap_recovery_step() {
       detected_at="$now"
       write_state_field last_lag_detected_at "$now"
     fi
-    if [ -z "$catalog_at_detection" ]; then
+    # Only write a real value; an empty catalog (fresh stanza, no archive
+    # entries on this timeline yet) leaves the field unset and the back-fill
+    # re-fires next iteration. Writing "" would set catalog_at_detection
+    # equal to the first non-empty catalog_max captured in a later
+    # iteration's back-fill, and we'd then never see a difference vs.
+    # current catalog_max — recovery couldn't fire.
+    if [ -z "$catalog_at_detection" ] && [ -n "$catalog_max" ]; then
       catalog_at_detection="$catalog_max"
       write_state_field catalog_max_at_detection "$catalog_at_detection"
     fi

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -441,9 +441,11 @@ gap_recovery_step() {
       write_state_field force_attempts "$force_attempts"
       GAP_STATE_DIAG="forced"
     else
-      local wait_remaining=$(( GAP_RECOVERY_BACKOFF_SECONDS - since_action ))
+      # No log line during the wait — the per-iteration "iteration: no
+      # action (... gap_state=waiting ...)" diagnostic at the end of
+      # watcher_iteration already surfaces enough state for operators
+      # without printing the same line 10× per backoff cycle.
       GAP_STATE_DIAG="waiting"
-      log "gap-recovery: catalog still at ${catalog_at_detection} (lag=${lag}, attempts=${force_attempts}, ${wait_remaining}s until next pkill)"
     fi
     return 0
   fi
@@ -656,9 +658,15 @@ log "starting (poll=${POLL_INTERVAL_SECONDS}s, initial_poll=${INITIAL_POLL_SECON
 # .pgbackrest_gap_pending live on disk and survive across iterations, so a
 # subshell that exits mid-recovery just resumes on the next tick. This is
 # the watcher's own supervisor — keeping it inside the script (rather than
-# in wrapper.sh) means we don't fork a new PID every iteration, which
-# avoids racing postgres's stale-postmaster.pid check on container
-# restarts.
+# in wrapper.sh) means the watcher's long-lived PID (the bash interpreter
+# running this loop) stays pinned; only the transient iteration subshell
+# churns through PIDs, and each subshell lives a few seconds. With the
+# old wrapper.sh-side `while true; do gosu watcher; done` supervisor, the
+# watcher's long-lived PID cycled through the same range where postgres
+# lands on container start, which raced postgres's stale-postmaster.pid
+# check (PID 45 from a phase-1 SIGKILL collided with a phase-2 watcher
+# respawn at the same number, postgres saw it as a live postmaster and
+# FATAL'd). Pinning the watcher main PID makes that race impossible.
 while true; do
   (
     sync_repo_path_from_marker

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1099,7 +1099,7 @@ t_disable_cleanup() {
 # triggered by .pgbackrest_gap_pending, periodic full + diff cadence,
 # empty-volume restore from S3, retention-driven expire, and the dual-repo
 # guard. Tests pass WAL_BACKUP_POLL_INTERVAL_SECONDS=5 and
-# WAL_BACKUP_GAP_RESOLVED_GRACE_SECONDS=10 so the watcher's decision loop
+# WAL_BACKUP_GAP_RECOVERY_BACKOFF_SECONDS=10 so the watcher's decision loop
 # turns over fast enough for second-scale assertions.
 #
 # Standby-branch coverage (HA replica exits early via pg_is_in_recovery) is
@@ -1133,7 +1133,7 @@ run_archiving_pg_fast_watcher() {
   local name="$1" vol="$2"; shift 2
   run_archiving_pg "$name" "$vol" \
     -e "WAL_BACKUP_POLL_INTERVAL_SECONDS=5" \
-    -e "WAL_BACKUP_GAP_RESOLVED_GRACE_SECONDS=10" \
+    -e "WAL_BACKUP_GAP_RECOVERY_BACKOFF_SECONDS=10" \
     "$@"
 }
 
@@ -1325,40 +1325,41 @@ t_watcher_gap_recovery_full() {
   docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null
   wait_for_watcher_backup "$name" full 60 || { ko t_watcher_gap_recovery_full "no initial full"; return; }
 
-  local before_count
-  before_count=$(docker logs "$name" 2>&1 | grep -c "backup --type=full completed" || true)
+  local before_diff_count
+  before_diff_count=$(docker logs "$name" 2>&1 | grep -c "backup --type=diff completed" || true)
 
-  # Drop the gap marker by hand (no real failures to keep the test fast). The
-  # watcher's gap_recovered() trivially-recovers when LAST_FAILED_EPOCH=0
-  # (pg_stat_archiver clean), so the marker alone is enough to fire the
-  # gap-recovery branch on the next poll.
+  # Drop the gap marker by hand (simulates a wrapper-touched failure where
+  # we want recovery without orchestrating a real archive-push outage).
+  # On the next iteration, gap_recovery_step sees the marker, back-fills
+  # state with current catalog max, and waits for the catalog to advance.
   docker exec -u postgres "$name" touch /var/lib/postgresql/data/.pgbackrest_gap_pending
 
-  # `cleared gap marker` is emitted right before `backup --type=full
-  # completed` in run_backup(). Wait on both signals inside the loop —
-  # checking them separately races against docker's stdout flush window
-  # (the two echoes can land in different `docker logs` snapshots even
-  # though the watcher emits them back-to-back in the same shell).
-  local deadline=$(($(date +%s) + 30)) hit=0
+  # Force WAL to keep flowing so archive-push runs and the catalog advances
+  # past the back-filled detection point. Once advance is observed, the
+  # state machine fires a diff backup to anchor a fresh restore point.
+  # Loop because a single switch may race the watcher's next iteration —
+  # the diff fires the iteration AFTER catalog advance is observed.
+  local deadline=$(($(date +%s) + 60)) hit=0
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    local logs now_count
+    docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null 2>&1
+    local logs now_diff_count
     logs=$(docker logs "$name" 2>&1)
-    now_count=$(echo "$logs" | grep -c "backup --type=full completed" || true)
-    if [ "$now_count" -gt "$before_count" ] \
-       && echo "$logs" | grep -q "cleared gap marker"; then
+    now_diff_count=$(echo "$logs" | grep -c "backup --type=diff completed" || true)
+    if [ "$now_diff_count" -gt "$before_diff_count" ] \
+       && echo "$logs" | grep -q "cleared by gap-recovery diff"; then
       hit=1; break
     fi
-    sleep 2
+    sleep 3
   done
   if [ "$hit" != "1" ]; then
-    ko t_watcher_gap_recovery_full "watcher did not take gap-recovery full or did not log 'cleared gap marker'"
+    ko t_watcher_gap_recovery_full "watcher did not take gap-recovery diff or did not log 'cleared by gap-recovery diff'"
     fail_dump t_watcher_gap_recovery_full "$name"
     return
   fi
 
-  # Marker should be cleared by run_backup() after the full lands.
+  # Marker should be cleared by clear_gap_recovery_state() after the diff.
   if docker exec "$name" test -f /var/lib/postgresql/data/.pgbackrest_gap_pending; then
-    ko t_watcher_gap_recovery_full ".pgbackrest_gap_pending was not cleared after gap-recovery full"
+    ko t_watcher_gap_recovery_full ".pgbackrest_gap_pending was not cleared after gap-recovery diff"
     return
   fi
 
@@ -1652,7 +1653,7 @@ t_watcher_gap_recovery_failed_count_path() {
     -e WAL_DROP_THRESHOLD_MB=999999 \
     -e POSTGRES_ARCHIVE_TIMEOUT=5 \
     -e WAL_BACKUP_POLL_INTERVAL_SECONDS=5 \
-    -e WAL_BACKUP_GAP_RESOLVED_GRACE_SECONDS=10 \
+    -e WAL_BACKUP_GAP_RECOVERY_BACKOFF_SECONDS=10 \
     -v "$vol:/var/lib/postgresql/data" \
     "$IMAGE" >/dev/null
   wait_for_pg "$name" || { ko t_watcher_gap_recovery_failed_count_path "no startup"; fail_dump t_watcher_gap_recovery_failed_count_path "$name"; return; }
@@ -1745,7 +1746,7 @@ t_watcher_gap_recovery_failed_count_path() {
 # repo catalog moving).
 #
 # The unique-to-LSN-lag fingerprint is `last_lag_detected_at` in the
-# watcher state file — only `check_lsn_lag_and_mark_gap` writes it. This
+# watcher state file — only `gap_recovery_step` writes it. This
 # test asserts the probe fired by checking that field, plus the absence
 # of wrapper-side drop log lines (which would mean the wrapper, not the
 # probe, wrote the marker).
@@ -1785,8 +1786,7 @@ t_watcher_gap_recovery_lsn_lag_path() {
     -e PGBACKREST_ARCHIVE_PUSH_QUEUE_MAX=128MiB \
     -e WAL_DROP_THRESHOLD_MB=999999 \
     -e WAL_BACKUP_POLL_INTERVAL_SECONDS=5 \
-    -e WAL_BACKUP_GAP_RESOLVED_GRACE_SECONDS=10 \
-    -e WAL_LAG_PROBE_INTERVAL_SECONDS=5 \
+    -e WAL_BACKUP_GAP_RECOVERY_BACKOFF_SECONDS=10 \
     -e WAL_LAG_GAP_THRESHOLD_SEGMENTS=4 \
     -v "$vol:/var/lib/postgresql/data" \
     "$IMAGE" >/dev/null
@@ -1799,11 +1799,12 @@ t_watcher_gap_recovery_lsn_lag_path() {
     docker exec "$name" psql -U postgres -c "INSERT INTO t SELECT g, repeat('x', 1000) FROM generate_series($((i*80000)), $(((i+1)*80000))) g; SELECT pg_switch_wal();" >/dev/null 2>&1
   done
 
-  # Wait for the probe to write the gap marker. WAL_LAG_PROBE_INTERVAL_SECONDS=5
-  # and POLL_INTERVAL_SECONDS=5 → detection within ~10-15s of the first drop.
-  # Poll on the marker FILE rather than a specific log line because docker
-  # log timing through high-volume pgbackrest output can race a one-shot
-  # "gap detected" line; the marker + state file are durable evidence.
+  # Wait for the probe to write the gap marker. Detection runs every
+  # iteration (POLL_INTERVAL_SECONDS=5) → marker should land within
+  # ~10-15s of the first drop. Poll on the marker FILE rather than a
+  # specific log line because docker log timing through high-volume
+  # pgbackrest output can race a one-shot "gap detected" line; the marker
+  # + state file are durable evidence.
   local deadline=$(($(date +%s) + 90)) hit=0
   while [ "$(date +%s)" -lt "$deadline" ]; do
     if docker exec "$name" test -f /var/lib/postgresql/data/.pgbackrest_gap_pending 2>/dev/null; then
@@ -1823,24 +1824,24 @@ t_watcher_gap_recovery_lsn_lag_path() {
   sleep 3
 
   # Assert: last_lag_detected_at recorded in the watcher state file. This
-  # is the durable fingerprint of the LSN-lag probe — only
-  # check_lsn_lag_and_mark_gap writes this field, so its presence proves
-  # the watcher's probe (not the wrapper, not the failed_count branch)
-  # wrote the gap marker. Tested via the state file rather than a log line
-  # because docker's json-file log driver under high-volume pgbackrest
-  # error output (each failed PUT is ~3-4 KiB of XML) intermittently fails
-  # to surface specific log lines to `docker logs | grep` in this CI's
-  # harness — the state file is robust to that timing.
+  # is the durable fingerprint of the LSN-lag detection branch — only
+  # gap_recovery_step writes this field on new detection (the
+  # wrapper-touched path back-fills it on the same iteration). Tested via
+  # the state file rather than a log line because docker's json-file log
+  # driver under high-volume pgbackrest error output (each failed PUT is
+  # ~3-4 KiB of XML) intermittently fails to surface specific log lines
+  # to `docker logs | grep` in this CI's harness — the state file is
+  # robust to that timing.
   local last_lag_at
   last_lag_at=$(docker exec "$name" grep -E "^last_lag_detected_at=" /var/lib/postgresql/data/.pgbackrest_backup_state 2>/dev/null | cut -d= -f2)
   if [ -z "$last_lag_at" ] || [ "$last_lag_at" = "0" ]; then
-    ko t_watcher_gap_recovery_lsn_lag_path "last_lag_detected_at not written to state (got '$last_lag_at') — LSN-lag probe did not fire"
+    ko t_watcher_gap_recovery_lsn_lag_path "last_lag_detected_at not written to state (got '$last_lag_at') — LSN-lag detection did not fire"
     fail_dump t_watcher_gap_recovery_lsn_lag_path "$name"
     return
   fi
 
   ok t_watcher_gap_recovery_lsn_lag_path
-  note "LSN-lag probe wrote marker + last_lag_detected_at=${last_lag_at}"
+  note "LSN-lag detection wrote marker + last_lag_detected_at=${last_lag_at}"
   docker rm -f "$name" >/dev/null
   docker volume rm "$vol" >/dev/null
 }

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1615,10 +1615,14 @@ count_archived_wal_segments() {
     | tail -1 | tr -d ' '
 }
 
-# G1. Real failure-driven gap recovery via pg_stat_archiver.failed_count
-# growth (with the .pgbackrest_gap_pending marker NEVER touched). Catches
-# the t_watcher_gap_recovery_full test's cheat: that test pokes the marker
-# directly. This one drives the watcher purely off failed_count.
+# G1. Failure-driven gap recovery via pg_stat_archiver.failed_count growth.
+# Exercises the failed_count entry condition of the gap-recovery state
+# machine — drives the watcher purely off failed_count rather than touching
+# the marker by hand. The state machine itself touches
+# .pgbackrest_gap_pending as a consequence of detection (that's the
+# "marker" used to remember we're in recovery across iterations), so this
+# test asserts the resulting gap-recovery diff lands and clears state,
+# not that the marker stays absent.
 t_watcher_gap_recovery_failed_count_path() {
   local name=t-gap-fc-${PG_VERSION}
   local vol=${name}-vol

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1665,8 +1665,8 @@ t_watcher_gap_recovery_failed_count_path() {
   docker exec "$name" psql -U postgres -c "CREATE TABLE t(id int); SELECT pg_switch_wal();" >/dev/null
   wait_for_watcher_backup "$name" full 60 || { ko t_watcher_gap_recovery_failed_count_path "no initial full"; fail_dump t_watcher_gap_recovery_failed_count_path "$name"; return; }
 
-  local before_count
-  before_count=$(docker logs "$name" 2>&1 | grep -c "backup --type=full completed" || true)
+  local before_diff_count
+  before_diff_count=$(docker logs "$name" 2>&1 | grep -c "backup --type=diff completed" || true)
 
   # Switch the user to read-only → PutObject fails with AccessDenied →
   # archive_command returns non-zero (wrapper threshold not met) → Postgres
@@ -1691,15 +1691,12 @@ t_watcher_gap_recovery_failed_count_path() {
     return
   fi
 
-  # Marker should NOT have been written — that's the whole point of this
-  # test (proves the failed_count branch fires independently of the marker).
-  if docker exec "$name" test -f /var/lib/postgresql/data/.pgbackrest_gap_pending; then
-    ko t_watcher_gap_recovery_failed_count_path ".pgbackrest_gap_pending was written; threshold should not have tripped"
-    return
-  fi
-
-  # Restore write access → archive-push succeeds again → grace window starts
-  # from last_failed_time. Wait grace + a few polls.
+  # Restore write access → archive-push succeeds again → catalog advances
+  # past detection point → state machine takes a diff to re-anchor the
+  # PITR window. (Marker may have been written by the failed_count entry
+  # condition — that's fine; it's the wrapper-threshold marker we're
+  # exercising in the OTHER test, this one exercises the failed_count
+  # entry condition into the same state machine.)
   mc "
     mc admin policy detach local readonly --user ${user} 2>/dev/null || true
     mc admin policy attach local readwrite --user ${user} 2>/dev/null || true
@@ -1707,19 +1704,21 @@ t_watcher_gap_recovery_failed_count_path() {
 
   local deadline=$(($(date +%s) + 60)) hit=0
   while [ "$(date +%s)" -lt "$deadline" ]; do
+    docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null 2>&1
     local now_count
-    now_count=$(docker logs "$name" 2>&1 | grep -c "backup --type=full completed" || true)
-    if [ "$now_count" -gt "$before_count" ]; then hit=1; break; fi
-    sleep 2
+    now_count=$(docker logs "$name" 2>&1 | grep -c "backup --type=diff completed" || true)
+    if [ "$now_count" -gt "$before_diff_count" ]; then hit=1; break; fi
+    sleep 3
   done
   if [ "$hit" != "1" ]; then
-    ko t_watcher_gap_recovery_failed_count_path "watcher did not take gap-recovery full via failed_count path"
+    ko t_watcher_gap_recovery_failed_count_path "watcher did not take gap-recovery diff via failed_count path"
     fail_dump t_watcher_gap_recovery_failed_count_path "$name"
     return
   fi
 
   # last_full_failed_count must have advanced past 0 — otherwise next
-  # iteration would re-trigger immediately.
+  # iteration would re-trigger immediately. clear_gap_recovery_state
+  # writes this field as part of post-diff cleanup.
   local last_failed_in_state
   last_failed_in_state=$(docker exec "$name" grep -E "^last_full_failed_count=" /var/lib/postgresql/data/.pgbackrest_backup_state 2>/dev/null | cut -d= -f2)
   if [ -z "$last_failed_in_state" ] || [ "$last_failed_in_state" = "0" ]; then
@@ -1728,7 +1727,7 @@ t_watcher_gap_recovery_failed_count_path() {
   fi
 
   ok t_watcher_gap_recovery_failed_count_path
-  note "failed_count=${failed_count} → grace → 2nd full; marker never written; last_full_failed_count=${last_failed_in_state}"
+  note "failed_count=${failed_count} → catalog advanced → gap-recovery diff; last_full_failed_count=${last_failed_in_state}"
   mc "mc admin user remove local ${user}" >/dev/null 2>&1 || true
   docker rm -f "$name" >/dev/null
   docker volume rm "$vol" >/dev/null

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -854,9 +854,26 @@ EOF
 # Unix socket and `pgbackrest backup` runs as the right uid. The watcher gates
 # itself on WAL_ARCHIVE_BUCKET / WAL_RECOVER_FROM_BUCKET internally, so the
 # fork is unconditional and cheap when archiving isn't on.
+#
+# Supervisor: a `while true` outer loop respawns the watcher if it ever
+# exits. The watcher loop is conservative (lots of `|| true` and
+# `${var:-default}` patterns) but isn't crash-proof — a bash interpretive
+# error, a hung psql getting SIGKILLed by something, or a future
+# refactor accident could exit the child silently. The state file +
+# .pgbackrest_gap_pending live on disk and survive respawns, so a fresh
+# watcher picks the in-flight recovery state up exactly where the old
+# one left off. 5s backoff is enough to avoid tight respawn loops if
+# the watcher exits immediately on startup (would mean a real bug, but
+# the cap keeps logs readable).
 fork_pgbackrest_backup_watcher() {
   [ -z "${WAL_ARCHIVE_BUCKET:-}" ] && return 0
-  gosu postgres /usr/local/bin/pgbackrest-backup-watcher.sh &
+  (
+    while true; do
+      gosu postgres /usr/local/bin/pgbackrest-backup-watcher.sh
+      echo "pgbackrest-watcher: exited; respawning in 5s" >&2
+      sleep 5
+    done
+  ) &
 }
 
 compute_volume_thresholds

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -858,12 +858,15 @@ EOF
 # Single watcher process — no external respawn wrapper. The watcher's own
 # main loop runs each iteration in a subshell so set -u / set -e style
 # aborts inside an iteration don't kill the outer loop. An external
-# `while true; do watcher; done` supervisor would cycle the watcher's PID
-# across iterations, which races the stale-postmaster.pid check in
-# postgres startup on container restarts (postgres reads "PID 45" from
-# the stale file, sends signal 0, and a recently-respawned watcher
-# subprocess happens to occupy that PID → postgres FATALs instead of
-# clearing the stale file).
+# `while true; do watcher; done` supervisor would cycle the watcher's
+# long-lived PID across respawns (each respawn = new gosu + new bash
+# interpreter), which races the stale-postmaster.pid check in postgres
+# startup on container restarts: postgres reads "PID 45" from the stale
+# file, sends signal 0, and a recently-respawned watcher main process
+# happens to occupy that PID → postgres FATALs instead of clearing the
+# stale file. With the watcher's own main loop holding a fixed PID, only
+# the transient iteration subshell churns (always short-lived,
+# never lands in postmaster.pid's range at container-start time).
 fork_pgbackrest_backup_watcher() {
   [ -z "${WAL_ARCHIVE_BUCKET:-}" ] && return 0
   gosu postgres /usr/local/bin/pgbackrest-backup-watcher.sh &

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -855,25 +855,18 @@ EOF
 # itself on WAL_ARCHIVE_BUCKET / WAL_RECOVER_FROM_BUCKET internally, so the
 # fork is unconditional and cheap when archiving isn't on.
 #
-# Supervisor: a `while true` outer loop respawns the watcher if it ever
-# exits. The watcher loop is conservative (lots of `|| true` and
-# `${var:-default}` patterns) but isn't crash-proof — a bash interpretive
-# error, a hung psql getting SIGKILLed by something, or a future
-# refactor accident could exit the child silently. The state file +
-# .pgbackrest_gap_pending live on disk and survive respawns, so a fresh
-# watcher picks the in-flight recovery state up exactly where the old
-# one left off. 5s backoff is enough to avoid tight respawn loops if
-# the watcher exits immediately on startup (would mean a real bug, but
-# the cap keeps logs readable).
+# Single watcher process — no external respawn wrapper. The watcher's own
+# main loop runs each iteration in a subshell so set -u / set -e style
+# aborts inside an iteration don't kill the outer loop. An external
+# `while true; do watcher; done` supervisor would cycle the watcher's PID
+# across iterations, which races the stale-postmaster.pid check in
+# postgres startup on container restarts (postgres reads "PID 45" from
+# the stale file, sends signal 0, and a recently-respawned watcher
+# subprocess happens to occupy that PID → postgres FATALs instead of
+# clearing the stale file).
 fork_pgbackrest_backup_watcher() {
   [ -z "${WAL_ARCHIVE_BUCKET:-}" ] && return 0
-  (
-    while true; do
-      gosu postgres /usr/local/bin/pgbackrest-backup-watcher.sh
-      echo "pgbackrest-watcher: exited; respawning in 5s" >&2
-      sleep 5
-    done
-  ) &
+  gosu postgres /usr/local/bin/pgbackrest-backup-watcher.sh &
 }
 
 compute_volume_thresholds


### PR DESCRIPTION
## Summary

Closes the recurring failure mode where pgBackRest async-push or foreground archive-push wedges leave the catalog frozen while postgres keeps trying. Three layers, all required to make this stop coming back:

1. **One state machine, owns all entry conditions** — replaces three separate detectors (wrapper-non-zero-exit, `failed_count` growth, throttled LSN-lag probe) and the wait-for-`gap_recovered`-then-full remediation
2. **Diff (not full) on recovery** — anchors `latestRestorableAt` in seconds the moment async resumes
3. **Crash-isolated watcher loop** — each iteration's body runs in a subshell so a `set -u`/`set -e` trip inside one iteration doesn't terminate the outer `while true`. Single watcher process, no PID cycling, no postgres-startup race.

### The state machine

Two independent entry conditions, same recovery flow:

```
enter recovery when:
  lag(handoff_wal, catalog_max) ≥ 32 segments       (async wedge / queue-max-trip)
  OR failed_count > last_full_failed_count          (foreground hard failure)
  OR .pgbackrest_gap_pending marker present         (wrapper hard-drop)

every iteration after entry:
  if catalog_max advanced past detection point:
    pgbackrest backup --type=diff
    clear all gap-recovery state (incl. last_full_failed_count refresh)
  elif ≥ GAP_RECOVERY_BACKOFF_SECONDS since last action (default 10min):
    pkill -f 'archive-push:async'
    record last_force_recovery_at, bump force_attempts
```

During an extended Tigris outage: detect → 10min → pkill #1 → 10min → pkill #2 → … → catalog advances → diff → cleared. No diff is ever attempted against an unreachable S3.

### Key changes

- `gap_recovery_step` replaces `check_lsn_lag_and_mark_gap` + `gap_recovered` + the `decide_action` gap branch
- `probe_catalog_max` uses **jq** (added to all Dockerfiles) — the previous grep+sort+sed had a silent catch-all that collapsed unparseable output into "lag=0", masking real wedges (the bug that left Nexa/Postgres-2xa1 and ERP-3.0 at 250+ segments of lag while watcher reported lag=0)
- No probe throttle — detection runs every iteration
- Threshold lowered from 64 → 32 segments
- `decide_action` no longer touches gap-recovery — returns silently while the marker is present so periodic-full can't race in mid-outage
- `clear_gap_recovery_state` refreshes `pg_stat_archiver` and rewrites `last_full_failed_count` so a gap-recovery diff anchors the failure counter (otherwise next iteration would re-fire detection immediately)
- `kick_async_daemon` targets `archive-push:async` — verified against pgBackRest source (`src/config/parse.c::cfgParseCommandRoleName` builds `<command>:<role>` with a colon; `src/command/archive/push/push.c:364` spawns the daemon via `cfgExecParam(cfgCmdArchivePush, cfgCmdRoleAsync, ...)`). The earlier regex `'pgbackrest .* archive-push .* --archive-async'` matched neither the daemon (colon, no space) nor the foreground caller (lives 300ms, no `--archive-async` in its own argv), so the kick was a no-op in production until code review caught it. Verify in a running container with `pgrep -af archive-push:async`.
- Empty-catalog back-fill tightened: when the wrapper touches the marker on a fresh stanza with no archive entries yet, we wait for `catalog_max` to be non-empty before recording it as the baseline. Avoids writing `catalog_max_at_detection=` (empty) into the state file.
- Crash-isolated main loop: each `watcher_iteration` runs in a `( … ) || log` subshell so a future refactor accident inside an iteration can't kill the supervisor. Watcher process stays single-PID (no `while true` wrapper in `wrapper.sh`) so postgres' stale-postmaster.pid check on container restarts doesn't race a cycling watcher PID.

### Test plan

- [x] `t_watcher_gap_recovery_full` exercises the diff-on-catalog-advance path
- [x] `t_watcher_gap_recovery_failed_count_path` updated to expect gap-recovery diff (was full), drives `pg_switch_wal` so catalog can advance
- [x] `t_watcher_gap_recovery_lsn_lag_path` keeps detection-side asserts; `WAL_LAG_PROBE_INTERVAL_SECONDS` knob removed
- [ ] CI on all PG versions (13-18) — jq added to all Dockerfiles
- [ ] Manual repro on the two services currently wedged (Nexa/Postgres-2xa1, ERP-3.0) — once this image deploys, they should detect → kick → diff within 10-20 minutes
- [ ] One follow-up worth doing in a separate PR: an e2e assertion that the `kick_async_daemon` pkill matches an actual `archive-push:async` process (would need a fixture that simulates a wedged daemon). For now, the in-source comment lists the `pgrep` verification command for ad-hoc validation.
