### PR TITLE
fix(pitr): kick async daemon when S3 probe blackout + WAL advancing

### DIFF
--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -157,6 +157,22 @@ log() { echo "pgbackrest-watcher: $*"; }
 #                                       otherwise every retry would create a
 #                                       new cluster-X-<epoch> sibling and
 #                                       spam orphaned prefixes.
+#   probe_fail_since=<epoch>         — epoch when pgbackrest info first failed
+#                                       in the current consecutive-failure run
+#                                       (0 = probes are succeeding). Reset to 0
+#                                       on any successful probe. Used by the
+#                                       S3-blind-spot kick: if probes have been
+#                                       failing for > GAP_RECOVERY_BACKOFF_SECONDS
+#                                       AND pg_stat_archiver shows WAL advancing,
+#                                       pkill the async daemon without S3
+#                                       confirmation — the probe blackout itself
+#                                       is evidence the async worker may be wedged
+#                                       on a hung S3 connection.
+#   probe_fail_archived_at_start=<int> — ARCHIVED_COUNT snapshot taken when the
+#                                       consecutive-failure run began. If count
+#                                       has grown since then, postgres is still
+#                                       handing WAL to the spool while S3 is dark
+#                                       — strengthens the kick signal.
 read_state() {
   local field="$1"
   [ ! -f "$STATE_FILE" ] && return 0
@@ -791,9 +807,53 @@ gap_recovery_step() {
   local probe_rc=$?
   if [ "$probe_rc" -ne 0 ]; then
     GAP_STATE_DIAG="probe-failed"
-    log "gap-recovery: pgbackrest info probe failed; leaving state unchanged"
+
+    # S3 blind-spot kick: the lag probe requires S3 reads to work. When S3 is
+    # completely unreachable (e.g. Tigris outage), probe_catalog_max times out
+    # on every iteration — LAST_OBSERVED_LAG_SEGMENTS stays at its stale value
+    # and the normal lag-threshold path never triggers, even though the async
+    # worker may be wedged on a hung PUT to the same unreachable endpoint.
+    #
+    # Mitigation: track how long probes have been continuously failing. If the
+    # blackout exceeds GAP_RECOVERY_BACKOFF_SECONDS AND pg_stat_archiver shows
+    # WAL is still being handed to the spool (ARCHIVED_COUNT grew since the
+    # blackout started), pkill the async daemon. The worker's hung connection
+    # will be killed; on the next WAL switch archive_command respawns the async
+    # process, which will retry the upload once S3 recovers.
+    #
+    # This does NOT touch the gap marker or enter the full gap-recovery state
+    # machine — catalog proof of S3 progress is still required to clear any
+    # existing marker. This is purely a "kick the stuck process" heuristic for
+    # the total-S3-outage scenario.
+    local probe_fail_since probe_fail_archived
+    probe_fail_since=$(read_state probe_fail_since); : "${probe_fail_since:=0}"
+    probe_fail_archived=$(read_state probe_fail_archived_at_start); : "${probe_fail_archived:=0}"
+
+    if [ "$probe_fail_since" -eq 0 ]; then
+      write_state_field probe_fail_since "$now"
+      write_state_field probe_fail_archived_at_start "${ARCHIVED_COUNT:-0}"
+      log "gap-recovery: pgbackrest info probe failed; leaving state unchanged (probe blackout started)"
+    else
+      local blackout_s=$(( now - probe_fail_since ))
+      local archived_grew=0
+      [ "${ARCHIVED_COUNT:-0}" -gt "$probe_fail_archived" ] && archived_grew=1
+      log "gap-recovery: pgbackrest info probe failed; leaving state unchanged (blackout=${blackout_s}s, archived_grew=${archived_grew})"
+
+      if [ "$blackout_s" -ge "$GAP_RECOVERY_BACKOFF_SECONDS" ] && [ "$archived_grew" -eq 1 ]; then
+        log "gap-recovery: S3 unreachable for ${blackout_s}s while postgres keeps handing WAL — kicking async daemon (blind-spot kick)"
+        kick_async_daemon
+        # Reset the blackout clock so we don't kick on every subsequent
+        # probe-fail iteration; the next kick fires after another full backoff.
+        write_state_field probe_fail_since "$now"
+        write_state_field probe_fail_archived_at_start "${ARCHIVED_COUNT:-0}"
+      fi
+    fi
     return 0
   fi
+
+  # Probe succeeded — reset the consecutive-failure tracking.
+  write_state_field probe_fail_since 0
+  write_state_field probe_fail_archived_at_start 0
   LAST_LAG_REPO_MAX="$catalog_max"
 
   # Lag (postgres handoff minus catalog max). 0 if either side missing.

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -2000,7 +2000,17 @@ EOF
   # closing WAL reaches the NEW path on the next archive_command (~60s),
   # not after a 10-min gap-recovery loop pkill. Without this, the daemon
   # holds the OLD repo1-path for its lifetime and self-heal stalls.
-  if ! docker logs "$name" 2>&1 | grep -q "wal-regression: kicking async daemon"; then
+  # Poll briefly: between "migrating" and "kicking" the watcher runs a
+  # psql round-trip + several state writes, so the kick log can lag the
+  # migration log by a few seconds on a loaded CI runner.
+  local kick_deadline=$(($(date +%s) + 15)) hit_kick=0
+  while [ "$(date +%s)" -lt "$kick_deadline" ]; do
+    if docker logs "$name" 2>&1 | grep -q "wal-regression: kicking async daemon"; then
+      hit_kick=1; break
+    fi
+    sleep 1
+  done
+  if [ "$hit_kick" != "1" ]; then
     ko t_watcher_wal_regression_async_spool_probe "migrate did not kick the async daemon (kick log line missing)"
     fail_dump t_watcher_wal_regression_async_spool_probe "$name"
     return


### PR DESCRIPTION
## What

When S3 (Tigris) is completely unreachable, `probe_catalog_max` times out on every watcher iteration. `LAST_OBSERVED_LAG_SEGMENTS` stays stale, the lag-threshold path never fires, and a hung async worker is never killed — even though the spool keeps accumulating WAL behind a queue-max-trip.

## Incident

**2026-05-28**: Two services on `t3.storageapi.dev` had the async worker wedged for ~6h. The watcher reported `lag=0` throughout because `pgbackrest info` also hits the same Tigris endpoint, and it was timing out too. The normal lag detection requires working S3 reads — when S3 is dark for both reads and writes, the watcher is blind.

## Fix

Track consecutive probe-failure duration in state (`probe_fail_since`, `probe_fail_archived_at_start`). When:
- Blackout duration ≥ `GAP_RECOVERY_BACKOFF_SECONDS` (default 600s), AND
- `ARCHIVED_COUNT` grew since blackout started (postgres is still handing WAL to the spool)

→ `pkill archive-push:async`. The hung S3 connection is torn down; `archive_command` respawns the async process on the next WAL switch; uploads retry once S3 recovers.

The clock resets after each kick (next kick after another full backoff). `probe_fail_since` resets to 0 on the first successful probe so normal lag detection resumes cleanly.

Does NOT touch the gap marker or enter the full gap-recovery state machine — this is purely a "kick the stuck process" heuristic for total-S3-outage scenarios.

Counterpart for postgres-ha: https://github.com/railwayapp-templates/postgres-ha/pull/51

## Test plan
- [ ] Normal: probes succeed → `probe_fail_since` reset to 0, no spurious kicks
- [ ] Simulated total-S3-outage + WAL advancing: after `GAP_RECOVERY_BACKOFF_SECONDS`, watcher logs "blind-spot kick" and `pkill archive-push:async` fires
- [ ] Probe fails but `ARCHIVED_COUNT` not advancing (DB idle): no kick
- [ ] S3 recovers mid-blackout: probe succeeds, state resets, normal lag detection resumes