### PR TITLE
fix(pitr): pre-archive pg_wal + free-disk safety in wrapper

### DIFF
--- a/pgbackrest-archive-push-wrapper.sh
+++ b/pgbackrest-archive-push-wrapper.sh
@@ -1,56 +1,52 @@
 #!/bin/bash
 # pgbackrest-archive-push-wrapper.sh — invoked by Postgres as archive_command.
 #
-# Wraps `pgbackrest archive-push` so that any kind of archive failure (hard
-# repo error, stuck async worker, anything else) cannot fill pg_wal/ and halt
-# Postgres. When pgbackrest fails AND pg_wal/ has grown past a threshold
-# (WAL_DROP_THRESHOLD_MB; sized by wrapper.sh's compute_volume_thresholds to
-# min(500 MiB, ~10% of volume) with operator override via this env var), the
-# wrapper returns success to Postgres anyway. Postgres recycles the WAL
-# segment as if archiving were disabled. The PITR window gets a coverage
-# gap from this segment forward; below the threshold
-# pg_stat_archiver.failed_count climbs normally and the dashboard surfaces
-# "PITR broken — fix archiving config", so the underlying issue (bad creds,
-# deleted bucket, expired keys, …) gets fixed before the threshold trips
-# and the failure signal disappears.
+# Wraps `pgbackrest archive-push` to keep Postgres alive when archiving can't
+# keep up with WAL generation. Three drop paths, all touch the gap_marker so
+# pgbackrest-backup-watcher.sh takes a fresh diff once archiving recovers
+# (sealing forward-restore coverage; the dropped segments themselves are
+# unrestorable, by design):
 #
-# Special case: if the bucket actively does not exist (S3 NoSuchBucket error),
-# there is no recovery without operator action — retrying is pointless and
-# letting WAL accumulate up to the threshold wastes disk. In that case the
-# wrapper drops immediately (returns 0) regardless of pg_wal size.
+#   1. PRE-ARCHIVE size check — before calling pgbackrest, drop the incoming
+#      segment if pg_wal is already past WAL_DROP_THRESHOLD_MB. Bounds the
+#      backlog when archiving succeeds individually but the async-push rate
+#      lags WAL generation (the failure mode that crashed junior.mtdn.dev:
+#      ~28 GiB pg_wal accumulated while pg_stat_archiver.failed_count stayed
+#      at 0 and every archive_command returned 0; the reactive check below
+#      never fired until disk filled and Postgres was already crashing).
 #
-# The env var name avoids the PGBACKREST_* prefix on purpose: pgBackRest
-# treats every PGBACKREST_* variable as a config option and warns about
-# unknown names on every invocation. WAL_DROP_THRESHOLD_MB sits outside
-# that namespace so it doesn't pollute logs.
+#   2. PRE-ARCHIVE free-disk check — drop if the data volume has less free
+#      space than WAL_DROP_THRESHOLD_MB, regardless of what's filling it.
+#      Mirrors the pg_wal cap so both protect Postgres uptime symmetrically:
+#      the cap is both the max pg_wal we retain AND the minimum free disk we
+#      keep available for Postgres to operate.
 #
-# Why ≤500 MiB here, vs pgBackRest's archive-push-queue-max ≤5GiB:
-# the two thresholds gate orthogonal failure regimes. archive-push-queue-max
-# governs the SPOOL — graceful absorption of transient S3 stalls, where the
-# async worker keeps retrying and most segments eventually get pushed. A
-# generous buffer there absorbs hours of outage cleanly. This wrapper-side
-# threshold gates the HARD-FAILURE path: bad creds, deleted bucket, expired
-# keys — pgbackrest's foreground returns non-zero immediately and there's
-# no realistic chance the next retry succeeds without operator intervention.
-# Holding 5 GiB of pg_wal hostage waiting for a fix that requires a config
-# change wastes data-volume disk; 500 MiB is enough to ride out a multi-
-# minute config-redeploy window without eating into customer disk budgets.
-# Both ceilings scale down proportionally on small volumes (1 GiB Hobby ⇒
-# ~100 MiB pg_wal / ~512 MiB spool) so a tiny volume isn't dominated by
-# archive buffers; on ≥25 GiB volumes both caps hold.
+#   3. POST-FAILURE check — if pgbackrest exited non-zero AND pg_wal is past
+#      threshold, drop. Catches hard failures (bad creds, deleted bucket,
+#      expired keys) where the foreground returns non-zero immediately and
+#      retrying without operator intervention has zero chance of success.
+#      Below threshold, pgbackrest's non-zero exit surfaces to Postgres so
+#      pg_stat_archiver.failed_count climbs and the dashboard surfaces
+#      "PITR broken — fix archiving config" before the threshold trips and
+#      the failure signal disappears.
 #
-# Below the threshold the wrapper surfaces pgbackrest's failure to Postgres
-# normally, so transient errors retry on the next archive_timeout instead
-# of being silently dropped.
+# Special case: NoSuchBucket / InvalidAccessKeyId always drop immediately
+# regardless of pg_wal size — no recovery is possible without operator
+# action, so holding any pg_wal hostage just wastes disk.
 #
-# Cost of `du -sb $PGDATA/pg_wal` here: only fires when archive-push fails.
-# Under normal operation pgbackrest succeeds in async mode (segment written
-# to spool, returns in milliseconds) and the wrapper exits before du runs.
-# When pgbackrest IS failing, archive_command retries on every WAL switch
-# (default archive_timeout=60s) — and pg_wal has by definition stopped
-# being recycled, so it's a few dozen segments at most. A directory
-# traversal of a few dozen small files every minute is the cheapest
-# thing happening on this host while S3 is unreachable. Not worth caching.
+# Threshold sizing (WAL_DROP_THRESHOLD_MB; defaults set by wrapper.sh's
+# compute_volume_thresholds): ~10% of volume, capped at 5 GiB, floor 64 MiB.
+# Matches pgBackRest's archive-push-queue-max=5 GiB spool cap so pg_wal and
+# spool consume symmetric on-disk budgets under sustained outage. Operator
+# override via the WAL_DROP_THRESHOLD_MB env var; the PGBACKREST_* prefix is
+# deliberately avoided because pgBackRest warns on unknown PGBACKREST_*
+# names on every invocation.
+#
+# Cost of `du -sb $PGDATA/pg_wal` + `df $PGDATA`: runs on every archive_command
+# call (≤1/segment switch, typically 1/min on idle DBs, capped by Postgres's
+# archive_timeout=60). Stat-only traversal of a few hundred files plus a single
+# statfs is sub-50 ms on any sane volume — well under the per-call S3 PUT
+# latency of the archive itself.
 
 set -u
 
@@ -61,8 +57,35 @@ if [ -z "$WAL_FILE" ]; then
 fi
 
 PGDATA="${PGDATA:-/var/lib/postgresql/data}"
-PGWAL_THRESHOLD_MB="${WAL_DROP_THRESHOLD_MB:-500}"
+PGWAL_THRESHOLD_MB="${WAL_DROP_THRESHOLD_MB:-5120}"
 PGWAL_THRESHOLD_BYTES=$(( PGWAL_THRESHOLD_MB * 1024 * 1024 ))
+
+mark_gap_and_log() {
+  # $1 = reason string; logs + touches the gap marker so the watcher takes
+  # a fresh diff once archiving recovers, anchoring forward-restore coverage.
+  echo "pgbackrest-wrapper: $1; dropping ${WAL_FILE} to keep Postgres up" >&2
+  touch "$PGDATA/.pgbackrest_gap_pending" 2>/dev/null || true
+}
+
+# Pre-archive safety. Drop without invoking pgbackrest when EITHER pg_wal is
+# already past threshold OR free disk is below threshold. The post-failure
+# check below only fires on pgbackrest non-zero exit, which leaves the
+# "archive succeeds individually but throughput < WAL generation" regime
+# undefended — every call returned 0, the reactive du never ran, pg_wal grew
+# to 28 GiB before Postgres ran out of disk.
+PGWAL_BYTES=$(du -sb "$PGDATA/pg_wal" 2>/dev/null | awk '{print $1}')
+FREE_BYTES=$(df -P -k "$PGDATA" 2>/dev/null | awk 'NR==2 {print $4 * 1024}')
+
+if [ -n "${PGWAL_BYTES:-}" ] && [ "$PGWAL_BYTES" -ge "$PGWAL_THRESHOLD_BYTES" ]; then
+  PGWAL_MB=$(( PGWAL_BYTES / 1024 / 1024 ))
+  mark_gap_and_log "pg_wal at ${PGWAL_MB} MiB before archive-push (threshold ${PGWAL_THRESHOLD_MB} MiB)"
+  exit 0
+fi
+if [ -n "${FREE_BYTES:-}" ] && [ "$FREE_BYTES" -lt "$PGWAL_THRESHOLD_BYTES" ]; then
+  FREE_MB=$(( FREE_BYTES / 1024 / 1024 ))
+  mark_gap_and_log "${FREE_MB} MiB free on ${PGDATA} (threshold ${PGWAL_THRESHOLD_MB} MiB)"
+  exit 0
+fi
 
 # Per-cluster repo-path: read the marker written by pgbackrest-init.sh /
 # wrapper.sh's bootstrap subshell. Without this, every archive-push would
@@ -93,11 +116,14 @@ fi
 # on the PUT. Both errors mean no recovery without operator action — drop
 # immediately rather than accumulating WAL up to the threshold.
 if printf '%s\n' "$pgb_out" | grep -qE 'NoSuchBucket|InvalidAccessKeyId'; then
-  echo "pgbackrest-wrapper: bucket gone or credentials revoked; dropping ${WAL_FILE} immediately" >&2
-  touch "$PGDATA/.pgbackrest_gap_pending" 2>/dev/null || true
+  mark_gap_and_log "bucket gone or credentials revoked"
   exit 0
 fi
 
+# Post-failure check: re-read pg_wal size in case it grew during the
+# pgbackrest invocation. Drop if past threshold; otherwise surface
+# pgbackrest's non-zero exit so pg_stat_archiver.failed_count climbs and
+# operators see the underlying issue while there's still time to fix it.
 PGWAL_BYTES=$(du -sb "$PGDATA/pg_wal" 2>/dev/null | awk '{print $1}')
 if [ -z "${PGWAL_BYTES:-}" ]; then
   exit "$PGB_RC"
@@ -105,11 +131,7 @@ fi
 
 if [ "$PGWAL_BYTES" -ge "$PGWAL_THRESHOLD_BYTES" ]; then
   PGWAL_MB=$(( PGWAL_BYTES / 1024 / 1024 ))
-  echo "pgbackrest-wrapper: pg_wal at ${PGWAL_MB} MiB (threshold ${PGWAL_THRESHOLD_MB} MiB) and archive-push failing; dropping ${WAL_FILE} to keep Postgres up" >&2
-  # Signal to pgbackrest-backup-watcher.sh that a gap was just created. The
-  # watcher takes a fresh full backup once archiving recovers, sealing the
-  # gap forward (the dropped segment itself is unrestorable, as before).
-  touch "$PGDATA/.pgbackrest_gap_pending" 2>/dev/null || true
+  mark_gap_and_log "pg_wal at ${PGWAL_MB} MiB (threshold ${PGWAL_THRESHOLD_MB} MiB) and archive-push failing"
   exit 0
 fi
 

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -133,17 +133,21 @@ fi
 # Two orthogonal thresholds gate the "WAL is accumulating, do something":
 #   - archive-push-queue-max (set in /etc/pgbackrest/pgbackrest.conf) governs
 #     the SPOOL. Trips on transient S3 stalls; pgBackRest drops segments
-#     from spool and reports success to archive_command. Generous buffer
-#     to absorb multi-hour outages cleanly. Default 5 GiB on volumes ≥10 GiB;
-#     scales down to ~50% of volume below that (see compute_volume_thresholds).
+#     from spool and reports success to archive_command. Default 5 GiB on
+#     volumes ≥10 GiB; scales down to ~50% of volume below that (see
+#     compute_volume_thresholds).
 #   - pgbackrest-archive-push-wrapper.sh's WAL_DROP_THRESHOLD_MB governs
-#     pg_wal/. Trips on HARD failures (bad creds, deleted bucket, expired
-#     keys) where pgbackrest's foreground returns non-zero and retrying
-#     without operator intervention has zero chance of success. Smaller
-#     cap because we shouldn't hold 5 GiB of pg_wal hostage waiting for a
-#     config fix. Default 500 MiB on volumes ≥5 GiB; scales down to ~10%
-#     of volume below that, floor 64 MiB.
-# Either way, PITR window truncates; DB stays up.
+#     pg_wal/ AND minimum free disk. Pre-archive: drop if pg_wal exceeds
+#     threshold OR the data volume has less free space than threshold,
+#     before invoking pgbackrest — catches the "archiving succeeds but
+#     throughput < WAL generation" regime that the reactive post-failure
+#     check missed (every pgbackrest call returned 0, pg_wal grew to 28 GiB
+#     anyway, Postgres ran out of disk). Post-archive: drop on hard
+#     pgbackrest failure if past threshold. Default 5 GiB on volumes
+#     ≥50 GiB; scales down to ~10% of volume below that, floor 64 MiB.
+# Either way, PITR window truncates; DB stays up. Every drop path touches
+# the .pgbackrest_gap_pending marker so pgbackrest-backup-watcher.sh takes
+# a fresh diff once archiving recovers, anchoring forward-restore coverage.
 # -----------------------------------------------------------------------------
 
 PGBACKREST_CONF_FILE="/etc/pgbackrest/pgbackrest.conf"
@@ -196,8 +200,8 @@ PGBACKREST_INVALID_BUCKET_MARKER="$PGDATA/.pgbackrest_invalid_bucket"
 # off — same behavior as "never enabled." Without this, an unresolved
 # `${{<bucket-id>.BUCKET}}` would land in /etc/pgbackrest/pgbackrest.conf
 # verbatim; pgBackRest would then hard-fail every archive_command and
-# pgbackrest-archive-push-wrapper.sh's 500 MiB WAL-drop threshold would
-# eventually trip — creating a real, unrecoverable PITR gap from what is
+# pgbackrest-archive-push-wrapper.sh's pg_wal threshold would eventually
+# trip — creating a real, unrecoverable PITR gap from what is
 # really an upstream wiring bug. The sentinel file lets the dashboard
 # surface this state distinctly from the no-config and unresolvable-creds
 # states.
@@ -354,37 +358,37 @@ detect_volume_total_kib() {
 
 # Compute volume-proportional WAL/spool thresholds and write them to globals
 # COMPUTED_WAL_DROP_MB + COMPUTED_QUEUE_MAX_MIB. Both scale DOWN from the
-# absolute defaults (500 MiB pg_wal drop / 5 GiB spool queue-max) on smaller
-# volumes — never up. Hobby's 1 GiB volume can't carry 5 GiB of spool, and
-# 500 MiB of pg_wal is half the disk; on a 25+ GiB volume the absolutes hold.
+# absolute default (5 GiB) on smaller volumes — never up. Hobby's 1 GiB volume
+# can't carry 5 GiB of either; on a 50+ GiB volume the absolutes hold.
 #
-# Ratios: wal-drop ~ 10% of volume (hard-failure pg_wal hostage), queue-max
-# ~ 50% of volume (transient-stall spool absorption). The 10× spread between
-# the two budgets is preserved across all volume sizes — hard failures still
-# bail fast, transient stalls still absorb generously.
+# Ratios: wal-drop ~10% of volume, queue-max ~50% of volume. wal-drop bounds
+# pg_wal AND the minimum free disk we keep available for Postgres to operate;
+# queue-max is the spool budget for absorbing transient S3 stalls. Both cap
+# at 5 GiB so pg_wal + spool together can never exceed ~10 GiB of WAL-related
+# on-disk footprint, regardless of how big the customer's data volume is.
 #
-# Floor: 64 MiB on wal-drop (~4 WAL segments — enough for one short stall),
-# 128 MiB on queue-max (~8 segments). Below these, archiving is effectively
-# disabled and the dashboard surfaces it.
+# Floor: 64 MiB on wal-drop (~4 WAL segments), 128 MiB on queue-max (~8
+# segments). Below these archiving is effectively off and the dashboard
+# surfaces it.
 compute_volume_thresholds() {
-  local total_kib total_mib wal_drop queue_max cap_queue
+  local total_kib total_mib wal_drop queue_max cap_max
+  cap_max=$(( 5 * 1024 ))
   total_kib=$(detect_volume_total_kib)
   if [ "$total_kib" -lt 1 ]; then
-    COMPUTED_WAL_DROP_MB=500
-    COMPUTED_QUEUE_MAX_MIB=5120
-    echo "pgbackrest: volume size unknown; using absolute thresholds wal-drop=500 MiB queue-max=5 GiB"
+    COMPUTED_WAL_DROP_MB=$cap_max
+    COMPUTED_QUEUE_MAX_MIB=$cap_max
+    echo "pgbackrest: volume size unknown; using absolute thresholds wal-drop=5 GiB queue-max=5 GiB"
     return
   fi
   total_mib=$(( total_kib / 1024 ))
 
   wal_drop=$(( total_mib / 10 ))
-  [ "$wal_drop" -gt 500 ] && wal_drop=500
+  [ "$wal_drop" -gt "$cap_max" ] && wal_drop=$cap_max
   [ "$wal_drop" -lt 64 ] && wal_drop=64
   COMPUTED_WAL_DROP_MB=$wal_drop
 
-  cap_queue=$(( 5 * 1024 ))
   queue_max=$(( total_mib / 2 ))
-  [ "$queue_max" -gt "$cap_queue" ] && queue_max=$cap_queue
+  [ "$queue_max" -gt "$cap_max" ] && queue_max=$cap_max
   [ "$queue_max" -lt 128 ] && queue_max=128
   COMPUTED_QUEUE_MAX_MIB=$queue_max
 


### PR DESCRIPTION
## Summary
- Wrapper now drops incoming WAL **before** calling pgbackrest if `pg_wal/` exceeds `WAL_DROP_THRESHOLD_MB` OR free disk on `$PGDATA` falls below it
- `WAL_DROP_THRESHOLD_MB` cap bumped 500 MiB → 5 GiB; sized to 10% of volume, floor 64 MiB (matches `archive-push-queue-max=5 GiB` spool cap)
- Every drop path still touches `.pgbackrest_gap_pending` so `pgbackrest-backup-watcher.sh` takes a fresh **diff** once archiving recovers — forward-restore coverage is preserved across the gap

## Why
On 2026-05-25 a customer's standalone Postgres (`junior.mtdn.dev / production / postgres`) crashed with **"No space left on device"** after `pg_wal/` grew to 28 GiB in ~7h. Every `archive_command` returned 0 (async pgbackrest foreground completes in ms once it's written to spool), so `pg_stat_archiver.failed_count` stayed at 0 and the existing post-failure `du -sb pg_wal` check in the wrapper never ran. The 500 MiB cap was reactive only — it gated the hard-failure regime (bad creds, deleted bucket) but missed the "archive succeeds individually but throughput < WAL generation" regime.

The verbatim crash:
```
2026-05-25 07:44:32.749 UTC [82] FATAL: archive command was terminated by signal 3: Quit
2026-05-25 07:44:32.749 UTC [82] DETAIL: The failed archive command was:
   /usr/local/bin/pgbackrest-archive-push-wrapper.sh pg_wal/00000001000000290000009F
2026-05-25 07:44:32.388 UTC pgbackrest-wrapper: pg_wal at 28016 MiB (threshold 500 MiB) and
   archive-push failing; dropping pg_wal/00000001000000290000009F to keep Postgres up
2026-05-25 07:44:34.812 UTC [84267] FATAL: could not write to file
   "pg_wal/xlogtemp.84267": No space left on device
```
The wrapper's drop log finally fires only at the very end (when postgres' own crash signaled the archive_command and forced a non-zero exit) — too late.

## Design
- **Pre-archive size check** — bounds backlog when async-push is just slow
- **Pre-archive free-disk check** — protects postgres uptime even when something *other* than pg_wal is filling the volume
- **Post-failure check** — unchanged; still catches hard pgbackrest exits

Threshold semantics: `WAL_DROP_THRESHOLD_MB` is **both** the max pg_wal we retain AND the minimum free disk we keep available for Postgres. Symmetric budget = one knob to tune.

Both `wal-drop` and `queue-max` now cap at 5 GiB so total WAL-related on-disk footprint can never exceed ~10 GiB regardless of volume size.

## Test plan
- [ ] Inject queue-max-style backpressure (kill async daemon, throttle Tigris) on a test cluster and confirm pg_wal stays within `WAL_DROP_THRESHOLD_MB`
- [ ] Fill the volume with a non-WAL file to ~< threshold free; confirm wrapper drops new segments and Postgres stays up
- [ ] Verify watcher takes a `diff` backup after gap_marker clears
- [ ] Hobby (1 GiB) volume sanity: threshold scales down to ~102 MiB; not stuck in always-drop