### PR TITLE
fix(wrapper): strip https:// prefix from WAL_ARCHIVE_ENDPOINT in pgbackrest.conf

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -497,6 +497,13 @@ render_pgbackrest_conf() {
     retention_block="repo1-retention-full=${retention_full}"$'\n'"repo1-retention-diff=${retention_diff}"$'\n'
   fi
 
+  # pgBackRest's repo1-s3-endpoint config option expects a bare hostname; it
+  # rejects values with a protocol prefix (https:// or http://) and exits
+  # immediately with a config validation error. Strip the prefix here so
+  # BYOB customers who set WAL_ARCHIVE_ENDPOINT=https://... get a valid conf.
+  local wal_archive_endpoint_stripped="${WAL_ARCHIVE_ENDPOINT#https://}"
+  wal_archive_endpoint_stripped="${wal_archive_endpoint_stripped#http://}"
+
   cat > "$PGBACKREST_CONF_FILE" <<EOF
 [global]
 repo1-type=s3
@@ -504,7 +511,7 @@ repo1-s3-bucket=${WAL_ARCHIVE_BUCKET}
 repo1-s3-key=${WAL_ARCHIVE_KEY}
 repo1-s3-key-secret=${WAL_ARCHIVE_SECRET}
 repo1-s3-region=${WAL_ARCHIVE_REGION}
-repo1-s3-endpoint=${WAL_ARCHIVE_ENDPOINT}
+repo1-s3-endpoint=${wal_archive_endpoint_stripped}
 repo1-s3-uri-style=${WAL_ARCHIVE_S3_URI_STYLE:-path}
 repo1-path=${WAL_ARCHIVE_PATH:-/pgbackrest}
 log-level-console=info


### PR DESCRIPTION
## Summary

- Strips `https://` and `http://` from `WAL_ARCHIVE_ENDPOINT` before writing to `pgbackrest.conf`

## Root cause

pgBackRest's `repo1-s3-endpoint` config option expects a bare hostname. If the value includes a protocol scheme (`https://hostname`), pgBackRest exits immediately with a config validation error — sub-second, before any network connection.

BYOB customers often set `WAL_ARCHIVE_ENDPOINT=https://...` (full R2/S3 URL). The wrapper was writing it verbatim, causing all `pgbackrest info` and `pgbackrest backup` calls to fail while `archive-push` appeared healthy (async mode: foreground writes to local spool → returns 0 before any S3 connection attempt).

Net effect: catalog verification never succeeds → gap recovery never runs → no diffs or fulls ever taken past the initial full, even if periodic backups are enabled.

**Note:** the env-var form (`PGBACKREST_REPO1_S3_ENDPOINT`) used by backboard's shell probe is more lenient and accepts `https://`; the conf-file form does not. This caused the backboard probe to succeed while the in-container watcher was silently broken.

## Test plan

- [ ] BYOB R2 customer with `https://` endpoint redeployed → pgbackrest info succeeds → catalog check passes → periodic diffs/fulls resume
- [ ] Railway-managed bucket path unaffected (no `://` in endpoint)
- [ ] Endpoint without protocol prefix passes through unchanged