### PR TITLE
fix(ci): rebuild postgres images on main changes

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,13 @@ on:
   schedule:
     - cron: "0 0 * * 1"  # Every Monday at midnight UTC
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "Dockerfile.*"
+      - "*.sh"
+      - ".github/workflows/build-and-push.yml"
 
 env:
   LATEST_POSTGRES_MAJOR: 16  # Change this to update which version gets tagged as 'latest'


### PR DESCRIPTION
Adds a `push` trigger to `build-and-push.yml` so the Postgres images are rebuilt whenever `Dockerfile.*`, `*.sh`, or the workflow itself changes on `main` — not just on the weekly Monday cron.

Reopened from #83 after rebasing on latest main.