### PR TITLE
fix(pgbackrest-wrapper): refuse to push when WAL_ARCHIVE_BUCKET is empty

### DIFF
--- a/pgbackrest-archive-push-wrapper.sh
+++ b/pgbackrest-archive-push-wrapper.sh
@@ -61,6 +61,25 @@ if [ -z "$WAL_FILE" ]; then
 fi
 
 PGDATA="${PGDATA:-/var/lib/postgresql/data}"
+
+# Defensive gate: if WAL_ARCHIVE_BUCKET is unset or empty at the time
+# archive_command fires, archiving is not configured for this service.
+# The normal path is wrapper.sh's clear_pgbackrest_state_if_disabled
+# removing $PGDATA/conf.d/pgbackrest.conf so postgres never picks up
+# archive_command in the first place — but a redeploy that didn't run,
+# pinning to an older postgres-ssl tag that predates the cleanup, or a
+# leftover ALTER SYSTEM SET archive_command in postgresql.auto.conf can
+# all leak the archive_command setting onto a postgres that has no
+# bucket. Surfacing pgbackrest's FileMissingError (exit 103) to Postgres
+# in that state produces tens of thousands of "archive_command failed"
+# lines a day for a service whose PITR is intentionally off. Return 0
+# so pg_wal recycles; the log line below is the only signal admins need
+# to clear the stale config (redeploy, or unset archive_command).
+if [ -z "${WAL_ARCHIVE_BUCKET:-}" ]; then
+  echo "pgbackrest-wrapper: WAL_ARCHIVE_BUCKET is unset; archive_command should not be installed. Dropping ${WAL_FILE} to keep Postgres up — redeploy the service so wrapper.sh can clean up the stale conf, or update the source image if a redeploy doesn't fix it." >&2
+  exit 0
+fi
+
 PGWAL_THRESHOLD_MB="${WAL_DROP_THRESHOLD_MB:-500}"
 PGWAL_THRESHOLD_BYTES=$(( PGWAL_THRESHOLD_MB * 1024 * 1024 ))
 


### PR DESCRIPTION
## Summary

Defensive gate in `pgbackrest-archive-push-wrapper.sh`: if `WAL_ARCHIVE_BUCKET` is unset / empty when `archive_command` fires, return 0 immediately so pg_wal recycles, and log once per invocation explaining the stale-config state.

`wrapper.sh`'s `clear_pgbackrest_state_if_disabled` already removes `$PGDATA/conf.d/pgbackrest.conf` when the bucket is empty, so a freshly-started container with no bucket configured never sees `archive_command`. The wrapper-side gate plugs the holes where that cleanup can't reach:

- Image pinned to an older `postgres-ssl` tag that predates the cleanup
- Customer cleared the bucket but didn't redeploy / cleanup didn't fully apply
- `ALTER SYSTEM SET archive_command` parked in `postgresql.auto.conf` (which `conf.d` doesn't override)

In any of those states the wrapper invokes `pgbackrest archive-push` against a never-initialized stanza, hits `FileMissingError` on `archive.info` (exit 103), and surfaces the failure to Postgres — generating tens of thousands of "archive_command failed" log lines per day on services whose PITR is intentionally off.

## Real-world repro

My Projects / 4779 staging — `postgres-ssl:17.9` pinned, all `WAL_ARCHIVE_*` vars set to `""`, `archive_command` still active, 39 655 failures + 675 log-spew lines / 24h. The dashboard fired ARCHIVER_UNHEALTHY (crit) on a service whose customer never wired PITR up in the first place.

## Companion PRs

- `railwayapp/mono` PR #29940 — stops the monitor misclassifying this state as ARCHIVER_UNHEALTHY (info-level PITR_DISABLED instead)
- `railwayapp-templates/postgres-ha` — equivalent gate

## Test plan

- [ ] Bash syntax check (`bash -n`) — passing locally
- [ ] CI e2e
- [ ] After image roll: confirm staging env of 4779 stops log-spamming `FileMissingError`