### PR TITLE
fix(pitr): kick async daemon when S3 probe blackout + WAL advancing

### DIFF
--- a/pgbackrest-archive-push-wrapper.sh
+++ b/pgbackrest-archive-push-wrapper.sh
@@ -91,7 +91,7 @@ fi
 # to a spool status file. Print it so the actual failure reason appears in
 # deployment logs instead of being invisible.
 WAL_BASENAME=$(basename "$WAL_FILE")
-SPOOL_ERR="${PGDATA}/pgbackrest-spool/archive/main/in/${WAL_BASENAME}.error"
+SPOOL_ERR="${PGDATA}/pgbackrest-spool/archive/main/out/${WAL_BASENAME}.error"
 if [ -f "$SPOOL_ERR" ]; then
   printf 'pgbackrest-wrapper: async spool error for %s (rc=%s):\n' "$WAL_BASENAME" "$PGB_RC" >&2
   cat "$SPOOL_ERR" >&2

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -466,8 +466,8 @@ apply_active_path() {
 # where async hit the regression but the foreground archive_command hasn't
 # yet been re-invoked to surface .error to pg_stat_archiver — so
 # LAST_FAILED_WAL is still NULL/stale and the failed_grew + epoch guards
-# below can't fire. Echoes the WAL filename of the first matching error;
-# returns non-zero if none found.
+# below can't fire. Echoes the WAL filename of the first catalog-valid
+# matching error; returns non-zero if none found.
 #
 # Match key is the first line of the .error file, which pgBackRest writes as
 # the integer exit code (see src/command/archive/common.c — archiveModePush
@@ -477,26 +477,38 @@ apply_active_path() {
 # across 2.x releases ("with different checksum" → "with a different
 # checksum" → …) and matching it would silently disarm on the next rename.
 probe_async_duplicate_error() {
+  local catalog_max="${1:-}"
   [ -d "$SPOOL_ERR_DIR" ] || return 1
   local err_file first_line base
   for err_file in "$SPOOL_ERR_DIR"/*.error; do
     [ -f "$err_file" ] || continue
     # Skip non-WAL-segment errors (backup history files like
     # <wal>.<offset>.backup also archive through this path and produce
-    # <name>.backup.error on exit 45). Without this filter, an
-    # alphabetically-earlier .backup.error would short-circuit the loop
-    # before reaching a real WAL-segment .error, the predicate's
-    # segment_to_number would reject the 31-char name and return empty,
-    # and migration would silently fail to fire that iteration. Same
-    # strict shape as segment_to_number's input check.
+    # <name>.backup.error on exit 45). Same strict shape as
+    # segment_to_number's input check.
     base=$(basename "$err_file" .error)
     [ ${#base} -eq 24 ] || continue
     case "$base" in *[!0-9A-Fa-f]*) continue ;; esac
     IFS= read -r first_line < "$err_file" 2>/dev/null || continue
-    if [ "$first_line" = "45" ]; then
-      echo "$base"
-      return 0
+    [ "$first_line" = "45" ] || continue
+
+    # When catalog_max is available, verify the failing segment is on the same
+    # timeline and at or before the S3 max — guards against stale .error files
+    # written on another timeline. If the first exit-45 file is stale, keep
+    # scanning: a later .error may be the real WAL_REGRESSION signal.
+    local d_n
+    d_n=$(segment_to_number "$base")
+    [ -n "$d_n" ] || continue
+    if [ -n "$catalog_max" ]; then
+      local d_tl c_tl c_n
+      d_tl="${base:0:8}"
+      c_tl="${catalog_max:0:8}"
+      c_n=$(segment_to_number "$catalog_max")
+      [ "$d_tl" = "$c_tl" ] && [ -n "$c_n" ] && [ "$d_n" -le "$c_n" ] || continue
     fi
+
+    echo "$base"
+    return 0
   done
   return 1
 }
@@ -619,13 +631,12 @@ migrate_to_new_archive_path() {
     sleep 0.2
   done
 
-  # Stale .error files in the async spool reference segments on the OLD
-  # path — the conflict that produced them doesn't exist at the new
-  # (empty) path. Without cleanup the next iteration's
-  # probe_async_duplicate_error would re-fire migration on leftovers.
-  # The spool is a coordination cache, never durable data — async
-  # re-uploads from pg_wal on next call.
-  rm -f "$SPOOL_ERR_DIR"/*.error 2>/dev/null || true
+  # Stale async status files reference segments on the OLD path — the
+  # conflict that produced .error files doesn't exist at the new (empty)
+  # path, and .ok files can incorrectly satisfy future archive-push calls
+  # without uploading the segment to the NEW path. The spool is a coordination
+  # cache, never durable data — async re-uploads from pg_wal on next call.
+  rm -f "$SPOOL_ERR_DIR"/*.error "$SPOOL_ERR_DIR"/*.ok 2>/dev/null || true
 
   # Clear the recovery sentinel last. NEEDS_INITIAL_BACKUP fires above the
   # GAP_MARKER gate in decide_action, so its presence here wouldn't block
@@ -681,32 +692,14 @@ gap_recovery_step() {
   # downstream regression detection can't fire. Read the spool directly so
   # an async-only wedge converges in one poll cycle.
   local dup_seg
-  if dup_seg=$(probe_async_duplicate_error) && [ -n "$dup_seg" ]; then
-    local d_tl d_n
-    d_tl="${dup_seg:0:8}"
-    d_n=$(segment_to_number "$dup_seg")
-    # When catalog_max is available, verify the failing segment is on the same
-    # timeline and at or before the S3 max — guards against a stale .error
-    # written on a different timeline. When catalog_max is empty
-    # (LAST_ARCHIVED_WAL unset after a postgres restart — exactly the
-    # post-rollback scenario this probe is designed for), trust the exit-45
-    # evidence directly: a segment already present in S3 at a different
-    # checksum is self-evident proof of WAL_REGRESSION regardless of what
-    # pgbackrest info can currently enumerate.
-    local _dup_ok=0
-    if [ -z "$catalog_max" ]; then
-      [ -n "$d_n" ] && _dup_ok=1
-    else
-      local _c_tl _c_n
-      _c_tl="${catalog_max:0:8}"; _c_n=$(segment_to_number "$catalog_max")
-      [ "$d_tl" = "$_c_tl" ] && [ -n "$d_n" ] && [ -n "$_c_n" ] \
-        && [ "$d_n" -le "$_c_n" ] && _dup_ok=1
-    fi
-    if [ "$_dup_ok" -eq 1 ]; then
-      log "wal-regression: async spool ArchiveDuplicateError for ${dup_seg} (catalog_max=${catalog_max:-unknown}) — self-healing"
-      migrate_to_new_archive_path
-      return 0
-    fi
+  if dup_seg=$(probe_async_duplicate_error "$catalog_max") && [ -n "$dup_seg" ]; then
+    # When catalog_max is empty (LAST_ARCHIVED_WAL unset after a postgres
+    # restart — exactly the post-rollback scenario this probe is designed for),
+    # the probe trusts exit-45 evidence directly: a segment already present in
+    # S3 at a different checksum is self-evident proof of WAL_REGRESSION.
+    log "wal-regression: async spool ArchiveDuplicateError for ${dup_seg} (catalog_max=${catalog_max:-unknown}) — self-healing"
+    migrate_to_new_archive_path
+    return 0
   fi
 
   # In recovery? Marker is the truth — either we set it on a previous lag

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -139,6 +139,15 @@ log() { echo "pgbackrest-watcher: $*"; }
 #                                       proof is "current catalog_max > this")
 #   last_force_recovery_at=<epoch>   — last time we pkill'd the async daemon
 #   force_attempts=<int>             — pkill cycles this gap-recovery cycle
+#   wal_regression_orig_path=<path>  — pre-migration repo1-path, set on the
+#                                       first WAL_REGRESSION self-heal and
+#                                       never cleared. Successive migrations
+#                                       compose suffix off this (orig-<e2>),
+#                                       not the live path (orig-<e1>-<e2>),
+#                                       so a customer who triggers multiple
+#                                       rollbacks gets flat sibling prefixes
+#                                       (cluster-X, cluster-X-e1, cluster-X-e2)
+#                                       rather than a deepening chain.
 read_state() {
   local field="$1"
   [ ! -f "$STATE_FILE" ] && return 0
@@ -422,7 +431,19 @@ kick_async_daemon() {
 apply_active_path() {
   local path="$1"
   [ -z "$path" ] && return 1
-  echo "$path" > "$PGDATA/.pgbackrest_repo_path"
+  # tmp+rename so a concurrent `cat $marker` from the archive-push wrapper
+  # (called by Postgres on every WAL switch) never sees a truncated /
+  # half-written file. rename(2) within the same directory is atomic on
+  # POSIX filesystems — the marker is either fully OLD or fully NEW for
+  # every reader. The conf rewrite below also has a `sed -i` non-atomic
+  # window, but pgBackRest reads env > conf and the wrapper exports
+  # PGBACKREST_REPO1_PATH from the marker, so the marker is the
+  # load-bearing read path and the one that needs the atomicity guarantee.
+  local marker="$PGDATA/.pgbackrest_repo_path"
+  local tmp
+  tmp=$(mktemp "${marker}.XXXX") || return 1
+  printf '%s\n' "$path" > "$tmp" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$marker" || { rm -f "$tmp"; return 1; }
   if [ -f "$PGBACKREST_CONF_FILE" ]; then
     sed -i "s|^repo1-path=.*|repo1-path=${path}|" "$PGBACKREST_CONF_FILE"
   fi
@@ -435,15 +456,21 @@ apply_active_path() {
 # yet been re-invoked to surface .error to pg_stat_archiver — so
 # LAST_FAILED_WAL is still NULL/stale and the failed_grew + epoch guards
 # below can't fire. Echoes the WAL filename of the first matching error;
-# returns non-zero if none found. Pattern set is pgBackRest 2.x — the
-# integer exit-code line is the most version-stable of the three.
+# returns non-zero if none found.
+#
+# Match key is the first line of the .error file, which pgBackRest writes as
+# the integer exit code (see src/command/archive/common.c — archiveAsyncStatus
+# writes `<code>\n<message>`). 45 == ArchiveDuplicateError is the only
+# version-stable identifier; the human-readable message phrasing has churned
+# across 2.x releases ("with different checksum" → "with a different
+# checksum" → …) and matching it would silently disarm on the next rename.
 probe_async_duplicate_error() {
   [ -d "$SPOOL_ERR_DIR" ] || return 1
-  local err_file
+  local err_file first_line
   for err_file in "$SPOOL_ERR_DIR"/*.error; do
     [ -f "$err_file" ] || continue
-    if grep -qE 'ArchiveDuplicateError|exit code: ?45|already exists in the (archive|repo).*different' \
-       "$err_file" 2>/dev/null; then
+    IFS= read -r first_line < "$err_file" 2>/dev/null || continue
+    if [ "$first_line" = "45" ]; then
       basename "$err_file" .error
       return 0
     fi
@@ -527,12 +554,27 @@ migrate_to_new_archive_path() {
   # conf rewrite is defense-in-depth for bare-shell diagnostics.
   apply_active_path "$new_path"
 
+  # Force-respawn the async daemon. pgBackRest's async worker reads its
+  # repo1-path once at fork/exec time and holds it for the daemon's
+  # lifetime — config rewrites and env changes do NOT propagate to a
+  # running daemon. Without this kick the OLD async daemon keeps draining
+  # the spool to the OLD path long after the marker flips, the
+  # post-migrate full's closing WAL never reaches the NEW path, and
+  # self-heal stalls until the regular gap-recovery loop pkills it
+  # (~GAP_RECOVERY_BACKOFF_SECONDS, default 10 min). pkill here drops
+  # that window to ~archive_timeout (default 60s) — the next foreground
+  # archive-push respawns the daemon with the new env / new conf.
+  log "wal-regression: kicking async daemon to pick up new repo1-path"
+  kick_async_daemon
+
   # Stale .error files in the async spool reference segments on the OLD
   # path — the conflict that produced them doesn't exist at the new
   # (empty) path. Without cleanup the next iteration's
   # probe_async_duplicate_error would re-fire migration on leftovers.
   # The spool is a coordination cache, never durable data — async
-  # re-uploads from pg_wal on next call.
+  # re-uploads from pg_wal on next call. Cleanup runs AFTER the kick so
+  # any final flush from the dying daemon doesn't recreate the file
+  # we're about to delete.
   rm -f "$SPOOL_ERR_DIR"/*.error 2>/dev/null || true
 
   # Clear the recovery sentinel last. NEEDS_INITIAL_BACKUP fires above the

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -406,27 +406,36 @@ kick_async_daemon() {
 }
 
 # Self-heals a WAL_REGRESSION condition by migrating archiving to a new S3
-# path suffix (e.g. cluster-SYSID → cluster-SYSID-2). WAL_REGRESSION occurs
-# when a volume snapshot rollback restores the data directory to an earlier LSN
-# while S3 retains the pre-rollback WAL at the same segment names. pgBackRest
-# refuses to overwrite existing S3 objects with different content (exit 45) so
-# every archive-push fails — pkill-async cycles do not fix this.
+# path suffix (e.g. cluster-SYSID → cluster-SYSID-<epoch>). WAL_REGRESSION
+# occurs when a volume snapshot rollback restores the data directory to an
+# earlier LSN while S3 retains the pre-rollback WAL at the same segment names.
+# pgBackRest refuses to overwrite existing S3 objects with different content
+# (exit 45) so every archive-push fails — pkill-async cycles do not fix this.
 #
 # The migration is non-destructive: the old path and all its backups remain in
 # S3 untouched. Both the archive-push wrapper and this watcher re-read
 # .pgbackrest_repo_path on every call/iteration, so writing the new path there
 # takes effect immediately without a redeploy.
 #
-# After writing the new path, all backup state is reset so the next iteration
-# enters NEEDS_INITIAL_BACKUP and triggers the stanza-create + full backup via
-# the standard run_backup path (exit 55 → stanza-create → retry). Clearing
-# GAP_MARKER here is required — decide_action skips all action while the
-# marker is set, which would create a chicken-and-egg with the new stanza.
+# Suffix is the wall-clock epoch at migration time, not an incrementing
+# generation counter. A counter lives in PGDATA's state file — a second
+# volume-snapshot rollback to a pre-self-heal PGDATA would reset the counter
+# to 0 and re-pick the same `-2` suffix as a prior migration, colliding with
+# the still-broken contents at that path. Epoch-suffixed paths are unique
+# across rollbacks for as long as wall-clock advances.
+#
+# Crash safety: state-reset writes land BEFORE the marker flip. A crash in
+# the middle leaves marker=OLD + last_full_at="" — the next iteration
+# re-detects WAL_REGRESSION at the old path and re-fires this function with
+# a fresh epoch, converging cleanly. The alternative (marker first) would
+# strand the watcher at the new empty path with stale last_full_at, skipping
+# NEEDS_INITIAL_BACKUP and waiting up to a full catalog-verify cycle to heal.
 migrate_to_new_archive_path() {
   local old_path="${PGBACKREST_REPO1_PATH}"
 
-  # Store the original (gen 0) path once so successive migrations produce
-  # -2, -3, … instead of chaining suffixes like -2-2.
+  # Track the pre-migration path so successive migrations land at
+  # cluster-SYSID-<epoch1>, cluster-SYSID-<epoch2>, … rather than chaining
+  # suffixes (cluster-SYSID-<epoch1>-<epoch2>).
   local orig_path
   orig_path=$(read_state wal_regression_orig_path)
   if [ -z "$orig_path" ]; then
@@ -434,29 +443,35 @@ migrate_to_new_archive_path() {
     write_state_field wal_regression_orig_path "$orig_path"
   fi
 
-  local gen
-  gen=$(read_state wal_regression_gen); : "${gen:=0}"
-  gen=$((gen + 1))
-  write_state_field wal_regression_gen "$gen"
-
-  # Suffix: gen=1 → -2, gen=2 → -3, etc.
-  local new_path="${orig_path}-$((gen + 1))"
+  local new_path="${orig_path}-$(date +%s)"
 
   log "wal-regression: migrating archive path (${old_path} → ${new_path}); old backups preserved at former path"
 
-  printf '%s' "$new_path" > "$PGDATA/.pgbackrest_repo_path"
-  PGBACKREST_REPO1_PATH="$new_path"
-  export PGBACKREST_REPO1_PATH
-
-  # Reset all backup state so the next iteration enters NEEDS_INITIAL_BACKUP
-  # at the new path. GAP_MARKER cleared so decide_action is unblocked.
+  # Reset backup-tracking + recovery state BEFORE flipping the marker. If
+  # this function is interrupted partway through, the next iteration sees
+  # marker=OLD with last_full_at="" and re-fires migrate (with a fresh
+  # epoch suffix) instead of getting stuck at a half-migrated state.
+  # Refresh stats so last_full_failed_count anchors at the current failed
+  # count — matches clear_gap_recovery_state's semantics so a re-detection
+  # immediately after migrate doesn't trip on a stale 0 anchor.
+  refresh_archiver_stats || true
+  write_state_field last_full_failed_count "${FAILED_COUNT:-0}"
   write_state_field last_full_at ""
   write_state_field last_diff_at ""
-  write_state_field last_full_failed_count 0
   write_state_field last_lag_detected_at 0
   write_state_field catalog_max_at_detection ""
   write_state_field last_force_recovery_at 0
   write_state_field force_attempts 0
+
+  # Commit point: once the marker is on disk, archive-push and the next
+  # watcher iteration target the new path.
+  echo "$new_path" > "$PGDATA/.pgbackrest_repo_path"
+  PGBACKREST_REPO1_PATH="$new_path"
+  export PGBACKREST_REPO1_PATH
+
+  # Clear the recovery sentinel last. NEEDS_INITIAL_BACKUP fires above the
+  # GAP_MARKER gate in decide_action, so its presence here wouldn't block
+  # the post-migrate full — removing it is purely tidiness.
   rm -f "$GAP_MARKER"
 
   log "wal-regression: state reset; next iteration will initialize stanza and take full backup at ${new_path}"
@@ -554,10 +569,13 @@ gap_recovery_step() {
 
     if [ "$since_action" -ge "$GAP_RECOVERY_BACKOFF_SECONDS" ]; then
       # Escape hatch: after ≥2 pkill cycles with no catalog advance, check
-      # whether this is a WAL_REGRESSION. If last_failed_wal is behind the
-      # catalog max on the same timeline, pkill-async cannot fix the conflict
-      # (the issue is structural — pgBackRest refuses to overwrite existing
-      # S3 objects with different content after a data-dir rollback).
+      # whether this is a WAL_REGRESSION. If last_failed_wal is at or before
+      # the catalog max on the same timeline, pkill-async cannot fix the
+      # conflict (the issue is structural — pgBackRest refuses to overwrite
+      # existing S3 objects with different content after a data-dir rollback).
+      # `-le` (not `-lt`) covers the boundary case where rollback lands
+      # exactly at the last successfully archived segment and postgres
+      # re-pushes that same segment number with different content.
       if [ "${force_attempts:-0}" -ge 2 ] && [ -n "$LAST_FAILED_WAL" ] && [ -n "$catalog_max" ] \
          && [ "${LAST_FAILED_EPOCH:-0}" -gt "${LAST_ARCHIVED_EPOCH:-0}" ]; then
         local wr_ftl wr_ctlmax_tl
@@ -567,7 +585,7 @@ gap_recovery_step() {
           local wr_f_n wr_c_n
           wr_f_n=$(segment_to_number "$LAST_FAILED_WAL")
           wr_c_n=$(segment_to_number "$catalog_max")
-          if [ -n "$wr_f_n" ] && [ -n "$wr_c_n" ] && [ "$wr_f_n" -lt "$wr_c_n" ]; then
+          if [ -n "$wr_f_n" ] && [ -n "$wr_c_n" ] && [ "$wr_f_n" -le "$wr_c_n" ]; then
             GAP_STATE_DIAG="wal-regression"
             log "wal-regression: detected after ${force_attempts} pkill attempts (failed_wal=${LAST_FAILED_WAL}, catalog_max=${catalog_max}) — self-healing"
             migrate_to_new_archive_path
@@ -606,11 +624,13 @@ gap_recovery_step() {
 
   if [ "$lag" -ge "$WAL_LAG_GAP_THRESHOLD_SEGMENTS" ] || [ "$failed_grew" -eq 1 ]; then
     # Before entering the pkill-cycle state machine, check whether this is a
-    # WAL_REGRESSION: last_failed_wal is behind the catalog max on the same
-    # timeline, meaning pgBackRest is refusing to overwrite existing S3 objects
-    # with different content (exit 45). pkill-async cannot fix this — it is a
-    # structural archive conflict, not a stuck process. Self-heal immediately
-    # by migrating to a new archive path suffix.
+    # WAL_REGRESSION: last_failed_wal is at or before the catalog max on the
+    # same timeline, meaning pgBackRest is refusing to overwrite existing S3
+    # objects with different content (exit 45). pkill-async cannot fix this —
+    # it is a structural archive conflict, not a stuck process. Self-heal
+    # immediately by migrating to a new archive path suffix. `-le` (not `-lt`)
+    # covers the boundary case where rollback lands exactly at the last
+    # archived segment.
     #
     # Guard: LAST_FAILED_EPOCH > LAST_ARCHIVED_EPOCH confirms the failure is
     # currently active, not a stale pg_stat_archiver.last_failed_wal from an
@@ -624,7 +644,7 @@ gap_recovery_step() {
         local wr_f_n wr_c_n
         wr_f_n=$(segment_to_number "$LAST_FAILED_WAL")
         wr_c_n=$(segment_to_number "$catalog_max")
-        if [ -n "$wr_f_n" ] && [ -n "$wr_c_n" ] && [ "$wr_f_n" -lt "$wr_c_n" ]; then
+        if [ -n "$wr_f_n" ] && [ -n "$wr_c_n" ] && [ "$wr_f_n" -le "$wr_c_n" ]; then
           GAP_STATE_DIAG="wal-regression"
           log "wal-regression: detected (failed_wal=${LAST_FAILED_WAL}, catalog_max=${catalog_max}, failed_count=${FAILED_COUNT:-0}) — self-healing immediately"
           migrate_to_new_archive_path

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -78,7 +78,7 @@ PGDATA="${PGDATA:-/var/lib/postgresql/data}"
 STATE_FILE="$PGDATA/.pgbackrest_backup_state"
 GAP_MARKER="$PGDATA/.pgbackrest_gap_pending"
 PGBACKREST_CONF_FILE="/etc/pgbackrest/pgbackrest.conf"
-SPOOL_ERR_DIR="$PGDATA/pgbackrest-spool/archive/main/in"
+SPOOL_ERR_DIR="$PGDATA/pgbackrest-spool/archive/main/out"
 
 # POLL_INTERVAL_SECONDS / GAP_RECOVERY_BACKOFF_SECONDS are env-overridable so
 # the e2e harness can exercise gap-recovery in <1 min instead of 10+. The
@@ -459,8 +459,9 @@ apply_active_path() {
 # returns non-zero if none found.
 #
 # Match key is the first line of the .error file, which pgBackRest writes as
-# the integer exit code (see src/command/archive/common.c — archiveAsyncStatus
-# writes `<code>\n<message>`). 45 == ArchiveDuplicateError is the only
+# the integer exit code (see src/command/archive/common.c — archiveModePush
+# uses the `out` queue; archiveAsyncStatusErrorWrite writes
+# `<code>\n<message>`). 45 == ArchiveDuplicateError is the only
 # version-stable identifier; the human-readable message phrasing has churned
 # across 2.x releases ("with different checksum" → "with a different
 # checksum" → …) and matching it would silently disarm on the next rename.
@@ -552,7 +553,10 @@ migrate_to_new_archive_path() {
   # mono's restore picker actually reads (it inspects the marker and
   # exports PGBACKREST_REPO1_PATH for its `pgbackrest info` calls); the
   # conf rewrite is defense-in-depth for bare-shell diagnostics.
-  apply_active_path "$new_path"
+  if ! apply_active_path "$new_path"; then
+    log "wal-regression: failed to apply new archive path (${new_path}); will retry"
+    return 1
+  fi
 
   # Force-respawn the async daemon. pgBackRest's async worker reads its
   # repo1-path once at fork/exec time and holds it for the daemon's

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -608,15 +608,23 @@ migrate_to_new_archive_path() {
   # archive-push respawns the daemon with the new env / new conf.
   log "wal-regression: kicking async daemon to pick up new repo1-path"
   kick_async_daemon
+  # Wait up to 2s for the daemon to actually exit before cleaning spool
+  # files. pkill(1) is non-blocking — in the window between signal delivery
+  # and process exit the daemon's shutdown path can write a new .error file,
+  # which would survive the rm below and cause probe_async_duplicate_error
+  # to re-fire migration on the very next poll.
+  local _drain_deadline=$(($(date +%s) + 2))
+  while pgrep -f 'archive-push:async' >/dev/null 2>&1 \
+        && [ "$(date +%s)" -lt "$_drain_deadline" ]; do
+    sleep 0.2
+  done
 
   # Stale .error files in the async spool reference segments on the OLD
   # path — the conflict that produced them doesn't exist at the new
   # (empty) path. Without cleanup the next iteration's
   # probe_async_duplicate_error would re-fire migration on leftovers.
   # The spool is a coordination cache, never durable data — async
-  # re-uploads from pg_wal on next call. Cleanup runs AFTER the kick so
-  # any final flush from the dying daemon doesn't recreate the file
-  # we're about to delete.
+  # re-uploads from pg_wal on next call.
   rm -f "$SPOOL_ERR_DIR"/*.error 2>/dev/null || true
 
   # Clear the recovery sentinel last. NEEDS_INITIAL_BACKUP fires above the
@@ -671,15 +679,31 @@ gap_recovery_step() {
   # invocation. On a quiet DB the next invocation may be a long way off, and
   # without a foreground-side failure LAST_FAILED_WAL is NULL and the
   # downstream regression detection can't fire. Read the spool directly so
-  # an async-only wedge converges in one poll cycle. Same predicate
-  # semantics: same timeline, failed segment ≤ catalog max.
+  # an async-only wedge converges in one poll cycle.
   local dup_seg
-  if dup_seg=$(probe_async_duplicate_error) && [ -n "$catalog_max" ] && [ -n "$dup_seg" ]; then
-    local d_tl c_tl d_n c_n
-    d_tl="${dup_seg:0:8}"; c_tl="${catalog_max:0:8}"
-    d_n=$(segment_to_number "$dup_seg"); c_n=$(segment_to_number "$catalog_max")
-    if [ "$d_tl" = "$c_tl" ] && [ -n "$d_n" ] && [ -n "$c_n" ] && [ "$d_n" -le "$c_n" ]; then
-      log "wal-regression: async spool ArchiveDuplicateError for ${dup_seg} (catalog_max=${catalog_max}) — self-healing"
+  if dup_seg=$(probe_async_duplicate_error) && [ -n "$dup_seg" ]; then
+    local d_tl d_n
+    d_tl="${dup_seg:0:8}"
+    d_n=$(segment_to_number "$dup_seg")
+    # When catalog_max is available, verify the failing segment is on the same
+    # timeline and at or before the S3 max — guards against a stale .error
+    # written on a different timeline. When catalog_max is empty
+    # (LAST_ARCHIVED_WAL unset after a postgres restart — exactly the
+    # post-rollback scenario this probe is designed for), trust the exit-45
+    # evidence directly: a segment already present in S3 at a different
+    # checksum is self-evident proof of WAL_REGRESSION regardless of what
+    # pgbackrest info can currently enumerate.
+    local _dup_ok=0
+    if [ -z "$catalog_max" ]; then
+      [ -n "$d_n" ] && _dup_ok=1
+    else
+      local _c_tl _c_n
+      _c_tl="${catalog_max:0:8}"; _c_n=$(segment_to_number "$catalog_max")
+      [ "$d_tl" = "$_c_tl" ] && [ -n "$d_n" ] && [ -n "$_c_n" ] \
+        && [ "$d_n" -le "$_c_n" ] && _dup_ok=1
+    fi
+    if [ "$_dup_ok" -eq 1 ]; then
+      log "wal-regression: async spool ArchiveDuplicateError for ${dup_seg} (catalog_max=${catalog_max:-unknown}) — self-healing"
       migrate_to_new_archive_path
       return 0
     fi

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -148,6 +148,15 @@ log() { echo "pgbackrest-watcher: $*"; }
 #                                       rollbacks gets flat sibling prefixes
 #                                       (cluster-X, cluster-X-e1, cluster-X-e2)
 #                                       rather than a deepening chain.
+#   wal_regression_pending_new_path=<path>
+#                                     — in-flight migration target. Written
+#                                       before apply_active_path; cleared on
+#                                       success. On retry after a transient
+#                                       apply_active_path failure, reuse this
+#                                       instead of computing a fresh epoch —
+#                                       otherwise every retry would create a
+#                                       new cluster-X-<epoch> sibling and
+#                                       spam orphaned prefixes.
 read_state() {
   local field="$1"
   [ ! -f "$STATE_FILE" ] && return 0
@@ -445,7 +454,9 @@ apply_active_path() {
   printf '%s\n' "$path" > "$tmp" || { rm -f "$tmp"; return 1; }
   mv "$tmp" "$marker" || { rm -f "$tmp"; return 1; }
   if [ -f "$PGBACKREST_CONF_FILE" ]; then
-    sed -i "s|^repo1-path=.*|repo1-path=${path}|" "$PGBACKREST_CONF_FILE"
+    if ! sed -i "s|^repo1-path=.*|repo1-path=${path}|" "$PGBACKREST_CONF_FILE"; then
+      log "apply_active_path: failed to rewrite repo1-path in ${PGBACKREST_CONF_FILE} (marker + env are authoritative; bare-shell diagnostics will see stale path)"
+    fi
   fi
   PGBACKREST_REPO1_PATH="$path"
   export PGBACKREST_REPO1_PATH
@@ -501,34 +512,39 @@ probe_async_duplicate_error() {
 # in S3 untouched and remain reachable through mono's PITR restore UI —
 # usePitrHistories.tsx discovers every cluster-* sub-prefix in the bucket
 # and offers each as a selectable restore source (`isCurrent` flag
-# distinguishes the active path from orphans), so a customer can still
-# PITR off the pre-rollback path if they want. No customer-side action is
-# required to keep that data reachable.
-#
-# Effective immediately without a redeploy because every read path converges
-# on the new path in lockstep:
-#   - archive-push wrapper + this watcher re-read .pgbackrest_repo_path on
-#     every call/iteration
-#   - mono's SSH probe reads the marker first and exports
-#     PGBACKREST_REPO1_PATH (env > conf), so the picker sees the new path
-#     the moment the marker flips
-#   - /etc/pgbackrest/pgbackrest.conf is rewritten for bare-shell diagnostics
+# distinguishes the active path from orphans). No customer-side action is
+# required to keep that data reachable. Effective immediately without a
+# redeploy — see apply_active_path's docblock for the marker/env/conf
+# convergence.
 #
 # Suffix is the wall-clock epoch at migration time, not an incrementing
 # generation counter. A counter lives in PGDATA's state file — a second
 # volume-snapshot rollback to a pre-self-heal PGDATA would reset the counter
 # to 0 and re-pick the same `-2` suffix as a prior migration, colliding with
 # the still-broken contents at that path. Epoch-suffixed paths are unique
-# across rollbacks for as long as wall-clock advances.
+# across rollbacks for as long as wall-clock advances. The computed epoch is
+# persisted in wal_regression_pending_new_path before the state reset and
+# reused on retry, so a transiently-failing apply_active_path doesn't spawn
+# a new sibling prefix per poll.
 #
 # Crash safety: state-reset writes land BEFORE the marker flip. A crash in
 # the middle leaves marker=OLD + last_full_at="" — the next iteration
 # re-detects WAL_REGRESSION at the old path and re-fires this function with
-# a fresh epoch, converging cleanly. The alternative (marker first) would
-# strand the watcher at the new empty path with stale last_full_at, skipping
-# NEEDS_INITIAL_BACKUP and waiting up to a full catalog-verify cycle to heal.
+# the persisted pending new_path, converging cleanly. The alternative
+# (marker first) would strand the watcher at the new empty path with stale
+# last_full_at, skipping NEEDS_INITIAL_BACKUP and waiting up to a full
+# catalog-verify cycle to heal.
 migrate_to_new_archive_path() {
-  local old_path="${PGBACKREST_REPO1_PATH}"
+  GAP_STATE_DIAG="wal-regression"
+
+  # PGBACKREST_REPO1_PATH is normally set by wrapper.sh's exec env and
+  # refreshed every iteration by sync_repo_path_from_marker, but a missing
+  # marker + missing env would trip `set -u` below. Bail with a clear log
+  # rather than aborting the watcher iteration mid-flow.
+  if [ -z "${PGBACKREST_REPO1_PATH:-}" ]; then
+    log "wal-regression: PGBACKREST_REPO1_PATH unset (marker missing, no env override); cannot migrate"
+    return 1
+  fi
 
   # Track the pre-migration path so successive migrations land at
   # cluster-SYSID-<epoch1>, cluster-SYSID-<epoch2>, … rather than chaining
@@ -536,18 +552,28 @@ migrate_to_new_archive_path() {
   local orig_path
   orig_path=$(read_state wal_regression_orig_path)
   if [ -z "$orig_path" ]; then
-    orig_path="${PGBACKREST_REPO1_PATH}"
+    orig_path="$PGBACKREST_REPO1_PATH"
     write_state_field wal_regression_orig_path "$orig_path"
   fi
 
-  local new_path="${orig_path}-$(date +%s)"
+  # Reuse the pending new_path from a prior failed attempt if present —
+  # otherwise apply_active_path failures (mktemp/mv on disk-full or
+  # permission errors) would compute a fresh `date +%s` every iteration and
+  # accumulate orphaned cluster-X-<epochN> siblings until the underlying
+  # condition cleared.
+  local new_path
+  new_path=$(read_state wal_regression_pending_new_path)
+  if [ -z "$new_path" ]; then
+    new_path="${orig_path}-$(date +%s)"
+    write_state_field wal_regression_pending_new_path "$new_path"
+  fi
 
-  log "wal-regression: migrating archive path (${old_path} → ${new_path}); old backups preserved at former path"
+  log "wal-regression: migrating archive path (${PGBACKREST_REPO1_PATH} → ${new_path}); old backups preserved at former path"
 
   # Reset backup-tracking + recovery state BEFORE flipping the marker. If
   # this function is interrupted partway through, the next iteration sees
-  # marker=OLD with last_full_at="" and re-fires migrate (with a fresh
-  # epoch suffix) instead of getting stuck at a half-migrated state.
+  # marker=OLD with last_full_at="" and re-fires migrate (reusing the
+  # persisted pending new_path) instead of getting stuck half-migrated.
   # Refresh stats so last_full_failed_count anchors at the current failed
   # count — matches clear_gap_recovery_state's semantics so a re-detection
   # immediately after migrate doesn't trip on a stale 0 anchor.
@@ -560,14 +586,15 @@ migrate_to_new_archive_path() {
   write_state_field last_force_recovery_at 0
   write_state_field force_attempts 0
 
-  # Commit point: marker + conf + env in lockstep. Marker-flip is what
-  # mono's restore picker actually reads (it inspects the marker and
-  # exports PGBACKREST_REPO1_PATH for its `pgbackrest info` calls); the
-  # conf rewrite is defense-in-depth for bare-shell diagnostics.
   if ! apply_active_path "$new_path"; then
     log "wal-regression: failed to apply new archive path (${new_path}); will retry"
     return 1
   fi
+
+  # Marker flipped successfully — clear the pending field so the next
+  # WAL_REGRESSION (a *new* rollback, not a retry of this one) computes a
+  # fresh epoch.
+  write_state_field wal_regression_pending_new_path ""
 
   # Force-respawn the async daemon. pgBackRest's async worker reads its
   # repo1-path once at fork/exec time and holds it for the daemon's
@@ -652,7 +679,6 @@ gap_recovery_step() {
     d_tl="${dup_seg:0:8}"; c_tl="${catalog_max:0:8}"
     d_n=$(segment_to_number "$dup_seg"); c_n=$(segment_to_number "$catalog_max")
     if [ "$d_tl" = "$c_tl" ] && [ -n "$d_n" ] && [ -n "$c_n" ] && [ "$d_n" -le "$c_n" ]; then
-      GAP_STATE_DIAG="wal-regression"
       log "wal-regression: async spool ArchiveDuplicateError for ${dup_seg} (catalog_max=${catalog_max}) — self-healing"
       migrate_to_new_archive_path
       return 0
@@ -738,7 +764,6 @@ gap_recovery_step() {
           wr_f_n=$(segment_to_number "$LAST_FAILED_WAL")
           wr_c_n=$(segment_to_number "$catalog_max")
           if [ -n "$wr_f_n" ] && [ -n "$wr_c_n" ] && [ "$wr_f_n" -le "$wr_c_n" ]; then
-            GAP_STATE_DIAG="wal-regression"
             log "wal-regression: detected after ${force_attempts} pkill attempts (failed_wal=${LAST_FAILED_WAL}, catalog_max=${catalog_max}) — self-healing"
             migrate_to_new_archive_path
             return 0
@@ -797,7 +822,6 @@ gap_recovery_step() {
         wr_f_n=$(segment_to_number "$LAST_FAILED_WAL")
         wr_c_n=$(segment_to_number "$catalog_max")
         if [ -n "$wr_f_n" ] && [ -n "$wr_c_n" ] && [ "$wr_f_n" -le "$wr_c_n" ]; then
-          GAP_STATE_DIAG="wal-regression"
           log "wal-regression: detected (failed_wal=${LAST_FAILED_WAL}, catalog_max=${catalog_max}, failed_count=${FAILED_COUNT:-0}) — self-healing immediately"
           migrate_to_new_archive_path
           return 0

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -357,20 +357,22 @@ segment_to_number() {
   echo $((log * SEGMENTS_PER_LOG_FILE + seg))
 }
 
-# Echoes the highest archived WAL segment on the same timeline as
-# LAST_ARCHIVED_WAL ("" if the catalog has no max for that timeline yet).
+# Echoes the highest archived WAL segment on the same timeline as the input
+# WAL (defaults to LAST_ARCHIVED_WAL; "" if the catalog has no max for that
+# timeline yet).
 # Returns 0 on a successful probe (including empty-result), 1 on transient
 # failure (pgbackrest info errored, JSON unparseable). The previous version
 # silently collapsed unparseable output into "lag=0" — that's the bug that
 # masked Nexa/Postgres-2xa1 and ERP-3.0 at 250+ segments lag while the
 # watcher reported lag=0. jq either parses or fails loudly; no quiet zero.
 probe_catalog_max() {
-  [ -z "$LAST_ARCHIVED_WAL" ] && { echo ""; return 0; }
+  local wal_for_timeline="${1:-$LAST_ARCHIVED_WAL}"
+  [ -z "$wal_for_timeline" ] && { echo ""; return 0; }
   local info_out
   info_out=$(timeout 30 pgbackrest --stanza=main --repo=1 info --output=json 2>/dev/null) || return 1
   [ -z "$info_out" ] && return 1
 
-  local tl="${LAST_ARCHIVED_WAL:0:8}"
+  local tl="${wal_for_timeline:0:8}"
   local repo_max
   repo_max=$(printf '%s' "$info_out" | jq -r --arg tl "$tl" '
     [ .[]?.archive[]?.max // empty
@@ -384,6 +386,20 @@ probe_catalog_max() {
 
   echo "$repo_max"
   return 0
+}
+
+# Returns a catalog max suitable for comparing against a specific WAL file.
+# If the already-probed catalog_max is empty or on another timeline (common
+# after postgres restart, when pg_stat_archiver.last_archived_wal is unset),
+# re-probe pgBackRest using the WAL's timeline explicitly.
+catalog_max_for_wal() {
+  local wal="$1" current="${2:-}"
+  [ -z "$wal" ] && { echo ""; return 0; }
+  if [ -n "$current" ] && [ "${current:0:8}" = "${wal:0:8}" ]; then
+    echo "$current"
+    return 0
+  fi
+  probe_catalog_max "$wal"
 }
 
 # Clears all gap-recovery state (marker file + state fields). Called after a
@@ -513,6 +529,59 @@ probe_async_duplicate_error() {
   return 1
 }
 
+write_state_field_required() {
+  local field="$1" value="$2"
+  if ! write_state_field "$field" "$value"; then
+    log "state-write: failed to persist ${field}; refusing unsafe archive-path migration step"
+    return 1
+  fi
+  return 0
+}
+
+# Finalizes a marker-flipped WAL_REGRESSION migration by forcing pgBackRest's
+# async daemon to re-read repo1-path and clearing stale async status files from
+# the old path. Only clear wal_regression_pending_new_path after this succeeds;
+# a crash before cleanup leaves the pending field in place so the next watcher
+# iteration retries this finalization instead of trusting stale .ok/.error files.
+finalize_wal_regression_migration() {
+  local path="$1"
+
+  log "wal-regression: kicking async daemon to pick up new repo1-path"
+  kick_async_daemon
+  # Wait up to 2s for the daemon to actually exit before cleaning spool
+  # files. pkill(1) is non-blocking — in the window between signal delivery
+  # and process exit the daemon's shutdown path can write a new .error file,
+  # which would survive the rm below and cause probe_async_duplicate_error
+  # to re-fire migration on the very next poll.
+  local _drain_deadline=$(($(date +%s) + 2))
+  while pgrep -f 'archive-push:async' >/dev/null 2>&1 \
+        && [ "$(date +%s)" -lt "$_drain_deadline" ]; do
+    sleep 0.2
+  done
+
+  # Stale async status files reference segments on the OLD path — the
+  # conflict that produced .error files doesn't exist at the new (empty)
+  # path, and .ok files can incorrectly satisfy future archive-push calls
+  # without uploading the segment to the NEW path. The spool is a coordination
+  # cache, never durable data — async re-uploads from pg_wal on next call.
+  if ! rm -f "$SPOOL_ERR_DIR"/*.error "$SPOOL_ERR_DIR"/*.ok 2>/dev/null; then
+    log "wal-regression: failed to clean async status files; will retry finalization"
+    return 1
+  fi
+
+  # Clear the recovery sentinel last. NEEDS_INITIAL_BACKUP fires above the
+  # GAP_MARKER gate in decide_action, so its presence here wouldn't block
+  # the post-migrate full — removing it is purely tidiness.
+  rm -f "$GAP_MARKER"
+
+  if ! write_state_field wal_regression_pending_new_path ""; then
+    log "wal-regression: failed to clear pending migration marker; will retry finalization"
+    return 1
+  fi
+
+  log "wal-regression: migration finalized at ${path}; async status cache cleared"
+}
+
 # Self-heals a WAL_REGRESSION condition by migrating archiving to a new S3
 # path suffix (e.g. cluster-SYSID → cluster-SYSID-<epoch>). WAL_REGRESSION
 # occurs when a volume snapshot rollback restores the data directory to an
@@ -565,7 +634,7 @@ migrate_to_new_archive_path() {
   orig_path=$(read_state wal_regression_orig_path)
   if [ -z "$orig_path" ]; then
     orig_path="$PGBACKREST_REPO1_PATH"
-    write_state_field wal_regression_orig_path "$orig_path"
+    write_state_field_required wal_regression_orig_path "$orig_path" || return 1
   fi
 
   # Reuse the pending new_path from a prior failed attempt if present —
@@ -577,7 +646,17 @@ migrate_to_new_archive_path() {
   new_path=$(read_state wal_regression_pending_new_path)
   if [ -z "$new_path" ]; then
     new_path="${orig_path}-$(date +%s)"
-    write_state_field wal_regression_pending_new_path "$new_path"
+    write_state_field_required wal_regression_pending_new_path "$new_path" || return 1
+  fi
+
+  # Previous iteration may have flipped the marker and crashed before clearing
+  # stale spool statuses / pending state. Do not compute a new path; finish the
+  # pending migration first so stale .ok files cannot mask missing uploads at
+  # the new path.
+  if [ "$PGBACKREST_REPO1_PATH" = "$new_path" ]; then
+    log "wal-regression: finalizing pending archive-path migration at ${new_path}"
+    finalize_wal_regression_migration "$new_path"
+    return $?
   fi
 
   log "wal-regression: migrating archive path (${PGBACKREST_REPO1_PATH} → ${new_path}); old backups preserved at former path"
@@ -588,60 +667,27 @@ migrate_to_new_archive_path() {
   # persisted pending new_path) instead of getting stuck half-migrated.
   # Refresh stats so last_full_failed_count anchors at the current failed
   # count — matches clear_gap_recovery_state's semantics so a re-detection
-  # immediately after migrate doesn't trip on a stale 0 anchor.
+  # immediately after migrate doesn't trip on a stale 0 anchor. These writes
+  # are load-bearing for the post-migrate NEEDS_INITIAL_BACKUP; if any fail,
+  # abort before marker flip rather than entering the new empty path with stale
+  # state.
   refresh_archiver_stats || true
-  write_state_field last_full_failed_count "${FAILED_COUNT:-0}"
-  write_state_field last_full_at ""
-  write_state_field last_diff_at ""
-  write_state_field last_lag_detected_at 0
-  write_state_field catalog_max_at_detection ""
-  write_state_field last_force_recovery_at 0
-  write_state_field force_attempts 0
+  write_state_field_required last_full_failed_count "${FAILED_COUNT:-0}" || return 1
+  write_state_field_required last_full_at "" || return 1
+  write_state_field_required last_diff_at "" || return 1
+  write_state_field_required last_lag_detected_at 0 || return 1
+  write_state_field_required catalog_max_at_detection "" || return 1
+  write_state_field_required last_force_recovery_at 0 || return 1
+  write_state_field_required force_attempts 0 || return 1
 
   if ! apply_active_path "$new_path"; then
     log "wal-regression: failed to apply new archive path (${new_path}); will retry"
     return 1
   fi
 
-  # Marker flipped successfully — clear the pending field so the next
-  # WAL_REGRESSION (a *new* rollback, not a retry of this one) computes a
-  # fresh epoch.
-  write_state_field wal_regression_pending_new_path ""
-
-  # Force-respawn the async daemon. pgBackRest's async worker reads its
-  # repo1-path once at fork/exec time and holds it for the daemon's
-  # lifetime — config rewrites and env changes do NOT propagate to a
-  # running daemon. Without this kick the OLD async daemon keeps draining
-  # the spool to the OLD path long after the marker flips, the
-  # post-migrate full's closing WAL never reaches the NEW path, and
-  # self-heal stalls until the regular gap-recovery loop pkills it
-  # (~GAP_RECOVERY_BACKOFF_SECONDS, default 10 min). pkill here drops
-  # that window to ~archive_timeout (default 60s) — the next foreground
-  # archive-push respawns the daemon with the new env / new conf.
-  log "wal-regression: kicking async daemon to pick up new repo1-path"
-  kick_async_daemon
-  # Wait up to 2s for the daemon to actually exit before cleaning spool
-  # files. pkill(1) is non-blocking — in the window between signal delivery
-  # and process exit the daemon's shutdown path can write a new .error file,
-  # which would survive the rm below and cause probe_async_duplicate_error
-  # to re-fire migration on the very next poll.
-  local _drain_deadline=$(($(date +%s) + 2))
-  while pgrep -f 'archive-push:async' >/dev/null 2>&1 \
-        && [ "$(date +%s)" -lt "$_drain_deadline" ]; do
-    sleep 0.2
-  done
-
-  # Stale async status files reference segments on the OLD path — the
-  # conflict that produced .error files doesn't exist at the new (empty)
-  # path, and .ok files can incorrectly satisfy future archive-push calls
-  # without uploading the segment to the NEW path. The spool is a coordination
-  # cache, never durable data — async re-uploads from pg_wal on next call.
-  rm -f "$SPOOL_ERR_DIR"/*.error "$SPOOL_ERR_DIR"/*.ok 2>/dev/null || true
-
-  # Clear the recovery sentinel last. NEEDS_INITIAL_BACKUP fires above the
-  # GAP_MARKER gate in decide_action, so its presence here wouldn't block
-  # the post-migrate full — removing it is purely tidiness.
-  rm -f "$GAP_MARKER"
+  if ! finalize_wal_regression_migration "$new_path"; then
+    return 1
+  fi
 
   log "wal-regression: state reset; next iteration will initialize stanza and take full backup at ${new_path}"
 }
@@ -771,17 +817,16 @@ gap_recovery_step() {
       # operator pkill, async daemon restarted by something else) and the
       # spool probe finds nothing, but pg_stat_archiver still reflects the
       # underlying failure.
-      if [ "${force_attempts:-0}" -ge 2 ] && [ -n "$LAST_FAILED_WAL" ] && [ -n "$catalog_max" ] \
+      if [ "${force_attempts:-0}" -ge 2 ] && [ -n "$LAST_FAILED_WAL" ] \
          && [ "${LAST_FAILED_EPOCH:-0}" -gt "${LAST_ARCHIVED_EPOCH:-0}" ]; then
-        local wr_ftl wr_ctlmax_tl
-        wr_ftl="${LAST_FAILED_WAL:0:8}"
-        wr_ctlmax_tl="${catalog_max:0:8}"
-        if [ "$wr_ftl" = "$wr_ctlmax_tl" ]; then
+        local wr_catalog_max
+        wr_catalog_max=$(catalog_max_for_wal "$LAST_FAILED_WAL" "$catalog_max") || wr_catalog_max=""
+        if [ -n "$wr_catalog_max" ]; then
           local wr_f_n wr_c_n
           wr_f_n=$(segment_to_number "$LAST_FAILED_WAL")
-          wr_c_n=$(segment_to_number "$catalog_max")
+          wr_c_n=$(segment_to_number "$wr_catalog_max")
           if [ -n "$wr_f_n" ] && [ -n "$wr_c_n" ] && [ "$wr_f_n" -le "$wr_c_n" ]; then
-            log "wal-regression: detected after ${force_attempts} pkill attempts (failed_wal=${LAST_FAILED_WAL}, catalog_max=${catalog_max}) — self-healing"
+            log "wal-regression: detected after ${force_attempts} pkill attempts (failed_wal=${LAST_FAILED_WAL}, catalog_max=${wr_catalog_max}) — self-healing"
             migrate_to_new_archive_path
             return 0
           fi
@@ -829,17 +874,16 @@ gap_recovery_step() {
     # Guard: LAST_FAILED_EPOCH > LAST_ARCHIVED_EPOCH confirms the failure is
     # currently active, not a stale pg_stat_archiver.last_failed_wal from an
     # old transient error (those fields are sticky until postgres restart).
-    if [ "$failed_grew" -eq 1 ] && [ -n "$LAST_FAILED_WAL" ] && [ -n "$catalog_max" ] \
+    if [ "$failed_grew" -eq 1 ] && [ -n "$LAST_FAILED_WAL" ] \
        && [ "${LAST_FAILED_EPOCH:-0}" -gt "${LAST_ARCHIVED_EPOCH:-0}" ]; then
-      local wr_ftl wr_ctlmax_tl
-      wr_ftl="${LAST_FAILED_WAL:0:8}"
-      wr_ctlmax_tl="${catalog_max:0:8}"
-      if [ "$wr_ftl" = "$wr_ctlmax_tl" ]; then
+      local wr_catalog_max
+      wr_catalog_max=$(catalog_max_for_wal "$LAST_FAILED_WAL" "$catalog_max") || wr_catalog_max=""
+      if [ -n "$wr_catalog_max" ]; then
         local wr_f_n wr_c_n
         wr_f_n=$(segment_to_number "$LAST_FAILED_WAL")
-        wr_c_n=$(segment_to_number "$catalog_max")
+        wr_c_n=$(segment_to_number "$wr_catalog_max")
         if [ -n "$wr_f_n" ] && [ -n "$wr_c_n" ] && [ "$wr_f_n" -le "$wr_c_n" ]; then
-          log "wal-regression: detected (failed_wal=${LAST_FAILED_WAL}, catalog_max=${catalog_max}, failed_count=${FAILED_COUNT:-0}) — self-healing immediately"
+          log "wal-regression: detected (failed_wal=${LAST_FAILED_WAL}, catalog_max=${wr_catalog_max}, failed_count=${FAILED_COUNT:-0}) — self-healing immediately"
           migrate_to_new_archive_path
           return 0
         fi

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -77,6 +77,17 @@ set -u
 PGDATA="${PGDATA:-/var/lib/postgresql/data}"
 STATE_FILE="$PGDATA/.pgbackrest_backup_state"
 GAP_MARKER="$PGDATA/.pgbackrest_gap_pending"
+PGBACKREST_CONF_FILE="/etc/pgbackrest/pgbackrest.conf"
+SPOOL_ERR_DIR="$PGDATA/pgbackrest-spool/archive/main/in"
+
+# Patroni REST API for HA clusters. In postgres-ha the API is up before
+# postgres accepts queries; in standalone postgres-ssl nothing listens on
+# 8008 and the patroni_* helpers short-circuit to no-op. Custom top-level
+# keys in /config are stored verbatim and broadcast to every node via DCS;
+# we use this as the cluster-wide active-archive-path source-of-truth so
+# a post-promotion leader doesn't restart archiving at the stale marker
+# inherited from its basebackup.
+PATRONI_API="${PATRONI_RESTAPI_URL:-http://127.0.0.1:8008}"
 
 # POLL_INTERVAL_SECONDS / GAP_RECOVERY_BACKOFF_SECONDS are env-overridable so
 # the e2e harness can exercise gap-recovery in <1 min instead of 10+. The
@@ -405,6 +416,80 @@ kick_async_daemon() {
   pkill -f 'archive-push:async' 2>/dev/null || true
 }
 
+# Source-of-truth setter for the active archive path. Updates the on-disk
+# marker (read by archive-push wrapper on every call and by the watcher's
+# sync_repo_path_from_marker), rewrites repo1-path in /etc/pgbackrest/pgbackrest.conf
+# (read by SSH-driven `pgbackrest info` from mono's restore picker, which
+# doesn't source the watcher's env), and updates the process env. Idempotent.
+apply_active_path() {
+  local path="$1"
+  [ -z "$path" ] && return 1
+  echo "$path" > "$PGDATA/.pgbackrest_repo_path"
+  if [ -f "$PGBACKREST_CONF_FILE" ]; then
+    sed -i "s|^repo1-path=.*|repo1-path=${path}|" "$PGBACKREST_CONF_FILE"
+  fi
+  PGBACKREST_REPO1_PATH="$path"
+  export PGBACKREST_REPO1_PATH
+}
+
+# Patroni availability probe. 2s timeout keeps the watcher loop snappy on
+# standalone postgres-ssl where nothing answers on 8008.
+patroni_available() {
+  curl -sf -o /dev/null --max-time 2 "${PATRONI_API}/" 2>/dev/null
+}
+
+# Adopt the cluster-wide active path from Patroni DCS. Called near the top
+# of each leader iteration; after a leader handoff this catches a stale
+# .pgbackrest_repo_path inherited from basebackup before any archive
+# activity routes to the wrong prefix.
+sync_active_path_from_patroni() {
+  patroni_available || return 0
+  local dcs_path
+  dcs_path=$(curl -sf --max-time 5 "${PATRONI_API}/config" 2>/dev/null \
+    | jq -r '.rwy_active_archive_path // empty' 2>/dev/null) || return 0
+  [ -z "$dcs_path" ] && return 0
+  if [ "$dcs_path" != "$PGBACKREST_REPO1_PATH" ]; then
+    log "active-path: adopting ${dcs_path} from Patroni DCS (was ${PGBACKREST_REPO1_PATH:-unset})"
+    apply_active_path "$dcs_path"
+  fi
+}
+
+# Broadcast the freshly-chosen active path to Patroni DCS. PATCH /config
+# with a custom top-level key — Patroni stores and propagates to every
+# node via etcd/Consul/k8s without acting on the key itself. Failure is
+# logged, not fatal; the migration's own state machine keeps re-firing
+# until a future iteration's publish succeeds.
+publish_active_path_to_patroni() {
+  patroni_available || return 0
+  local path="$1"
+  curl -sf -X PATCH --max-time 5 \
+    -H 'Content-Type: application/json' \
+    -d "{\"rwy_active_archive_path\":\"${path}\"}" \
+    "${PATRONI_API}/config" >/dev/null 2>&1 \
+    || log "patroni: failed to publish active path (will re-assert next iteration)"
+}
+
+# Async-spool probe for ArchiveDuplicateError (exit 45). Catches the case
+# where async hit the regression but the foreground archive_command hasn't
+# yet been re-invoked to surface .error to pg_stat_archiver — so
+# LAST_FAILED_WAL is still NULL/stale and the failed_grew + epoch guards
+# below can't fire. Echoes the WAL filename of the first matching error;
+# returns non-zero if none found. Pattern set is pgBackRest 2.x — the
+# integer exit-code line is the most version-stable of the three.
+probe_async_duplicate_error() {
+  [ -d "$SPOOL_ERR_DIR" ] || return 1
+  local err_file
+  for err_file in "$SPOOL_ERR_DIR"/*.error; do
+    [ -f "$err_file" ] || continue
+    if grep -qE 'ArchiveDuplicateError|exit code: ?45|already exists in the (archive|repo).*different' \
+       "$err_file" 2>/dev/null; then
+      basename "$err_file" .error
+      return 0
+    fi
+  done
+  return 1
+}
+
 # Self-heals a WAL_REGRESSION condition by migrating archiving to a new S3
 # path suffix (e.g. cluster-SYSID → cluster-SYSID-<epoch>). WAL_REGRESSION
 # occurs when a volume snapshot rollback restores the data directory to an
@@ -412,10 +497,16 @@ kick_async_daemon() {
 # pgBackRest refuses to overwrite existing S3 objects with different content
 # (exit 45) so every archive-push fails — pkill-async cycles do not fix this.
 #
-# The migration is non-destructive: the old path and all its backups remain in
-# S3 untouched. Both the archive-push wrapper and this watcher re-read
-# .pgbackrest_repo_path on every call/iteration, so writing the new path there
-# takes effect immediately without a redeploy.
+# The migration is non-destructive: the old path and all its backups remain
+# in S3 untouched. Effective immediately without a redeploy because three
+# read paths all converge on the new path in lockstep:
+#   - archive-push wrapper + this watcher re-read .pgbackrest_repo_path
+#   - mono's SSH-driven `pgbackrest info` (restore picker) reads repo1-path
+#     from /etc/pgbackrest/pgbackrest.conf — rewritten by apply_active_path
+#   - HA replicas adopt via Patroni DCS — publish_active_path_to_patroni
+#     PATCHes /config so a post-promotion leader sees the new path on its
+#     first iteration instead of restarting at the original cluster-SYSID
+#     and re-firing migration with a different epoch suffix
 #
 # Suffix is the wall-clock epoch at migration time, not an incrementing
 # generation counter. A counter lives in PGDATA's state file — a second
@@ -463,11 +554,23 @@ migrate_to_new_archive_path() {
   write_state_field last_force_recovery_at 0
   write_state_field force_attempts 0
 
-  # Commit point: once the marker is on disk, archive-push and the next
-  # watcher iteration target the new path.
-  echo "$new_path" > "$PGDATA/.pgbackrest_repo_path"
-  PGBACKREST_REPO1_PATH="$new_path"
-  export PGBACKREST_REPO1_PATH
+  # Commit point: marker + conf + env in lockstep. SSH-driven `pgbackrest
+  # info` from mono's restore picker reads the conf, not the marker, so a
+  # conf that lags the marker would leave the restore UI invisible to the
+  # new path until the next container redeploy. Patroni DCS broadcast lets
+  # a post-promotion leader adopt this path on its first iteration instead
+  # of restarting at the original cluster-SYSID and re-firing migration
+  # with a different epoch suffix (orphaning the in-flight prefix).
+  apply_active_path "$new_path"
+  publish_active_path_to_patroni "$new_path"
+
+  # Stale .error files in the async spool reference segments on the OLD
+  # path — the conflict that produced them doesn't exist at the new
+  # (empty) path. Without cleanup the next iteration's
+  # probe_async_duplicate_error would re-fire migration on leftovers.
+  # The spool is a coordination cache, never durable data — async
+  # re-uploads from pg_wal on next call.
+  rm -f "$SPOOL_ERR_DIR"/*.error 2>/dev/null || true
 
   # Clear the recovery sentinel last. NEEDS_INITIAL_BACKUP fires above the
   # GAP_MARKER gate in decide_action, so its presence here wouldn't block
@@ -514,6 +617,27 @@ gap_recovery_step() {
     fi
   fi
   LAST_OBSERVED_LAG_SEGMENTS="$lag"
+
+  # Async-spool probe runs before any of the foreground-signal branches.
+  # pgBackRest async writes a .error file when push fails; the foreground
+  # only surfaces that error to pg_stat_archiver on the next archive_command
+  # invocation. On a quiet DB the next invocation may be a long way off, and
+  # without a foreground-side failure LAST_FAILED_WAL is NULL and the
+  # downstream regression detection can't fire. Read the spool directly so
+  # an async-only wedge converges in one poll cycle. Same predicate
+  # semantics: same timeline, failed segment ≤ catalog max.
+  local dup_seg
+  if dup_seg=$(probe_async_duplicate_error) && [ -n "$catalog_max" ] && [ -n "$dup_seg" ]; then
+    local d_tl c_tl d_n c_n
+    d_tl="${dup_seg:0:8}"; c_tl="${catalog_max:0:8}"
+    d_n=$(segment_to_number "$dup_seg"); c_n=$(segment_to_number "$catalog_max")
+    if [ "$d_tl" = "$c_tl" ] && [ -n "$d_n" ] && [ -n "$c_n" ] && [ "$d_n" -le "$c_n" ]; then
+      GAP_STATE_DIAG="wal-regression"
+      log "wal-regression: async spool ArchiveDuplicateError for ${dup_seg} (catalog_max=${catalog_max}) — self-healing"
+      migrate_to_new_archive_path
+      return 0
+    fi
+  fi
 
   # In recovery? Marker is the truth — either we set it on a previous lag
   # detection or the archive-push wrapper touched it on a hard failure.
@@ -804,6 +928,13 @@ watcher_iteration() {
     log "iteration skipped: standby"
     return 0
   fi
+
+  # Adopt the cluster-wide active path from Patroni DCS before any archive
+  # activity. On the very first iteration after a leader handoff this picks
+  # up a path the prior leader wrote at migration time but that this node's
+  # local .pgbackrest_repo_path (inherited from basebackup) doesn't reflect.
+  # No-op on standalone postgres-ssl (port 8008 not listening).
+  sync_active_path_from_patroni
 
   emit_wal_heartbeat
 

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -139,6 +139,22 @@ log() { echo "pgbackrest-watcher: $*"; }
 #                                       proof is "current catalog_max > this")
 #   last_force_recovery_at=<epoch>   — last time we pkill'd the async daemon
 #   force_attempts=<int>             — pkill cycles this gap-recovery cycle
+#   probe_fail_since=<epoch>         — epoch when pgbackrest info first failed
+#                                       in the current consecutive-failure run
+#                                       (0 = probes are succeeding). Reset to 0
+#                                       on any successful probe. Used by the
+#                                       S3-blind-spot kick: if probes have been
+#                                       failing for > GAP_RECOVERY_BACKOFF_SECONDS
+#                                       AND pg_stat_archiver shows WAL advancing,
+#                                       pkill the async daemon without S3
+#                                       confirmation — the probe blackout itself
+#                                       is evidence the async worker may be wedged
+#                                       on a hung S3 connection.
+#   probe_fail_archived_at_start=<int> — ARCHIVED_COUNT snapshot taken when the
+#                                       consecutive-failure run began. If count
+#                                       has grown since then, postgres is still
+#                                       handing WAL to the spool while S3 is dark
+#                                       — strengthens the kick signal.
 #   wal_regression_orig_path=<path>  — pre-migration repo1-path, set on the
 #                                       first WAL_REGRESSION self-heal and
 #                                       never cleared. Successive migrations
@@ -758,9 +774,53 @@ gap_recovery_step() {
   local probe_rc=$?
   if [ "$probe_rc" -ne 0 ]; then
     GAP_STATE_DIAG="probe-failed"
-    log "gap-recovery: pgbackrest info probe failed; leaving state unchanged"
+
+    # S3 blind-spot kick: the lag probe requires S3 reads to work. When S3 is
+    # completely unreachable (e.g. Tigris outage), probe_catalog_max times out
+    # on every iteration — LAST_OBSERVED_LAG_SEGMENTS stays at its stale value
+    # and the normal lag-threshold path never triggers, even though the async
+    # worker may be wedged on a hung PUT to the same unreachable endpoint.
+    #
+    # Mitigation: track how long probes have been continuously failing. If the
+    # blackout exceeds GAP_RECOVERY_BACKOFF_SECONDS AND pg_stat_archiver shows
+    # WAL is still being handed to the spool (ARCHIVED_COUNT grew since the
+    # blackout started), pkill the async daemon. The worker's hung connection
+    # will be killed; on the next WAL switch archive_command respawns the async
+    # process, which will retry the upload once S3 recovers.
+    #
+    # This does NOT touch the gap marker or enter the full gap-recovery state
+    # machine — catalog proof of S3 progress is still required to clear any
+    # existing marker. This is purely a "kick the stuck process" heuristic for
+    # the total-S3-outage scenario.
+    local probe_fail_since probe_fail_archived
+    probe_fail_since=$(read_state probe_fail_since); : "${probe_fail_since:=0}"
+    probe_fail_archived=$(read_state probe_fail_archived_at_start); : "${probe_fail_archived:=0}"
+
+    if [ "$probe_fail_since" -eq 0 ]; then
+      write_state_field probe_fail_since "$now"
+      write_state_field probe_fail_archived_at_start "${ARCHIVED_COUNT:-0}"
+      log "gap-recovery: pgbackrest info probe failed; leaving state unchanged (probe blackout started)"
+    else
+      local blackout_s=$(( now - probe_fail_since ))
+      local archived_grew=0
+      [ "${ARCHIVED_COUNT:-0}" -gt "$probe_fail_archived" ] && archived_grew=1
+      log "gap-recovery: pgbackrest info probe failed; leaving state unchanged (blackout=${blackout_s}s, archived_grew=${archived_grew})"
+
+      if [ "$blackout_s" -ge "$GAP_RECOVERY_BACKOFF_SECONDS" ] && [ "$archived_grew" -eq 1 ]; then
+        log "gap-recovery: S3 unreachable for ${blackout_s}s while postgres keeps handing WAL — kicking async daemon (blind-spot kick)"
+        kick_async_daemon
+        # Reset the blackout clock so we don't kick on every subsequent
+        # probe-fail iteration; the next kick fires after another full backoff.
+        write_state_field probe_fail_since "$now"
+        write_state_field probe_fail_archived_at_start "${ARCHIVED_COUNT:-0}"
+      fi
+    fi
     return 0
   fi
+
+  # Probe succeeded — reset the consecutive-failure tracking.
+  write_state_field probe_fail_since 0
+  write_state_field probe_fail_archived_at_start 0
   LAST_LAG_REPO_MAX="$catalog_max"
 
   # Lag (postgres handoff minus catalog max). 0 if either side missing.

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -80,15 +80,6 @@ GAP_MARKER="$PGDATA/.pgbackrest_gap_pending"
 PGBACKREST_CONF_FILE="/etc/pgbackrest/pgbackrest.conf"
 SPOOL_ERR_DIR="$PGDATA/pgbackrest-spool/archive/main/in"
 
-# Patroni REST API for HA clusters. In postgres-ha the API is up before
-# postgres accepts queries; in standalone postgres-ssl nothing listens on
-# 8008 and the patroni_* helpers short-circuit to no-op. Custom top-level
-# keys in /config are stored verbatim and broadcast to every node via DCS;
-# we use this as the cluster-wide active-archive-path source-of-truth so
-# a post-promotion leader doesn't restart archiving at the stale marker
-# inherited from its basebackup.
-PATRONI_API="${PATRONI_RESTAPI_URL:-http://127.0.0.1:8008}"
-
 # POLL_INTERVAL_SECONDS / GAP_RECOVERY_BACKOFF_SECONDS are env-overridable so
 # the e2e harness can exercise gap-recovery in <1 min instead of 10+. The
 # defaults are conservative; nothing user-facing advertises these knobs.
@@ -432,43 +423,6 @@ apply_active_path() {
   export PGBACKREST_REPO1_PATH
 }
 
-# Patroni availability probe. 2s timeout keeps the watcher loop snappy on
-# standalone postgres-ssl where nothing answers on 8008.
-patroni_available() {
-  curl -sf -o /dev/null --max-time 2 "${PATRONI_API}/" 2>/dev/null
-}
-
-# Adopt the cluster-wide active path from Patroni DCS. Called near the top
-# of each leader iteration; after a leader handoff this catches a stale
-# .pgbackrest_repo_path inherited from basebackup before any archive
-# activity routes to the wrong prefix.
-sync_active_path_from_patroni() {
-  patroni_available || return 0
-  local dcs_path
-  dcs_path=$(curl -sf --max-time 5 "${PATRONI_API}/config" 2>/dev/null \
-    | jq -r '.rwy_active_archive_path // empty' 2>/dev/null) || return 0
-  [ -z "$dcs_path" ] && return 0
-  if [ "$dcs_path" != "$PGBACKREST_REPO1_PATH" ]; then
-    log "active-path: adopting ${dcs_path} from Patroni DCS (was ${PGBACKREST_REPO1_PATH:-unset})"
-    apply_active_path "$dcs_path"
-  fi
-}
-
-# Broadcast the freshly-chosen active path to Patroni DCS. PATCH /config
-# with a custom top-level key — Patroni stores and propagates to every
-# node via etcd/Consul/k8s without acting on the key itself. Failure is
-# logged, not fatal; the migration's own state machine keeps re-firing
-# until a future iteration's publish succeeds.
-publish_active_path_to_patroni() {
-  patroni_available || return 0
-  local path="$1"
-  curl -sf -X PATCH --max-time 5 \
-    -H 'Content-Type: application/json' \
-    -d "{\"rwy_active_archive_path\":\"${path}\"}" \
-    "${PATRONI_API}/config" >/dev/null 2>&1 \
-    || log "patroni: failed to publish active path (will re-assert next iteration)"
-}
-
 # Async-spool probe for ArchiveDuplicateError (exit 45). Catches the case
 # where async hit the regression but the foreground archive_command hasn't
 # yet been re-invoked to surface .error to pg_stat_archiver — so
@@ -498,15 +452,11 @@ probe_async_duplicate_error() {
 # (exit 45) so every archive-push fails — pkill-async cycles do not fix this.
 #
 # The migration is non-destructive: the old path and all its backups remain
-# in S3 untouched. Effective immediately without a redeploy because three
-# read paths all converge on the new path in lockstep:
+# in S3 untouched. Effective immediately without a redeploy because both
+# read paths converge on the new path in lockstep:
 #   - archive-push wrapper + this watcher re-read .pgbackrest_repo_path
 #   - mono's SSH-driven `pgbackrest info` (restore picker) reads repo1-path
 #     from /etc/pgbackrest/pgbackrest.conf — rewritten by apply_active_path
-#   - HA replicas adopt via Patroni DCS — publish_active_path_to_patroni
-#     PATCHes /config so a post-promotion leader sees the new path on its
-#     first iteration instead of restarting at the original cluster-SYSID
-#     and re-firing migration with a different epoch suffix
 #
 # Suffix is the wall-clock epoch at migration time, not an incrementing
 # generation counter. A counter lives in PGDATA's state file — a second
@@ -557,12 +507,8 @@ migrate_to_new_archive_path() {
   # Commit point: marker + conf + env in lockstep. SSH-driven `pgbackrest
   # info` from mono's restore picker reads the conf, not the marker, so a
   # conf that lags the marker would leave the restore UI invisible to the
-  # new path until the next container redeploy. Patroni DCS broadcast lets
-  # a post-promotion leader adopt this path on its first iteration instead
-  # of restarting at the original cluster-SYSID and re-firing migration
-  # with a different epoch suffix (orphaning the in-flight prefix).
+  # new path until the next container redeploy.
   apply_active_path "$new_path"
-  publish_active_path_to_patroni "$new_path"
 
   # Stale .error files in the async spool reference segments on the OLD
   # path — the conflict that produced them doesn't exist at the new
@@ -928,13 +874,6 @@ watcher_iteration() {
     log "iteration skipped: standby"
     return 0
   fi
-
-  # Adopt the cluster-wide active path from Patroni DCS before any archive
-  # activity. On the very first iteration after a leader handoff this picks
-  # up a path the prior leader wrote at migration time but that this node's
-  # local .pgbackrest_repo_path (inherited from basebackup) doesn't reflect.
-  # No-op on standalone postgres-ssl (port 8008 not listening).
-  sync_active_path_from_patroni
 
   emit_wal_heartbeat
 

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -408,10 +408,17 @@ kick_async_daemon() {
 }
 
 # Source-of-truth setter for the active archive path. Updates the on-disk
-# marker (read by archive-push wrapper on every call and by the watcher's
-# sync_repo_path_from_marker), rewrites repo1-path in /etc/pgbackrest/pgbackrest.conf
-# (read by SSH-driven `pgbackrest info` from mono's restore picker, which
-# doesn't source the watcher's env), and updates the process env. Idempotent.
+# marker (read by the archive-push wrapper on every call and by the watcher's
+# sync_repo_path_from_marker), rewrites repo1-path in
+# /etc/pgbackrest/pgbackrest.conf, and updates the process env. Idempotent.
+#
+# The conf rewrite is defense-in-depth, not the load-bearing read path:
+# mono's restore-picker SSH probe (packages/backboard/src/controllers/databases/
+# pgbackrestInfo.ts) reads the marker via `cat $PGDATA/.pgbackrest_repo_path`
+# and exports PGBACKREST_REPO1_PATH as an env override, and env > conf in
+# pgBackRest's option resolution. Marker-flip alone is what the picker sees.
+# The conf rewrite catches bare `pgbackrest info` invocations that don't go
+# through the override — operator `docker exec` shells, future callers, etc.
 apply_active_path() {
   local path="$1"
   [ -z "$path" ] && return 1
@@ -452,11 +459,21 @@ probe_async_duplicate_error() {
 # (exit 45) so every archive-push fails — pkill-async cycles do not fix this.
 #
 # The migration is non-destructive: the old path and all its backups remain
-# in S3 untouched. Effective immediately without a redeploy because both
-# read paths converge on the new path in lockstep:
-#   - archive-push wrapper + this watcher re-read .pgbackrest_repo_path
-#   - mono's SSH-driven `pgbackrest info` (restore picker) reads repo1-path
-#     from /etc/pgbackrest/pgbackrest.conf — rewritten by apply_active_path
+# in S3 untouched and remain reachable through mono's PITR restore UI —
+# usePitrHistories.tsx discovers every cluster-* sub-prefix in the bucket
+# and offers each as a selectable restore source (`isCurrent` flag
+# distinguishes the active path from orphans), so a customer can still
+# PITR off the pre-rollback path if they want. No customer-side action is
+# required to keep that data reachable.
+#
+# Effective immediately without a redeploy because every read path converges
+# on the new path in lockstep:
+#   - archive-push wrapper + this watcher re-read .pgbackrest_repo_path on
+#     every call/iteration
+#   - mono's SSH probe reads the marker first and exports
+#     PGBACKREST_REPO1_PATH (env > conf), so the picker sees the new path
+#     the moment the marker flips
+#   - /etc/pgbackrest/pgbackrest.conf is rewritten for bare-shell diagnostics
 #
 # Suffix is the wall-clock epoch at migration time, not an incrementing
 # generation counter. A counter lives in PGDATA's state file — a second
@@ -504,10 +521,10 @@ migrate_to_new_archive_path() {
   write_state_field last_force_recovery_at 0
   write_state_field force_attempts 0
 
-  # Commit point: marker + conf + env in lockstep. SSH-driven `pgbackrest
-  # info` from mono's restore picker reads the conf, not the marker, so a
-  # conf that lags the marker would leave the restore UI invisible to the
-  # new path until the next container redeploy.
+  # Commit point: marker + conf + env in lockstep. Marker-flip is what
+  # mono's restore picker actually reads (it inspects the marker and
+  # exports PGBACKREST_REPO1_PATH for its `pgbackrest info` calls); the
+  # conf rewrite is defense-in-depth for bare-shell diagnostics.
   apply_active_path "$new_path"
 
   # Stale .error files in the async spool reference segments on the OLD

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -161,27 +161,34 @@ FAILED_COUNT=0
 LAST_ARCHIVED_EPOCH=0
 LAST_FAILED_EPOCH=0
 LAST_ARCHIVED_WAL=""
+LAST_FAILED_WAL=""
 
-# COALESCE(last_archived_wal, '-') keeps the field non-empty so `read -r`'s
-# whitespace IFS-splitting doesn't collapse a trailing empty column into the
-# previous one and corrupt the bind. The sentinel is stripped below.
+# COALESCE(…, '-') keeps fields non-empty so `read -r`'s whitespace
+# IFS-splitting doesn't collapse trailing empty columns into the previous one
+# and corrupt the bind. The sentinel is stripped below.
 refresh_archiver_stats() {
-  local stats wal_field
+  local stats wal_field failed_wal_field
   stats=$(psql -U postgres -tAXq -F' ' -c "
     SELECT
       archived_count,
       failed_count,
       COALESCE(EXTRACT(EPOCH FROM last_archived_time)::bigint, 0),
       COALESCE(EXTRACT(EPOCH FROM last_failed_time)::bigint, 0),
-      COALESCE(last_archived_wal, '-')
+      COALESCE(last_archived_wal, '-'),
+      COALESCE(last_failed_wal, '-')
     FROM pg_stat_archiver
   " 2>/dev/null) || return 1
   [ -z "$stats" ] && return 1
-  read -r ARCHIVED_COUNT FAILED_COUNT LAST_ARCHIVED_EPOCH LAST_FAILED_EPOCH wal_field <<<"$stats"
+  read -r ARCHIVED_COUNT FAILED_COUNT LAST_ARCHIVED_EPOCH LAST_FAILED_EPOCH wal_field failed_wal_field <<<"$stats"
   if [ "$wal_field" = "-" ]; then
     LAST_ARCHIVED_WAL=""
   else
     LAST_ARCHIVED_WAL="$wal_field"
+  fi
+  if [ "$failed_wal_field" = "-" ]; then
+    LAST_FAILED_WAL=""
+  else
+    LAST_FAILED_WAL="$failed_wal_field"
   fi
 }
 
@@ -398,6 +405,63 @@ kick_async_daemon() {
   pkill -f 'archive-push:async' 2>/dev/null || true
 }
 
+# Self-heals a WAL_REGRESSION condition by migrating archiving to a new S3
+# path suffix (e.g. cluster-SYSID → cluster-SYSID-2). WAL_REGRESSION occurs
+# when a volume snapshot rollback restores the data directory to an earlier LSN
+# while S3 retains the pre-rollback WAL at the same segment names. pgBackRest
+# refuses to overwrite existing S3 objects with different content (exit 45) so
+# every archive-push fails — pkill-async cycles do not fix this.
+#
+# The migration is non-destructive: the old path and all its backups remain in
+# S3 untouched. Both the archive-push wrapper and this watcher re-read
+# .pgbackrest_repo_path on every call/iteration, so writing the new path there
+# takes effect immediately without a redeploy.
+#
+# After writing the new path, all backup state is reset so the next iteration
+# enters NEEDS_INITIAL_BACKUP and triggers the stanza-create + full backup via
+# the standard run_backup path (exit 55 → stanza-create → retry). Clearing
+# GAP_MARKER here is required — decide_action skips all action while the
+# marker is set, which would create a chicken-and-egg with the new stanza.
+migrate_to_new_archive_path() {
+  local old_path="${PGBACKREST_REPO1_PATH}"
+
+  # Store the original (gen 0) path once so successive migrations produce
+  # -2, -3, … instead of chaining suffixes like -2-2.
+  local orig_path
+  orig_path=$(read_state wal_regression_orig_path)
+  if [ -z "$orig_path" ]; then
+    orig_path="${PGBACKREST_REPO1_PATH}"
+    write_state_field wal_regression_orig_path "$orig_path"
+  fi
+
+  local gen
+  gen=$(read_state wal_regression_gen); : "${gen:=0}"
+  gen=$((gen + 1))
+  write_state_field wal_regression_gen "$gen"
+
+  # Suffix: gen=1 → -2, gen=2 → -3, etc.
+  local new_path="${orig_path}-$((gen + 1))"
+
+  log "wal-regression: migrating archive path (${old_path} → ${new_path}); old backups preserved at former path"
+
+  printf '%s' "$new_path" > "$PGDATA/.pgbackrest_repo_path"
+  PGBACKREST_REPO1_PATH="$new_path"
+  export PGBACKREST_REPO1_PATH
+
+  # Reset all backup state so the next iteration enters NEEDS_INITIAL_BACKUP
+  # at the new path. GAP_MARKER cleared so decide_action is unblocked.
+  write_state_field last_full_at ""
+  write_state_field last_diff_at ""
+  write_state_field last_full_failed_count 0
+  write_state_field last_lag_detected_at 0
+  write_state_field catalog_max_at_detection ""
+  write_state_field last_force_recovery_at 0
+  write_state_field force_attempts 0
+  rm -f "$GAP_MARKER"
+
+  log "wal-regression: state reset; next iteration will initialize stanza and take full backup at ${new_path}"
+}
+
 # Recovery state machine. Replaces the old "wait for grace then take a full"
 # path with: detect → wait 10 min → pkill → wait 10 min → pkill → … →
 # (catalog advances) → take diff → clear. Repeats pkill every backoff window
@@ -489,6 +553,29 @@ gap_recovery_step() {
     local since_action=$((now - last_action_at))
 
     if [ "$since_action" -ge "$GAP_RECOVERY_BACKOFF_SECONDS" ]; then
+      # Escape hatch: after ≥2 pkill cycles with no catalog advance, check
+      # whether this is a WAL_REGRESSION. If last_failed_wal is behind the
+      # catalog max on the same timeline, pkill-async cannot fix the conflict
+      # (the issue is structural — pgBackRest refuses to overwrite existing
+      # S3 objects with different content after a data-dir rollback).
+      if [ "${force_attempts:-0}" -ge 2 ] && [ -n "$LAST_FAILED_WAL" ] && [ -n "$catalog_max" ] \
+         && [ "${LAST_FAILED_EPOCH:-0}" -gt "${LAST_ARCHIVED_EPOCH:-0}" ]; then
+        local wr_ftl wr_ctlmax_tl
+        wr_ftl="${LAST_FAILED_WAL:0:8}"
+        wr_ctlmax_tl="${catalog_max:0:8}"
+        if [ "$wr_ftl" = "$wr_ctlmax_tl" ]; then
+          local wr_f_n wr_c_n
+          wr_f_n=$(segment_to_number "$LAST_FAILED_WAL")
+          wr_c_n=$(segment_to_number "$catalog_max")
+          if [ -n "$wr_f_n" ] && [ -n "$wr_c_n" ] && [ "$wr_f_n" -lt "$wr_c_n" ]; then
+            GAP_STATE_DIAG="wal-regression"
+            log "wal-regression: detected after ${force_attempts} pkill attempts (failed_wal=${LAST_FAILED_WAL}, catalog_max=${catalog_max}) — self-healing"
+            migrate_to_new_archive_path
+            return 0
+          fi
+        fi
+      fi
+
       force_attempts=$((force_attempts + 1))
       local stuck_min=$(( (now - detected_at) / 60 ))
       log "gap-recovery: catalog frozen at ${catalog_at_detection} for ${stuck_min}min (handoff=${LAST_ARCHIVED_WAL}, lag=${lag}) — pkill async (attempt #${force_attempts})"
@@ -518,6 +605,34 @@ gap_recovery_step() {
   [ "${FAILED_COUNT:-0}" -gt "$last_full_failed" ] && failed_grew=1
 
   if [ "$lag" -ge "$WAL_LAG_GAP_THRESHOLD_SEGMENTS" ] || [ "$failed_grew" -eq 1 ]; then
+    # Before entering the pkill-cycle state machine, check whether this is a
+    # WAL_REGRESSION: last_failed_wal is behind the catalog max on the same
+    # timeline, meaning pgBackRest is refusing to overwrite existing S3 objects
+    # with different content (exit 45). pkill-async cannot fix this — it is a
+    # structural archive conflict, not a stuck process. Self-heal immediately
+    # by migrating to a new archive path suffix.
+    #
+    # Guard: LAST_FAILED_EPOCH > LAST_ARCHIVED_EPOCH confirms the failure is
+    # currently active, not a stale pg_stat_archiver.last_failed_wal from an
+    # old transient error (those fields are sticky until postgres restart).
+    if [ "$failed_grew" -eq 1 ] && [ -n "$LAST_FAILED_WAL" ] && [ -n "$catalog_max" ] \
+       && [ "${LAST_FAILED_EPOCH:-0}" -gt "${LAST_ARCHIVED_EPOCH:-0}" ]; then
+      local wr_ftl wr_ctlmax_tl
+      wr_ftl="${LAST_FAILED_WAL:0:8}"
+      wr_ctlmax_tl="${catalog_max:0:8}"
+      if [ "$wr_ftl" = "$wr_ctlmax_tl" ]; then
+        local wr_f_n wr_c_n
+        wr_f_n=$(segment_to_number "$LAST_FAILED_WAL")
+        wr_c_n=$(segment_to_number "$catalog_max")
+        if [ -n "$wr_f_n" ] && [ -n "$wr_c_n" ] && [ "$wr_f_n" -lt "$wr_c_n" ]; then
+          GAP_STATE_DIAG="wal-regression"
+          log "wal-regression: detected (failed_wal=${LAST_FAILED_WAL}, catalog_max=${catalog_max}, failed_count=${FAILED_COUNT:-0}) — self-healing immediately"
+          migrate_to_new_archive_path
+          return 0
+        fi
+      fi
+    fi
+
     touch "$GAP_MARKER"
     write_state_field last_lag_detected_at "$now"
     write_state_field catalog_max_at_detection "$catalog_max"

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -467,12 +467,23 @@ apply_active_path() {
 # checksum" → …) and matching it would silently disarm on the next rename.
 probe_async_duplicate_error() {
   [ -d "$SPOOL_ERR_DIR" ] || return 1
-  local err_file first_line
+  local err_file first_line base
   for err_file in "$SPOOL_ERR_DIR"/*.error; do
     [ -f "$err_file" ] || continue
+    # Skip non-WAL-segment errors (backup history files like
+    # <wal>.<offset>.backup also archive through this path and produce
+    # <name>.backup.error on exit 45). Without this filter, an
+    # alphabetically-earlier .backup.error would short-circuit the loop
+    # before reaching a real WAL-segment .error, the predicate's
+    # segment_to_number would reject the 31-char name and return empty,
+    # and migration would silently fail to fire that iteration. Same
+    # strict shape as segment_to_number's input check.
+    base=$(basename "$err_file" .error)
+    [ ${#base} -eq 24 ] || continue
+    case "$base" in *[!0-9A-Fa-f]*) continue ;; esac
     IFS= read -r first_line < "$err_file" 2>/dev/null || continue
     if [ "$first_line" = "45" ]; then
-      basename "$err_file" .error
+      echo "$base"
       return 0
     fi
   done
@@ -709,6 +720,14 @@ gap_recovery_step() {
       # `-le` (not `-lt`) covers the boundary case where rollback lands
       # exactly at the last successfully archived segment and postgres
       # re-pushes that same segment number with different content.
+      #
+      # Failsafe behind probe_async_duplicate_error above — which converges
+      # in one poll cycle and doesn't need pg_stat_archiver to be populated
+      # — so in steady state this branch is dead. It survives for the case
+      # where the .error files got cleaned between iterations (kick races,
+      # operator pkill, async daemon restarted by something else) and the
+      # spool probe finds nothing, but pg_stat_archiver still reflects the
+      # underlying failure.
       if [ "${force_attempts:-0}" -ge 2 ] && [ -n "$LAST_FAILED_WAL" ] && [ -n "$catalog_max" ] \
          && [ "${LAST_FAILED_EPOCH:-0}" -gt "${LAST_ARCHIVED_EPOCH:-0}" ]; then
         local wr_ftl wr_ctlmax_tl

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -441,6 +441,32 @@ kick_async_daemon() {
   pkill -f 'archive-push:async' 2>/dev/null || true
 }
 
+# Rewrite repo1-path in pgbackrest.conf without requiring write permission on
+# /etc/pgbackrest. The watcher runs as postgres; wrapper.sh chowns the conf
+# file to postgres but leaves the directory root-owned, so sed -i/temp+rename
+# fails even though the file itself is writable. Render to a temp file under
+# PGDATA, then copy over the existing inode (file write permission is enough).
+rewrite_pgbackrest_conf_path() {
+  local path="$1" tmp
+  [ -f "$PGBACKREST_CONF_FILE" ] || return 0
+  tmp=$(mktemp "$PGDATA/.pgbackrest_conf.XXXX") || return 1
+  if ! awk -v path="$path" '
+    BEGIN { replaced = 0 }
+    /^repo1-path=/ { print "repo1-path=" path; replaced = 1; next }
+    { print }
+    END { if (!replaced) print "repo1-path=" path }
+  ' "$PGBACKREST_CONF_FILE" > "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  if ! cat "$tmp" > "$PGBACKREST_CONF_FILE"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  rm -f "$tmp"
+  return 0
+}
+
 # Source-of-truth setter for the active archive path. Updates the on-disk
 # marker (read by the archive-push wrapper on every call and by the watcher's
 # sync_repo_path_from_marker), rewrites repo1-path in
@@ -460,7 +486,7 @@ apply_active_path() {
   # (called by Postgres on every WAL switch) never sees a truncated /
   # half-written file. rename(2) within the same directory is atomic on
   # POSIX filesystems — the marker is either fully OLD or fully NEW for
-  # every reader. The conf rewrite below also has a `sed -i` non-atomic
+  # every reader. The conf rewrite below also has a non-atomic overwrite
   # window, but pgBackRest reads env > conf and the wrapper exports
   # PGBACKREST_REPO1_PATH from the marker, so the marker is the
   # load-bearing read path and the one that needs the atomicity guarantee.
@@ -469,10 +495,8 @@ apply_active_path() {
   tmp=$(mktemp "${marker}.XXXX") || return 1
   printf '%s\n' "$path" > "$tmp" || { rm -f "$tmp"; return 1; }
   mv "$tmp" "$marker" || { rm -f "$tmp"; return 1; }
-  if [ -f "$PGBACKREST_CONF_FILE" ]; then
-    if ! sed -i "s|^repo1-path=.*|repo1-path=${path}|" "$PGBACKREST_CONF_FILE"; then
-      log "apply_active_path: failed to rewrite repo1-path in ${PGBACKREST_CONF_FILE} (marker + env are authoritative; bare-shell diagnostics will see stale path)"
-    fi
+  if ! rewrite_pgbackrest_conf_path "$path"; then
+    log "apply_active_path: failed to rewrite repo1-path in ${PGBACKREST_CONF_FILE} (marker + env are authoritative; bare-shell diagnostics will see stale path)"
   fi
   PGBACKREST_REPO1_PATH="$path"
   export PGBACKREST_REPO1_PATH
@@ -580,6 +604,24 @@ finalize_wal_regression_migration() {
   fi
 
   log "wal-regression: migration finalized at ${path}; async status cache cleared"
+}
+
+# If a prior iteration flipped the marker and cleaned stale spool statuses but
+# crashed (or hit a transient state-file write failure) before clearing
+# wal_regression_pending_new_path, no .error may remain to call
+# migrate_to_new_archive_path again. Retry finalization directly whenever the
+# active marker already equals the pending target; suppress other gap work for
+# this iteration so failures keep retrying cleanly on the next poll.
+finalize_pending_wal_regression_migration_if_needed() {
+  local pending
+  pending=$(read_state wal_regression_pending_new_path)
+  [ -z "$pending" ] && return 1
+  [ "${PGBACKREST_REPO1_PATH:-}" != "$pending" ] && return 1
+
+  GAP_STATE_DIAG="wal-regression-finalizing"
+  log "wal-regression: finalizing pending archive-path migration at ${pending}"
+  finalize_wal_regression_migration "$pending" || true
+  return 0
 }
 
 # Self-heals a WAL_REGRESSION condition by migrating archiving to a new S3
@@ -706,6 +748,10 @@ migrate_to_new_archive_path() {
 # avoid racing periodic-full/diff on top of an in-flight recovery.
 gap_recovery_step() {
   local now; now=$(date +%s)
+
+  if finalize_pending_wal_regression_migration_if_needed; then
+    return 0
+  fi
 
   local catalog_max
   catalog_max=$(probe_catalog_max)

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1880,6 +1880,172 @@ t_watcher_gap_recovery_lsn_lag_path() {
   docker volume rm "$vol" >/dev/null
 }
 
+# WAL_REGRESSION self-heal via async-spool probe. Simulates the post-volume-
+# rollback failure mode by planting a synthetic ArchiveDuplicateError in the
+# async spool's .error directory — the same shape pgBackRest writes when it
+# tries to push a segment whose name already exists in S3 with different
+# content. The probe path runs before any of the foreground-signal branches,
+# so we don't need to coordinate with pg_stat_archiver or wait through a
+# pkill backoff: a single planted .error file is enough to fire migrate.
+#
+# Engineering a "real" rollback would require stopping postgres, snapshotting
+# PGDATA, advancing the LSN with extra archive-pushes, then restoring the
+# snapshot — doable but heavy. The probe is also the only detection path
+# that fires when the foreground archive_command hasn't been re-invoked yet
+# (last_failed_wal still NULL on a quiet DB), so it's the most defensive of
+# the three branches to pin down with automation.
+t_watcher_wal_regression_async_spool_probe() {
+  local name=t-walreg-spool-${PG_VERSION}
+  local vol=${name}-vol
+  reset_bucket
+  new_volume "$vol"
+  docker rm -f "$name" >/dev/null 2>&1 || true
+
+  run_archiving_pg_fast_watcher "$name" "$vol"
+  wait_for_pg "$name" || { ko t_watcher_wal_regression_async_spool_probe "no startup"; fail_dump t_watcher_wal_regression_async_spool_probe "$name"; return; }
+  for _ in $(seq 1 15); do
+    docker logs "$name" 2>&1 | grep -q "stanza-create completed" && break
+    sleep 1
+  done
+  docker exec "$name" psql -U postgres -c "CREATE TABLE t(id int); SELECT pg_switch_wal();" >/dev/null
+  wait_for_watcher_backup "$name" full 60 || { ko t_watcher_wal_regression_async_spool_probe "no initial full"; fail_dump t_watcher_wal_regression_async_spool_probe "$name"; return; }
+
+  # Snapshot the original marker + last_archived_wal so we can assert the
+  # migration target and that the old path's full survives.
+  local orig_path orig_full_count last_archived
+  orig_path=$(docker exec "$name" cat /var/lib/postgresql/data/.pgbackrest_repo_path)
+  orig_full_count=$(count_backups_of_type "$name" full)
+  last_archived=$(docker exec "$name" psql -U postgres -At \
+    -c "SELECT last_archived_wal FROM pg_stat_archiver" 2>/dev/null)
+  if [ -z "$last_archived" ]; then
+    ko t_watcher_wal_regression_async_spool_probe "no last_archived_wal after initial full"
+    fail_dump t_watcher_wal_regression_async_spool_probe "$name"
+    return
+  fi
+
+  # Plant a synthetic .error file in the async spool. Content matches all
+  # three patterns in probe_async_duplicate_error's regex so future pgBackRest
+  # message-format drift on any one phrase doesn't silently disarm the test.
+  # File name = last_archived_wal → predicate's "same timeline, segment ≤
+  # catalog_max" reduces to equality, the boundary case the migration's `-le`
+  # (not `-lt`) was widened to catch.
+  docker exec "$name" sh -c "
+    mkdir -p /var/lib/postgresql/data/pgbackrest-spool/archive/main/in
+    cat > /var/lib/postgresql/data/pgbackrest-spool/archive/main/in/${last_archived}.error <<EOF
+ERROR: [045]: ArchiveDuplicateError
+WAL segment ${last_archived} already exists in the archive with different checksum
+exit code: 45
+EOF
+    chown postgres:postgres /var/lib/postgresql/data/pgbackrest-spool/archive/main/in/${last_archived}.error
+  " || { ko t_watcher_wal_regression_async_spool_probe "could not plant .error file"; fail_dump t_watcher_wal_regression_async_spool_probe "$name"; return; }
+
+  # Wait for the watcher to log the migration. Poll = 5s; 60s allows two
+  # iterations + state writes + the next iteration's post-migrate full to
+  # start landing in the log buffer.
+  local deadline=$(($(date +%s) + 60)) hit_migrate=0
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if docker logs "$name" 2>&1 | grep -q "wal-regression: migrating archive path"; then
+      hit_migrate=1; break
+    fi
+    sleep 2
+  done
+  if [ "$hit_migrate" != "1" ]; then
+    ko t_watcher_wal_regression_async_spool_probe "watcher did not log wal-regression migration within deadline"
+    fail_dump t_watcher_wal_regression_async_spool_probe "$name"
+    return
+  fi
+
+  # Marker must now point at `<orig_path>-<digits>` (epoch suffix). Epoch
+  # is wall-clock seconds, so >=1 decimal digit; we don't pin a specific
+  # value because clock skew under CI load can shift it.
+  local new_path
+  new_path=$(docker exec "$name" cat /var/lib/postgresql/data/.pgbackrest_repo_path)
+  case "$new_path" in
+    "${orig_path}-"[0-9]*) ;;
+    *)
+      ko t_watcher_wal_regression_async_spool_probe "marker did not get an epoch suffix; orig=${orig_path}, new=${new_path}"
+      fail_dump t_watcher_wal_regression_async_spool_probe "$name"
+      return ;;
+  esac
+
+  # State file must record the pre-migration path so successive migrations
+  # land at cluster-X-<e2> rather than chaining suffixes (cluster-X-<e1>-<e2>).
+  local orig_in_state
+  orig_in_state=$(docker exec "$name" grep -E "^wal_regression_orig_path=" \
+    /var/lib/postgresql/data/.pgbackrest_backup_state 2>/dev/null | cut -d= -f2-)
+  if [ "$orig_in_state" != "$orig_path" ]; then
+    ko t_watcher_wal_regression_async_spool_probe "wal_regression_orig_path expected '${orig_path}', got '${orig_in_state}'"
+    fail_dump t_watcher_wal_regression_async_spool_probe "$name"
+    return
+  fi
+
+  # The rendered pgbackrest.conf must have repo1-path rewritten too —
+  # defense for bare-shell diagnostics that don't go through the
+  # PGBACKREST_REPO1_PATH env override that mono's picker uses.
+  local conf_path
+  conf_path=$(docker exec "$name" grep -E "^repo1-path=" \
+    /etc/pgbackrest/pgbackrest.conf 2>/dev/null | cut -d= -f2-)
+  if [ "$conf_path" != "$new_path" ]; then
+    ko t_watcher_wal_regression_async_spool_probe "pgbackrest.conf repo1-path expected '${new_path}', got '${conf_path}'"
+    fail_dump t_watcher_wal_regression_async_spool_probe "$name"
+    return
+  fi
+
+  # migrate cleans the planted .error so the next iteration's probe doesn't
+  # re-fire on a leftover. Tested directly because a stuck leftover would
+  # cause migration churn (one new -<epoch> path per iteration).
+  if docker exec "$name" test -f "/var/lib/postgresql/data/pgbackrest-spool/archive/main/in/${last_archived}.error"; then
+    ko t_watcher_wal_regression_async_spool_probe "migrate did not clean planted .error file"
+    fail_dump t_watcher_wal_regression_async_spool_probe "$name"
+    return
+  fi
+
+  # Wait for the post-migrate NEEDS_INITIAL_BACKUP full to land at the new
+  # path. last_full_at="" was written before the marker flip, so the next
+  # iteration's decide_action takes a full unconditionally. Drive WAL
+  # switches to keep the archive-push warm; the stanza-create on the new
+  # path needs at least one segment to anchor against.
+  local full_deadline=$(($(date +%s) + 120)) full_hit=0
+  while [ "$(date +%s)" -lt "$full_deadline" ]; do
+    local now_count
+    now_count=$(docker logs "$name" 2>&1 | grep -c "backup --type=full completed" || true)
+    if [ "$now_count" -gt 1 ]; then full_hit=1; break; fi   # initial + post-migrate
+    docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null 2>&1
+    sleep 3
+  done
+  if [ "$full_hit" != "1" ]; then
+    ko t_watcher_wal_regression_async_spool_probe "post-migrate full did not land within deadline"
+    fail_dump t_watcher_wal_regression_async_spool_probe "$name"
+    return
+  fi
+
+  # Old path's full survives — the migration is non-destructive. Probe
+  # the old path directly with a per-call PGBACKREST_REPO1_PATH override.
+  # This is the exact mechanism mono's usePitrHistories uses to enumerate
+  # orphaned histories in the restore UI, so this assertion also confirms
+  # the UI's discovery path works end-to-end after self-heal.
+  local old_fulls_after
+  old_fulls_after=$(docker exec -u postgres "$name" bash -c "
+    export PGBACKREST_REPO1_S3_BUCKET=\"\$WAL_ARCHIVE_BUCKET\"
+    export PGBACKREST_REPO1_S3_KEY=\"\$WAL_ARCHIVE_KEY\"
+    export PGBACKREST_REPO1_S3_KEY_SECRET=\"\$WAL_ARCHIVE_SECRET\"
+    export PGBACKREST_REPO1_S3_REGION=\"\$WAL_ARCHIVE_REGION\"
+    export PGBACKREST_REPO1_S3_ENDPOINT=\"\$WAL_ARCHIVE_ENDPOINT\"
+    export PGBACKREST_REPO1_PATH=\"$orig_path\"
+    pgbackrest --stanza=main info 2>/dev/null | grep -cE '^[[:space:]]+full backup: ' || true
+  " 2>/dev/null | tail -1)
+  if [ "${old_fulls_after:-0}" -lt "$orig_full_count" ]; then
+    ko t_watcher_wal_regression_async_spool_probe "old path full count regressed: was ${orig_full_count}, now ${old_fulls_after}"
+    fail_dump t_watcher_wal_regression_async_spool_probe "$name"
+    return
+  fi
+
+  ok t_watcher_wal_regression_async_spool_probe
+  note "migrated ${orig_path} → ${new_path}; old full preserved (${old_fulls_after} visible at ${orig_path})"
+  docker rm -f "$name" >/dev/null
+  docker volume rm "$vol" >/dev/null
+}
+
 # G2. PITR target older than oldest-retained full → wrapper exits 1 with a
 # clear "no matching backup set" error. Image-level defense-in-depth for the
 # mono mutation's pre-validation, which can be stale by the time the
@@ -3312,6 +3478,7 @@ ALL_TESTS=(
   t_retention_expires_old_fulls
   t_watcher_gap_recovery_failed_count_path
   t_watcher_gap_recovery_lsn_lag_path
+  t_watcher_wal_regression_async_spool_probe
   t_pitr_target_before_retention_window_refuses
   t_retention_expire_cascades_to_wal
   t_empty_volume_restore_refuses_on_bad_creds

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -2030,6 +2030,18 @@ EOF
     return
   fi
 
+  # Pending target must only clear after marker flip + async spool cleanup
+  # finalize successfully. If this sticks, a later iteration is expected to
+  # retry finalization rather than trusting stale old-path .ok/.error files.
+  local pending_in_state
+  pending_in_state=$(docker exec "$name" grep -E "^wal_regression_pending_new_path=" \
+    /var/lib/postgresql/data/.pgbackrest_backup_state 2>/dev/null | cut -d= -f2-)
+  if [ -n "$pending_in_state" ]; then
+    ko t_watcher_wal_regression_async_spool_probe "wal_regression_pending_new_path should be clear after finalize, got '${pending_in_state}'"
+    fail_dump t_watcher_wal_regression_async_spool_probe "$name"
+    return
+  fi
+
   # The rendered pgbackrest.conf must have repo1-path rewritten too —
   # defense for bare-shell diagnostics that don't go through the
   # PGBACKREST_REPO1_PATH env override that mono's picker uses.

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1940,12 +1940,12 @@ t_watcher_wal_regression_async_spool_probe() {
   # "same timeline, segment ≤ catalog_max" reduces to equality, the
   # boundary case the migration's `-le` (not `-lt`) was widened to catch.
   docker exec "$name" sh -c "
-    mkdir -p /var/lib/postgresql/data/pgbackrest-spool/archive/main/in
-    cat > /var/lib/postgresql/data/pgbackrest-spool/archive/main/in/${last_archived}.error <<EOF
+    mkdir -p /var/lib/postgresql/data/pgbackrest-spool/archive/main/out
+    cat > /var/lib/postgresql/data/pgbackrest-spool/archive/main/out/${last_archived}.error <<EOF
 45
 WAL segment ${last_archived} already exists in the archive with a different checksum
 EOF
-    chown postgres:postgres /var/lib/postgresql/data/pgbackrest-spool/archive/main/in/${last_archived}.error
+    chown postgres:postgres /var/lib/postgresql/data/pgbackrest-spool/archive/main/out/${last_archived}.error
   " || { ko t_watcher_wal_regression_async_spool_probe "could not plant .error file"; fail_dump t_watcher_wal_regression_async_spool_probe "$name"; return; }
 
   # Wait for the watcher to log the migration. Poll = 5s; 60s allows two
@@ -2013,7 +2013,7 @@ EOF
   # migrate cleans the planted .error so the next iteration's probe doesn't
   # re-fire on a leftover. Tested directly because a stuck leftover would
   # cause migration churn (one new -<epoch> path per iteration).
-  if docker exec "$name" test -f "/var/lib/postgresql/data/pgbackrest-spool/archive/main/in/${last_archived}.error"; then
+  if docker exec "$name" test -f "/var/lib/postgresql/data/pgbackrest-spool/archive/main/out/${last_archived}.error"; then
     ko t_watcher_wal_regression_async_spool_probe "migrate did not clean planted .error file"
     fail_dump t_watcher_wal_regression_async_spool_probe "$name"
     return

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1915,10 +1915,29 @@ t_watcher_wal_regression_async_spool_probe() {
   local orig_path orig_full_count last_archived
   orig_path=$(docker exec "$name" cat /var/lib/postgresql/data/.pgbackrest_repo_path)
   orig_full_count=$(count_backups_of_type "$name" full)
-  last_archived=$(docker exec "$name" psql -U postgres -At \
-    -c "SELECT last_archived_wal FROM pg_stat_archiver" 2>/dev/null)
+
+  # After a full backup pgBackRest archives a backup history file
+  # (e.g. 000000010000000000000003.00000028.backup) via archive_command, and
+  # pg_stat_archiver reflects it as last_archived_wal. That name is not a
+  # plain 24-char WAL segment, so segment_to_number rejects it and the
+  # probe_async_duplicate_error boundary check fails silently. Force a WAL
+  # switch here so the next archived file is a real segment, then poll until
+  # last_archived_wal is exactly 24 hex chars before planting the .error.
+  docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null
+  local seg_deadline=$(($(date +%s) + 20))
+  last_archived=""
+  while [ "$(date +%s)" -lt "$seg_deadline" ]; do
+    local candidate
+    candidate=$(docker exec "$name" psql -U postgres -At \
+      -c "SELECT last_archived_wal FROM pg_stat_archiver" 2>/dev/null)
+    if [ "${#candidate}" -eq 24 ]; then
+      last_archived="$candidate"
+      break
+    fi
+    sleep 1
+  done
   if [ -z "$last_archived" ]; then
-    ko t_watcher_wal_regression_async_spool_probe "no last_archived_wal after initial full"
+    ko t_watcher_wal_regression_async_spool_probe "no 24-char WAL segment in last_archived_wal after pg_switch_wal"
     fail_dump t_watcher_wal_regression_async_spool_probe "$name"
     return
   fi

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1923,28 +1923,27 @@ t_watcher_wal_regression_async_spool_probe() {
     return
   fi
 
-  # Kill the async pgBackRest daemon before planting the .error file. In a
-  # healthy container (no actual rollback) the async daemon watches the spool
-  # via inotify and will immediately re-queue the segment when a .error file
-  # appears. Since the segment IS already in S3 with the same checksum,
-  # pgBackRest exits 0 and cleans up the file in sub-second time — before the
-  # first watcher poll (5s). Stopping the daemon first prevents that race.
-  # archive_timeout=60s means the next archive_command invocation is ~60s
-  # away, giving the watcher ample time to detect and process the file.
+  # Pre-kill the async daemon so the synthetic .error file isn't auto-
+  # cleaned by the daemon's inotify-driven re-queue: the planted WAL
+  # segment IS in S3 with the same checksum, so the daemon would exit 0
+  # and remove the file in sub-second time, before the first watcher
+  # poll. The "kicking async daemon" log-line assertion below covers the
+  # production behavior (daemon alive when migrate fires).
   docker exec "$name" pkill -f "archive-push:async" 2>/dev/null || true
 
-  # Plant a synthetic .error file in the async spool. Content matches all
-  # three patterns in probe_async_duplicate_error's regex so future pgBackRest
-  # message-format drift on any one phrase doesn't silently disarm the test.
-  # File name = last_archived_wal → predicate's "same timeline, segment ≤
-  # catalog_max" reduces to equality, the boundary case the migration's `-le`
-  # (not `-lt`) was widened to catch.
+  # Plant a synthetic .error file in the async spool matching pgBackRest's
+  # real on-disk format (see src/command/archive/common.c —
+  # archiveAsyncStatus writes `<exit_code>\n<message>\n`). First line is
+  # the integer exit code (45 == ArchiveDuplicateError), which is what
+  # probe_async_duplicate_error matches against — version-stable across
+  # 2.x phrasing changes. File name = last_archived_wal → predicate's
+  # "same timeline, segment ≤ catalog_max" reduces to equality, the
+  # boundary case the migration's `-le` (not `-lt`) was widened to catch.
   docker exec "$name" sh -c "
     mkdir -p /var/lib/postgresql/data/pgbackrest-spool/archive/main/in
     cat > /var/lib/postgresql/data/pgbackrest-spool/archive/main/in/${last_archived}.error <<EOF
-ERROR: [045]: ArchiveDuplicateError
-WAL segment ${last_archived} already exists in the archive with different checksum
-exit code: 45
+45
+WAL segment ${last_archived} already exists in the archive with a different checksum
 EOF
     chown postgres:postgres /var/lib/postgresql/data/pgbackrest-spool/archive/main/in/${last_archived}.error
   " || { ko t_watcher_wal_regression_async_spool_probe "could not plant .error file"; fail_dump t_watcher_wal_regression_async_spool_probe "$name"; return; }
@@ -1961,6 +1960,16 @@ EOF
   done
   if [ "$hit_migrate" != "1" ]; then
     ko t_watcher_wal_regression_async_spool_probe "watcher did not log wal-regression migration within deadline"
+    fail_dump t_watcher_wal_regression_async_spool_probe "$name"
+    return
+  fi
+
+  # Migrate must explicitly kick the async daemon so the post-migrate
+  # closing WAL reaches the NEW path on the next archive_command (~60s),
+  # not after a 10-min gap-recovery loop pkill. Without this, the daemon
+  # holds the OLD repo1-path for its lifetime and self-heal stalls.
+  if ! docker logs "$name" 2>&1 | grep -q "wal-regression: kicking async daemon"; then
+    ko t_watcher_wal_regression_async_spool_probe "migrate did not kick the async daemon (kick log line missing)"
     fail_dump t_watcher_wal_regression_async_spool_probe "$name"
     return
   fi

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1950,22 +1950,35 @@ t_watcher_wal_regression_async_spool_probe() {
   # production behavior (daemon alive when migrate fires).
   docker exec "$name" pkill -f "archive-push:async" 2>/dev/null || true
 
-  # Plant a synthetic .error file in the async spool matching pgBackRest's
-  # real on-disk format (see src/command/archive/common.c —
-  # archiveAsyncStatus writes `<exit_code>\n<message>\n`). First line is
-  # the integer exit code (45 == ArchiveDuplicateError), which is what
-  # probe_async_duplicate_error matches against — version-stable across
-  # 2.x phrasing changes. File name = last_archived_wal → predicate's
-  # "same timeline, segment ≤ catalog_max" reduces to equality, the
-  # boundary case the migration's `-le` (not `-lt`) was widened to catch.
+  # Plant synthetic async status files matching pgBackRest's real on-disk
+  # format (see src/command/archive/common.c — archiveAsyncStatus writes
+  # `<exit_code>\n<message>\n`). First line is the integer exit code
+  # (45 == ArchiveDuplicateError), which is what probe_async_duplicate_error
+  # matches against — version-stable across 2.x phrasing changes. File name =
+  # last_archived_wal → predicate's "same timeline, segment ≤ catalog_max"
+  # reduces to equality, the boundary case the migration's `-le` (not `-lt`)
+  # was widened to catch. Also plant an alphabetically-earlier stale exit-45
+  # on another timeline so the probe must continue scanning until it finds
+  # the catalog-valid candidate, and plant a stale .ok to prove migration
+  # clears all old-path async statuses, not just .error files.
   docker exec "$name" sh -c "
     mkdir -p /var/lib/postgresql/data/pgbackrest-spool/archive/main/out
+    cat > /var/lib/postgresql/data/pgbackrest-spool/archive/main/out/000000000000000000000001.error <<EOF
+45
+stale duplicate error from another timeline
+EOF
     cat > /var/lib/postgresql/data/pgbackrest-spool/archive/main/out/${last_archived}.error <<EOF
 45
 WAL segment ${last_archived} already exists in the archive with a different checksum
 EOF
-    chown postgres:postgres /var/lib/postgresql/data/pgbackrest-spool/archive/main/out/${last_archived}.error
-  " || { ko t_watcher_wal_regression_async_spool_probe "could not plant .error file"; fail_dump t_watcher_wal_regression_async_spool_probe "$name"; return; }
+    cat > /var/lib/postgresql/data/pgbackrest-spool/archive/main/out/${last_archived}.ok <<EOF
+0
+stale ok from old archive path
+EOF
+    chown postgres:postgres /var/lib/postgresql/data/pgbackrest-spool/archive/main/out/000000000000000000000001.error \
+      /var/lib/postgresql/data/pgbackrest-spool/archive/main/out/${last_archived}.error \
+      /var/lib/postgresql/data/pgbackrest-spool/archive/main/out/${last_archived}.ok
+  " || { ko t_watcher_wal_regression_async_spool_probe "could not plant async status files"; fail_dump t_watcher_wal_regression_async_spool_probe "$name"; return; }
 
   # Wait for the watcher to log the migration. Poll = 5s; 60s allows two
   # iterations + state writes + the next iteration's post-migrate full to
@@ -2029,11 +2042,15 @@ EOF
     return
   fi
 
-  # migrate cleans the planted .error so the next iteration's probe doesn't
-  # re-fire on a leftover. Tested directly because a stuck leftover would
-  # cause migration churn (one new -<epoch> path per iteration).
-  if docker exec "$name" test -f "/var/lib/postgresql/data/pgbackrest-spool/archive/main/out/${last_archived}.error"; then
-    ko t_watcher_wal_regression_async_spool_probe "migrate did not clean planted .error file"
+  # migrate cleans planted async status files so the next iteration's probe
+  # doesn't re-fire on a leftover .error, and future archive-push calls can't
+  # treat stale old-path .ok files as proof a segment reached the NEW path.
+  if docker exec "$name" sh -c "
+    test -e /var/lib/postgresql/data/pgbackrest-spool/archive/main/out/000000000000000000000001.error || \
+    test -e /var/lib/postgresql/data/pgbackrest-spool/archive/main/out/${last_archived}.error || \
+    test -e /var/lib/postgresql/data/pgbackrest-spool/archive/main/out/${last_archived}.ok
+  "; then
+    ko t_watcher_wal_regression_async_spool_probe "migrate did not clean planted async status files"
     fail_dump t_watcher_wal_regression_async_spool_probe "$name"
     return
   fi

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1923,6 +1923,16 @@ t_watcher_wal_regression_async_spool_probe() {
     return
   fi
 
+  # Kill the async pgBackRest daemon before planting the .error file. In a
+  # healthy container (no actual rollback) the async daemon watches the spool
+  # via inotify and will immediately re-queue the segment when a .error file
+  # appears. Since the segment IS already in S3 with the same checksum,
+  # pgBackRest exits 0 and cleans up the file in sub-second time — before the
+  # first watcher poll (5s). Stopping the daemon first prevents that race.
+  # archive_timeout=60s means the next archive_command invocation is ~60s
+  # away, giving the watcher ample time to detect and process the file.
+  docker exec "$name" pkill -f "archive-push:async" 2>/dev/null || true
+
   # Plant a synthetic .error file in the async spool. Content matches all
   # three patterns in probe_async_duplicate_error's regex so future pgBackRest
   # message-format drift on any one phrase doesn't silently disarm the test.


### PR DESCRIPTION
## What

When the S3 backend (Tigris) is completely unreachable, `probe_catalog_max` times out on every watcher iteration. `LAST_OBSERVED_LAG_SEGMENTS` stays at its stale zero value, the lag-threshold path never triggers, and a hung async worker is never killed — even though the spool keeps accumulating WAL behind a queue-max-trip.

## Incident that motivated this

**2026-05-28**: Two services on `t3.storageapi.dev` had the async worker wedged for ~6h. The watcher reported `lag=0` throughout because `pgbackrest info` (which also hits Tigris) was timing out on every probe call. Normal lag detection requires working S3 reads. When S3 is dark for both reads and writes, the watcher is blind.

Both services self-recovered once Tigris came back, but all WAL archived between queue-max-trip and recovery was at risk of permanent loss (dropped segments only survived because postgres hadn't recycled `pg_wal` yet).

## Fix

Track consecutive probe-failure duration in the state file (`probe_fail_since`, `probe_fail_archived_at_start`). When:
- The probe blackout duration ≥ `GAP_RECOVERY_BACKOFF_SECONDS` (default 600s), AND
- `pg_stat_archiver.archived_count` has grown since the blackout started (postgres is still handing WAL to the spool)

→ `pkill archive-push:async`. The hung S3 connection is torn down; `archive_command` respawns the async process on the next WAL switch; uploads retry once S3 recovers.

The blackout clock resets after each kick so we don't pkill on every subsequent failing probe — the next blind-spot kick waits another full backoff period. The counter resets to 0 on the first successful probe so normal lag detection resumes cleanly.

This does **not** touch the gap marker or enter the full gap-recovery state machine — catalog proof of S3 progress is still required for that. This is a targeted "kick the stuck process" heuristic for total-S3-outage scenarios only.

## Test plan
- [ ] Normal operation: probes succeed → `probe_fail_since` is reset to 0 every iteration, no spurious kicks
- [ ] Simulated probe failure (unreachable S3, `timeout 30` fires): after `GAP_RECOVERY_BACKOFF_SECONDS` with advancing `archived_count`, watcher logs "blind-spot kick" and `pkill archive-push:async` fires
- [ ] Probe fails but `archived_count` not advancing (DB idle): no kick (condition guards against killing a healthy-but-idle worker during an S3 outage where nothing was in-flight)
- [ ] S3 recovers mid-blackout: probe succeeds, state resets, normal lag detection resumes