### PR TITLE
fix(pitr): self-heal catalog-verify rc=2 deadlock in backup watcher

### DIFF
--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -325,13 +325,15 @@ catalog_check_backup() {
   rc=$?
   [ "$rc" -ne 0 ] && return 2
   [ -z "$info_out" ] && return 2
-  if printf '%s' "$info_out" | jq -e '[.[]?.backup[]? | select(.type == "full")] | length > 0' >/dev/null 2>&1; then
-    return 0
-  fi
-  local jq_rc=$?
-  # jq exit 1 = filter evaluated to false → no full present (conclusive).
-  # Any other rc (2 = parse error, 3+ = other) → treat as inconclusive.
-  [ "$jq_rc" -eq 1 ] && return 1
+  # jq -r outputs "true" or "false"; || handles parse errors (jq rc=2+).
+  # Avoid capturing $? after an if...fi block — bash sets $? to 0 when the
+  # condition is false and there is no else branch, masking jq's rc=1.
+  local has_full
+  has_full=$(printf '%s' "$info_out" \
+    | jq -r '[.[]?.backup[]? | select(.type == "full")] | length > 0' 2>/dev/null) \
+    || return 2
+  [ "$has_full" = "true" ]  && return 0
+  [ "$has_full" = "false" ] && return 1
   return 2
 }
 

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -107,6 +107,21 @@ DIFF_INTERVAL_HOURS="${WAL_BACKUP_DIFF_INTERVAL_HOURS:-24}"
 # fresh state). Default: 3600 (1 hour).
 CATALOG_VERIFY_INTERVAL_SECONDS="${WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS:-3600}"
 
+# Catalog-verify deadlock breaker (seconds). catalog_check_backup returns rc=2
+# (inconclusive) for ANY non-zero `pgbackrest info` — S3 outage, auth failure,
+# OR a backup.info that pgBackRest rejects after an interrupted first full
+# (redeploy racing the initial backup). The verify path treats rc=2 as
+# transient and never clears the stale last_full_at, so the self-heal that
+# re-takes the first full (rc=1 path) can never fire: WAL keeps archiving while
+# fullCount stays 0 forever, surfaced only as LOG_SPEW. Distinguishing a real
+# S3 outage from a permanent rejected-catalog: during an outage archiving also
+# stops, so ARCHIVED_COUNT is flat; a rejected backup.info keeps WAL flowing
+# (heartbeat → archive_timeout → push) and ARCHIVED_COUNT climbs. When rc=2 has
+# persisted this long AND ARCHIVED_COUNT grew over the window, treat the catalog
+# as broken (not S3 down): log the real `pgbackrest info` stderr, run
+# stanza-create, and clear last_full_at to re-fire NEEDS_INITIAL_BACKUP.
+CATALOG_VERIFY_SELFHEAL_AFTER_SECONDS="${WAL_BACKUP_CATALOG_VERIFY_SELFHEAL_AFTER_SECONDS:-1800}"
+
 # LSN-lag detection — see file header. Detection runs every iteration (no
 # probe throttle): `pgbackrest info` is local-to-S3 round-trip, ~50-200ms,
 # cheap enough to call every minute. 32 segments ≈ 512 MiB — far enough above
@@ -134,6 +149,16 @@ log() { echo "pgbackrest-watcher: $*"; }
 #   last_diff_at=<epoch>             — last successful diff/incr backup
 #   last_full_failed_count=<int>     — pg_stat_archiver.failed_count after last full
 #   last_catalog_verify_at=<epoch>   — last S3 catalog probe (catalog_check_backup)
+#   catalog_verify_inconclusive_since=<epoch>
+#                                    — epoch when catalog_check_backup first
+#                                      returned rc=2 in the current consecutive
+#                                      run (0 = last verify was conclusive).
+#                                      Reset to 0 on any rc=0/rc=1. Drives the
+#                                      deadlock breaker in decide_action.
+#   catalog_verify_inconclusive_archived_at_start=<int>
+#                                    — ARCHIVED_COUNT when the current rc=2 run
+#                                      began; growth since proves WAL is still
+#                                      reaching S3 (catalog broken, not S3 down).
 #   last_lag_detected_at=<epoch>     — when current gap-recovery cycle started
 #   catalog_max_at_detection=<wal>   — catalog max segment at detection (recovery
 #                                       proof is "current catalog_max > this")
@@ -307,6 +332,18 @@ catalog_check_backup() {
   # Any other rc (2 = parse error, 3+ = other) → treat as inconclusive.
   [ "$jq_rc" -eq 1 ] && return 1
   return 2
+}
+
+# Re-runs the catalog probe with stderr captured and logs the exit code + a
+# short tail of the error. catalog_check_backup swallows stderr (2>/dev/null)
+# so a permanently-rejected backup.info is invisible in container logs — this
+# is called only when the deadlock breaker trips, so the cost of a second
+# `pgbackrest info` is paid at most once per self-heal, not every poll.
+log_catalog_probe_error() {
+  local err rc
+  err=$(timeout 60 pgbackrest --stanza=main --repo=1 info --output=json 2>&1 >/dev/null)
+  rc=$?
+  log "catalog probe diagnostic: pgbackrest info exited rc=${rc}; stderr: $(printf '%s' "$err" | tr '\n' ' ' | cut -c1-300)"
 }
 
 # LAST_OBSERVED_LAG_SEGMENTS / LAST_LAG_REPO_MAX surface the most recent
@@ -1101,11 +1138,41 @@ decide_action() {
     # iteration retries instead of locking out the verify for an hour.
     if [ "$_crc" -eq 0 ]; then
       write_state_field last_catalog_verify_at "$now"
+      write_state_field catalog_verify_inconclusive_since 0
       log "catalog verified — full backup present in S3"
     elif [ "$_crc" -eq 2 ]; then
-      log "catalog check inconclusive (S3 unreachable or stanza not yet created); skipping"
+      # Inconclusive. Track how long this consecutive rc=2 run has lasted and
+      # whether archiving kept advancing through it. A real S3 outage freezes
+      # both the probe AND archive-push, so ARCHIVED_COUNT stays flat; a
+      # backup.info pgBackRest rejects (interrupted first full) keeps WAL
+      # flowing while the probe stays broken. Only the latter is a deadlock we
+      # can break — re-taking the first full is futile if S3 is actually down.
+      local incon_since incon_archived
+      incon_since=$(read_state catalog_verify_inconclusive_since); : "${incon_since:=0}"
+      incon_archived=$(read_state catalog_verify_inconclusive_archived_at_start); : "${incon_archived:=0}"
+      if [ "$incon_since" -eq 0 ]; then
+        write_state_field catalog_verify_inconclusive_since "$now"
+        write_state_field catalog_verify_inconclusive_archived_at_start "${ARCHIVED_COUNT:-0}"
+        log "catalog check inconclusive (S3 unreachable or backup.info not readable); skipping (run started)"
+      else
+        local incon_for=$(( now - incon_since ))
+        local archived_grew=0
+        [ "${ARCHIVED_COUNT:-0}" -gt "$incon_archived" ] && archived_grew=1
+        if [ "$incon_for" -ge "$CATALOG_VERIFY_SELFHEAL_AFTER_SECONDS" ] && [ "$archived_grew" -eq 1 ]; then
+          log "catalog check inconclusive for ${incon_for}s while WAL keeps archiving (archived ${incon_archived}→${ARCHIVED_COUNT:-0}) — backup.info is broken, not S3 down; self-healing"
+          log_catalog_probe_error
+          pgbackrest --stanza=main stanza-create 2>&1 | while IFS= read -r _l; do log "stanza-create: ${_l}"; done
+          write_state_field catalog_verify_inconclusive_since 0
+          write_state_field last_catalog_verify_at "$now"
+          log "clearing last_full_at to re-trigger initial full (was last_full=${last_full})"
+          write_state_field last_full_at ""
+          DECIDED_ACTION="full"; return 0
+        fi
+        log "catalog check inconclusive (S3 unreachable or backup.info not readable); skipping (inconclusive ${incon_for}s, archived_grew=${archived_grew})"
+      fi
     else
       write_state_field last_catalog_verify_at "$now"
+      write_state_field catalog_verify_inconclusive_since 0
       log "catalog shows no full backup despite local state (last_full=${last_full}); clearing last_full_at to trigger new full"
       write_state_field last_full_at ""
       DECIDED_ACTION="full"; return 0

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -107,20 +107,14 @@ DIFF_INTERVAL_HOURS="${WAL_BACKUP_DIFF_INTERVAL_HOURS:-24}"
 # fresh state). Default: 3600 (1 hour).
 CATALOG_VERIFY_INTERVAL_SECONDS="${WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS:-3600}"
 
-# Catalog-verify deadlock breaker (seconds). catalog_check_backup returns rc=2
-# (inconclusive) for ANY non-zero `pgbackrest info` — S3 outage, auth failure,
-# OR a backup.info that pgBackRest rejects after an interrupted first full
-# (redeploy racing the initial backup). The verify path treats rc=2 as
-# transient and never clears the stale last_full_at, so the self-heal that
-# re-takes the first full (rc=1 path) can never fire: WAL keeps archiving while
-# fullCount stays 0 forever, surfaced only as LOG_SPEW. Distinguishing a real
-# S3 outage from a permanent rejected-catalog: during an outage archiving also
-# stops, so ARCHIVED_COUNT is flat; a rejected backup.info keeps WAL flowing
-# (heartbeat → archive_timeout → push) and ARCHIVED_COUNT climbs. When rc=2 has
-# persisted this long AND ARCHIVED_COUNT grew over the window, treat the catalog
-# as broken (not S3 down): log the real `pgbackrest info` stderr, run
-# stanza-create, and clear last_full_at to re-fire NEEDS_INITIAL_BACKUP.
-CATALOG_VERIFY_SELFHEAL_AFTER_SECONDS="${WAL_BACKUP_CATALOG_VERIFY_SELFHEAL_AFTER_SECONDS:-1800}"
+# Minimum spacing between full-backup *attempts* (seconds). NEEDS_INITIAL_BACKUP
+# and the catalog-verify rc=1 self-heal both clear/leave last_full_at empty,
+# which makes decide_action want a full every poll — so a full that keeps
+# FAILING (S3 down, broken backup.info) would hammer S3 with full-sized pushes
+# every ~60s. last_full_attempt_at is stamped at the start of each full, and
+# decide_action suppresses the next full until this much time has passed. The
+# first attempt on a fresh enable is never delayed (no prior attempt recorded).
+FULL_RETRY_BACKOFF_SECONDS="${WAL_BACKUP_FULL_RETRY_BACKOFF_SECONDS:-600}"
 
 # LSN-lag detection — see file header. Detection runs every iteration (no
 # probe throttle): `pgbackrest info` is local-to-S3 round-trip, ~50-200ms,
@@ -149,16 +143,12 @@ log() { echo "pgbackrest-watcher: $*"; }
 #   last_diff_at=<epoch>             — last successful diff/incr backup
 #   last_full_failed_count=<int>     — pg_stat_archiver.failed_count after last full
 #   last_catalog_verify_at=<epoch>   — last S3 catalog probe (catalog_check_backup)
-#   catalog_verify_inconclusive_since=<epoch>
-#                                    — epoch when catalog_check_backup first
-#                                      returned rc=2 in the current consecutive
-#                                      run (0 = last verify was conclusive).
-#                                      Reset to 0 on any rc=0/rc=1. Drives the
-#                                      deadlock breaker in decide_action.
-#   catalog_verify_inconclusive_archived_at_start=<int>
-#                                    — ARCHIVED_COUNT when the current rc=2 run
-#                                      began; growth since proves WAL is still
-#                                      reaching S3 (catalog broken, not S3 down).
+#   last_full_attempt_at=<epoch>     — epoch a full backup was last *attempted*
+#                                      (stamped at the start of run_backup full,
+#                                      success or fail). decide_action spaces
+#                                      successive full attempts at least
+#                                      FULL_RETRY_BACKOFF_SECONDS apart so a
+#                                      failing full doesn't hammer S3 every poll.
 #   last_lag_detected_at=<epoch>     — when current gap-recovery cycle started
 #   catalog_max_at_detection=<wal>   — catalog max segment at detection (recovery
 #                                       proof is "current catalog_max > this")
@@ -264,6 +254,12 @@ is_standby() {
 run_backup() {
   local type="$1"
   log "running pgbackrest backup --type=$type"
+  # Stamp the attempt time up front (success or fail) so decide_action's
+  # FULL_RETRY_BACKOFF_SECONDS spacing applies to a full that keeps failing,
+  # rather than re-firing it every poll.
+  if [ "$type" = "full" ]; then
+    write_state_field last_full_attempt_at "$(date +%s)"
+  fi
   # --repo=1 scopes backup + post-backup expire to this service's own bucket.
   # On a fork repo2 is source's read-only bucket; without the pin pgBackRest
   # would default to writing the new base into both repos.
@@ -1110,79 +1106,79 @@ decide_action() {
   # loudly instead of producing an unrestorable base — no need to gate on
   # "archive-push has worked once". Earlier the gate cost 60-120s of dead
   # time on idle DBs (heartbeat → archive_timeout → archive-push cycle).
+  # Full-attempt backoff. A full that keeps FAILING (S3 down, broken
+  # backup.info) would otherwise be re-attempted every poll once last_full is
+  # empty — hammering S3 with full-sized pushes. last_full_attempt_at is
+  # stamped at the START of every full in run_backup, so successive *attempts*
+  # are spaced at least FULL_RETRY_BACKOFF_SECONDS apart. The first attempt on
+  # a fresh enable fires immediately (no prior attempt recorded), so a healthy
+  # initial full is never delayed.
+  local last_full_attempt full_attempt_ok=1
+  last_full_attempt=$(read_state last_full_attempt_at)
+  if [ -n "$last_full_attempt" ] \
+     && [ $((now - last_full_attempt)) -lt "$FULL_RETRY_BACKOFF_SECONDS" ]; then
+    full_attempt_ok=0
+  fi
+
   if [ -z "$last_full" ]; then
-    DECIDED_ACTION="full"; return 0
+    if [ "$full_attempt_ok" -eq 1 ]; then DECIDED_ACTION="full"; return 0; fi
+    DECIDED_ACTION=""; return 0
   fi
 
   # Catalog verification — periodically confirm S3 actually has a full backup.
   # Catches divergence between local state and S3 reality: the backup command
   # may have returned exit 0 without committing catalog metadata (S3 partial
   # write, stanza-create race), or a volume survived a redeployment with stale
-  # state pointing at a different stanza/sysid path. Only clears state when the
-  # catalog explicitly confirms "no backup" (exit 0 + empty backup list); an
-  # unreachable S3 or missing stanza returns non-zero and is treated as
-  # inconclusive so we don't burn a full on every transient S3 hiccup.
+  # state pointing at a different stanza/sysid path.
+  #
+  # Three outcomes (catalog_check_backup):
+  #   rc=0 full present     → nothing to do.
+  #   rc=1 no full present   → conclusive (info succeeded, empty backup list).
+  #                            Clear last_full_at so NEEDS_INITIAL re-takes the
+  #                            full. Safe to act on a single rc=1 — it's a
+  #                            successful probe, so it can't be a transient.
+  #   rc=2 inconclusive      → info errored (S3 hiccup, auth, or a backup.info
+  #                            pgBackRest rejects). Don't clear last_full (that
+  #                            would burn a full on every transient hiccup, and
+  #                            transient info errors are common). Instead log
+  #                            the otherwise-swallowed stderr and run an
+  #                            idempotent stanza-create — cheap, and it repairs
+  #                            a missing/half-written backup.info so the *next*
+  #                            verify returns rc=1 and the clear path takes
+  #                            over. A truly-unreachable S3 makes stanza-create
+  #                            a no-op; nothing is burned.
+  #
+  # last_catalog_verify_at is stamped on ALL outcomes (including rc=2), so the
+  # probe — and the stanza-create — run at most once per interval rather than
+  # every poll. That bound is also what stops the rc=2 case from spewing a log
+  # line every 60s.
   local last_catalog_verify
   last_catalog_verify=$(read_state last_catalog_verify_at)
-  local needs_verify=0
-  if [ -z "$last_catalog_verify" ] || [ $((now - last_catalog_verify)) -ge "$CATALOG_VERIFY_INTERVAL_SECONDS" ]; then
-    needs_verify=1
-  fi
-  if [ "$needs_verify" -eq 1 ]; then
+  if [ "$CATALOG_VERIFY_INTERVAL_SECONDS" -gt 0 ] \
+     && { [ -z "$last_catalog_verify" ] || [ $((now - last_catalog_verify)) -ge "$CATALOG_VERIFY_INTERVAL_SECONDS" ]; }; then
     log "verifying S3 catalog has full backup"
     catalog_check_backup
     local _crc=$?
-    # Stamp the verify timestamp only on conclusive results (rc=0 full
-    # present, rc=1 no full present). On rc=2 (inconclusive — S3 hiccup,
-    # stanza not yet created) leave the timestamp untouched so the next
-    # iteration retries instead of locking out the verify for an hour.
+    write_state_field last_catalog_verify_at "$now"
     if [ "$_crc" -eq 0 ]; then
-      write_state_field last_catalog_verify_at "$now"
-      write_state_field catalog_verify_inconclusive_since 0
       log "catalog verified — full backup present in S3"
-    elif [ "$_crc" -eq 2 ]; then
-      # Inconclusive. Track how long this consecutive rc=2 run has lasted and
-      # whether archiving kept advancing through it. A real S3 outage freezes
-      # both the probe AND archive-push, so ARCHIVED_COUNT stays flat; a
-      # backup.info pgBackRest rejects (interrupted first full) keeps WAL
-      # flowing while the probe stays broken. Only the latter is a deadlock we
-      # can break — re-taking the first full is futile if S3 is actually down.
-      local incon_since incon_archived
-      incon_since=$(read_state catalog_verify_inconclusive_since); : "${incon_since:=0}"
-      incon_archived=$(read_state catalog_verify_inconclusive_archived_at_start); : "${incon_archived:=0}"
-      if [ "$incon_since" -eq 0 ]; then
-        write_state_field catalog_verify_inconclusive_since "$now"
-        write_state_field catalog_verify_inconclusive_archived_at_start "${ARCHIVED_COUNT:-0}"
-        log "catalog check inconclusive (S3 unreachable or backup.info not readable); skipping (run started)"
-      else
-        local incon_for=$(( now - incon_since ))
-        local archived_grew=0
-        [ "${ARCHIVED_COUNT:-0}" -gt "$incon_archived" ] && archived_grew=1
-        if [ "$incon_for" -ge "$CATALOG_VERIFY_SELFHEAL_AFTER_SECONDS" ] && [ "$archived_grew" -eq 1 ]; then
-          log "catalog check inconclusive for ${incon_for}s while WAL keeps archiving (archived ${incon_archived}→${ARCHIVED_COUNT:-0}) — backup.info is broken, not S3 down; self-healing"
-          log_catalog_probe_error
-          pgbackrest --stanza=main stanza-create 2>&1 | while IFS= read -r _l; do log "stanza-create: ${_l}"; done
-          write_state_field catalog_verify_inconclusive_since 0
-          write_state_field last_catalog_verify_at "$now"
-          log "clearing last_full_at to re-trigger initial full (was last_full=${last_full})"
-          write_state_field last_full_at ""
-          DECIDED_ACTION="full"; return 0
-        fi
-        log "catalog check inconclusive (S3 unreachable or backup.info not readable); skipping (inconclusive ${incon_for}s, archived_grew=${archived_grew})"
-      fi
-    else
-      write_state_field last_catalog_verify_at "$now"
-      write_state_field catalog_verify_inconclusive_since 0
+    elif [ "$_crc" -eq 1 ]; then
       log "catalog shows no full backup despite local state (last_full=${last_full}); clearing last_full_at to trigger new full"
       write_state_field last_full_at ""
-      DECIDED_ACTION="full"; return 0
+      if [ "$full_attempt_ok" -eq 1 ]; then DECIDED_ACTION="full"; return 0; fi
+      DECIDED_ACTION=""; return 0
+    else
+      log "catalog check inconclusive (pgbackrest info errored); logging probe error + running idempotent stanza-create"
+      log_catalog_probe_error
+      pgbackrest --stanza=main stanza-create 2>&1 | while IFS= read -r _l; do log "stanza-create: ${_l}"; done
     fi
   fi
 
   # Periodic full. FULL_INTERVAL_SECONDS=0 disables the periodic full while
   # still allowing NEEDS_INITIAL_BACKUP (above) and gap-recovery to fire.
   if [ "$FULL_INTERVAL_SECONDS" -gt 0 ] \
-     && [ "$now" -ge $((last_full + FULL_INTERVAL_SECONDS)) ]; then
+     && [ "$now" -ge $((last_full + FULL_INTERVAL_SECONDS)) ] \
+     && [ "$full_attempt_ok" -eq 1 ]; then
     DECIDED_ACTION="full"; return 0
   fi
 

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -347,6 +347,22 @@ log_catalog_probe_error() {
   log "catalog probe diagnostic: pgbackrest info exited rc=${rc}; stderr: $(printf '%s' "$err" | tr '\n' ' ' | cut -c1-300)"
 }
 
+# Runs pgbackrest stanza-create every watcher iteration. stanza-create is
+# idempotent: when the stanza already exists and backup.info is valid, it does
+# a couple of S3 reads and exits 0 (silent). It only writes when backup.info is
+# missing or corrupt — exactly the rc=2 deadlock scenario. Running it every
+# iteration decouples stanza repair from the catalog-verify interval so a broken
+# stanza is fixed on the next poll (~60s) rather than waiting up to
+# CATALOG_VERIFY_INTERVAL_SECONDS (default 1h). Logs only on failure.
+stanza_create_step() {
+  local out rc
+  out=$(timeout 60 pgbackrest --stanza=main stanza-create 2>&1)
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    log "stanza-create: exited rc=${rc}; $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-300)"
+  fi
+}
+
 # LAST_OBSERVED_LAG_SEGMENTS / LAST_LAG_REPO_MAX surface the most recent
 # observation to watcher_iteration's diagnostic log line.
 LAST_OBSERVED_LAG_SEGMENTS=0
@@ -1173,9 +1189,8 @@ decide_action() {
       if [ "$full_attempt_ok" -eq 1 ]; then DECIDED_ACTION="full"; return 0; fi
       DECIDED_ACTION=""; return 0
     else
-      log "catalog check inconclusive (pgbackrest info errored); logging probe error + running idempotent stanza-create"
+      log "catalog check inconclusive (pgbackrest info errored); logging probe error (stanza-create ran this iteration)"
       log_catalog_probe_error
-      pgbackrest --stanza=main stanza-create 2>&1 | while IFS= read -r _l; do log "stanza-create: ${_l}"; done
     fi
   fi
 
@@ -1257,6 +1272,12 @@ watcher_iteration() {
   # segsize. Failure leaves the previous value in place; the watcher
   # never sees an arithmetic crash from a missing global.
   refresh_wal_segment_size || true
+
+  # Idempotent stanza health — every iteration. A no-op (2 S3 reads) when the
+  # stanza is healthy; repairs a missing or corrupt backup.info on the spot.
+  # Running every iteration means a broken stanza is fixed on the next poll
+  # rather than waiting up to CATALOG_VERIFY_INTERVAL_SECONDS.
+  stanza_create_step
 
   # Gap-recovery state machine — detects WAL/catalog divergence and drives
   # the kick-and-diff sequence. Runs every iteration; pgbackrest info is

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -107,13 +107,15 @@ DIFF_INTERVAL_HOURS="${WAL_BACKUP_DIFF_INTERVAL_HOURS:-24}"
 # fresh state). Default: 3600 (1 hour).
 CATALOG_VERIFY_INTERVAL_SECONDS="${WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS:-3600}"
 
-# Minimum spacing between full-backup *attempts* (seconds). NEEDS_INITIAL_BACKUP
-# and the catalog-verify rc=1 self-heal both clear/leave last_full_at empty,
-# which makes decide_action want a full every poll — so a full that keeps
-# FAILING (S3 down, broken backup.info) would hammer S3 with full-sized pushes
-# every ~60s. last_full_attempt_at is stamped at the start of each full, and
-# decide_action suppresses the next full until this much time has passed. The
-# first attempt on a fresh enable is never delayed (no prior attempt recorded).
+# Minimum spacing between retries of a FAILING full backup (seconds).
+# NEEDS_INITIAL_BACKUP and the catalog-verify rc=1 self-heal both leave
+# last_full_at empty, which makes decide_action want a full every poll — so a
+# full that keeps failing (S3 down, broken backup.info) would hammer S3 with
+# full-sized pushes every ~60s. run_backup records last_full_failure_at only on
+# a failed full (and clears it on success); decide_action suppresses the next
+# full until this elapses. A full that follows a *deliberate* last_full_at clear
+# (fresh enable, rc=1 self-heal, WAL_REGRESSION migrate) carries no fresh
+# failure marker, so it fires immediately — only failing retries are throttled.
 FULL_RETRY_BACKOFF_SECONDS="${WAL_BACKUP_FULL_RETRY_BACKOFF_SECONDS:-600}"
 
 # LSN-lag detection — see file header. Detection runs every iteration (no
@@ -143,12 +145,13 @@ log() { echo "pgbackrest-watcher: $*"; }
 #   last_diff_at=<epoch>             — last successful diff/incr backup
 #   last_full_failed_count=<int>     — pg_stat_archiver.failed_count after last full
 #   last_catalog_verify_at=<epoch>   — last S3 catalog probe (catalog_check_backup)
-#   last_full_attempt_at=<epoch>     — epoch a full backup was last *attempted*
-#                                      (stamped at the start of run_backup full,
-#                                      success or fail). decide_action spaces
-#                                      successive full attempts at least
-#                                      FULL_RETRY_BACKOFF_SECONDS apart so a
-#                                      failing full doesn't hammer S3 every poll.
+#   last_full_failure_at=<epoch>     — epoch a full backup last FAILED (written
+#                                      in run_backup on a failed full, cleared
+#                                      on success). decide_action throttles
+#                                      retries of a failing full to one per
+#                                      FULL_RETRY_BACKOFF_SECONDS; a full after a
+#                                      deliberate last_full_at clear is never
+#                                      delayed (no fresh failure marker).
 #   last_lag_detected_at=<epoch>     — when current gap-recovery cycle started
 #   catalog_max_at_detection=<wal>   — catalog max segment at detection (recovery
 #                                       proof is "current catalog_max > this")
@@ -254,12 +257,6 @@ is_standby() {
 run_backup() {
   local type="$1"
   log "running pgbackrest backup --type=$type"
-  # Stamp the attempt time up front (success or fail) so decide_action's
-  # FULL_RETRY_BACKOFF_SECONDS spacing applies to a full that keeps failing,
-  # rather than re-firing it every poll.
-  if [ "$type" = "full" ]; then
-    write_state_field last_full_attempt_at "$(date +%s)"
-  fi
   # --repo=1 scopes backup + post-backup expire to this service's own bucket.
   # On a fork repo2 is source's read-only bucket; without the pin pgBackRest
   # would default to writing the new base into both repos.
@@ -277,6 +274,10 @@ run_backup() {
   fi
 
   if [ "$exit_code" -ne 0 ]; then
+    # Record the failure time only for fulls so decide_action can space
+    # repeated initial/periodic full *retries* (FULL_RETRY_BACKOFF_SECONDS)
+    # without hammering S3 every poll. Diffs aren't gated.
+    [ "$type" = "full" ] && write_state_field last_full_failure_at "$(date +%s)"
     log "backup --type=$type failed (will retry on next poll)"
     return 1
   fi
@@ -286,6 +287,10 @@ run_backup() {
     full)
       write_state_field last_full_at "$now"
       write_state_field last_diff_at "$now"
+      # Clear the failure marker so a subsequent deliberate last_full_at clear
+      # (catalog-verify rc=1, WAL_REGRESSION migrate) re-fires the full
+      # immediately rather than inheriting this run's backoff.
+      write_state_field last_full_failure_at ""
       # clear_gap_recovery_state refreshes pg_stat_archiver and writes
       # last_full_failed_count itself — folds failures-during-backup into
       # the anchor so the next iteration doesn't re-fire detection.
@@ -1106,17 +1111,17 @@ decide_action() {
   # loudly instead of producing an unrestorable base — no need to gate on
   # "archive-push has worked once". Earlier the gate cost 60-120s of dead
   # time on idle DBs (heartbeat → archive_timeout → archive-push cycle).
-  # Full-attempt backoff. A full that keeps FAILING (S3 down, broken
-  # backup.info) would otherwise be re-attempted every poll once last_full is
-  # empty — hammering S3 with full-sized pushes. last_full_attempt_at is
-  # stamped at the START of every full in run_backup, so successive *attempts*
-  # are spaced at least FULL_RETRY_BACKOFF_SECONDS apart. The first attempt on
-  # a fresh enable fires immediately (no prior attempt recorded), so a healthy
-  # initial full is never delayed.
-  local last_full_attempt full_attempt_ok=1
-  last_full_attempt=$(read_state last_full_attempt_at)
-  if [ -n "$last_full_attempt" ] \
-     && [ $((now - last_full_attempt)) -lt "$FULL_RETRY_BACKOFF_SECONDS" ]; then
+  # Full-retry backoff. A full that keeps FAILING (S3 down, broken backup.info)
+  # would otherwise be re-attempted every poll while last_full is empty —
+  # hammering S3 with full-sized pushes. run_backup records last_full_failure_at
+  # only when a full FAILS (and clears it on success), so this gates *retries*
+  # of a failing full without ever delaying a full that follows a deliberate
+  # last_full_at clear (fresh enable, catalog-verify rc=1, WAL_REGRESSION
+  # migrate — all of which leave no fresh failure marker).
+  local last_full_failure full_attempt_ok=1
+  last_full_failure=$(read_state last_full_failure_at)
+  if [ -n "$last_full_failure" ] \
+     && [ $((now - last_full_failure)) -lt "$FULL_RETRY_BACKOFF_SECONDS" ]; then
     full_attempt_ok=0
   fi
 

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -3384,25 +3384,22 @@ t_chain_restore_r1_to_r2() {
   docker volume rm "$src_vol" "$r1_vol" "$r2_vol" >/dev/null
 }
 
-# M2. Catalog-verify self-heal (rc=1 path). A volume can survive with
-# last_full_at set in local state while S3 has lost the full (catalog
-# wiped / restored from a backup that predates the full / redeploy that
-# dropped the bucket). NEEDS_INITIAL_BACKUP only fires on empty state, so
-# without catalog verification the watcher takes diffs against a phantom
-# full forever. This test reproduces it by keeping the volume but wiping
-# S3, then asserts the periodic verify sees "no full present", clears
-# last_full_at, and a fresh full is taken.
+# M2. Catalog-verify self-heal. local state can carry last_full_at while S3
+# has lost the full (catalog wiped, redeploy that dropped the bucket, restore
+# from before the full). NEEDS_INITIAL_BACKUP only fires on empty state, so
+# without catalog verification the watcher rides a phantom full forever. This
+# wipes the catalog out from under the running container (volume keeps
+# last_full_at), then asserts the verify repairs the stanza (rc=2 →
+# stanza-create) and on the next cycle sees "no full present" (rc=1), clears
+# last_full_at, and takes a fresh full.
 t_catalog_verify_deadlock_selfheals() {
   local name=t-verify-deadlock-${PG_VERSION}
   local vol=${name}-vol
   reset_bucket
   new_volume "$vol"
   docker rm -f "$name" >/dev/null 2>&1 || true
-  # Fast verify + short full-retry backoff so the self-heal completes inside
-  # the test window rather than the 1h / 10min prod defaults.
   run_archiving_pg_fast_watcher "$name" "$vol" \
-    -e WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS=5 \
-    -e WAL_BACKUP_FULL_RETRY_BACKOFF_SECONDS=5
+    -e WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS=5
   wait_for_pg "$name" || { ko t_catalog_verify_deadlock_selfheals "startup"; return; }
   for _ in $(seq 1 15); do
     docker logs "$name" 2>&1 | grep -q "stanza-create completed" && break
@@ -3411,34 +3408,38 @@ t_catalog_verify_deadlock_selfheals() {
   docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null
   wait_for_watcher_backup "$name" full 60 || { ko t_catalog_verify_deadlock_selfheals "no initial full"; fail_dump t_catalog_verify_deadlock_selfheals "$name"; return; }
 
-  # Reproduce the divergence: keep the volume (local state still says
-  # last_full_at=<initial full>), but wipe S3. On restart bootstrap recreates
-  # an empty stanza; last_full_at is stale so NEEDS_INITIAL won't re-fire —
-  # only the catalog-verify rc=1 path (valid stanza, zero backups) can break
-  # the deadlock. A fresh container also resets docker logs, so the assertions
-  # below only see post-restart output.
-  docker rm -f "$name" >/dev/null
-  reset_bucket
-  run_archiving_pg_fast_watcher "$name" "$vol" \
-    -e WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS=5 \
-    -e WAL_BACKUP_FULL_RETRY_BACKOFF_SECONDS=5
-  wait_for_pg "$name" || { ko t_catalog_verify_deadlock_selfheals "restart"; fail_dump t_catalog_verify_deadlock_selfheals "$name"; return; }
+  local before_full
+  before_full=$(docker logs "$name" 2>&1 | grep -c "pgbackrest-watcher: backup --type=full completed" || true)
+
+  # Wipe the catalog while the container keeps running. `rb --force` removes
+  # every object regardless of the leading-slash repo path (cluster-<sysid>
+  # lives under "/pgbackrest/…", which `rm -r local/<bucket>` can miss);
+  # recreate empty so stanza-create + archive-push can resume. Now: info finds
+  # the stanza gone (rc=2 → stanza-create), then an empty stanza (rc=1).
+  mc "mc rb --force local/${BUCKET} >/dev/null 2>&1; mc mb -p local/${BUCKET} >/dev/null"
 
   # Keep WAL moving so the post-clear full has a closing segment to archive.
-  ( for _ in $(seq 1 30); do
+  ( for _ in $(seq 1 50); do
       docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null 2>&1 || true
       sleep 2
     done ) &
   local wal_pid=$!
 
-  # Expect: verify sees no full → clears last_full_at → NEEDS_INITIAL → full.
-  if ! wait_for_watcher_backup "$name" full 90; then
-    kill "$wal_pid" 2>/dev/null || true
-    ko t_catalog_verify_deadlock_selfheals "no fresh full after S3 lost the catalog"
+  # A NEW full must land after the wipe (count grows past the initial one).
+  local deadline=$(($(date +%s) + 120)) got=0
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    local after_full
+    after_full=$(docker logs "$name" 2>&1 | grep -c "pgbackrest-watcher: backup --type=full completed" || true)
+    [ "$after_full" -gt "$before_full" ] && { got=1; break; }
+    sleep 3
+  done
+  kill "$wal_pid" 2>/dev/null || true
+
+  if [ "$got" != 1 ]; then
+    ko t_catalog_verify_deadlock_selfheals "no fresh full after catalog wipe"
     fail_dump t_catalog_verify_deadlock_selfheals "$name"
     return
   fi
-  kill "$wal_pid" 2>/dev/null || true
   if ! docker logs "$name" 2>&1 | grep -q "clearing last_full_at to trigger new full"; then
     ko t_catalog_verify_deadlock_selfheals "fresh full taken but not via the catalog-verify rc=1 clear path"
     fail_dump t_catalog_verify_deadlock_selfheals "$name"
@@ -3446,7 +3447,7 @@ t_catalog_verify_deadlock_selfheals() {
   fi
 
   ok t_catalog_verify_deadlock_selfheals
-  note "volume kept stale last_full_at + S3 wiped → catalog-verify rc=1 cleared last_full_at → fresh full taken"
+  note "catalog wiped under running container → verify rc=2 stanza-create then rc=1 cleared last_full_at → fresh full taken"
   docker rm -f "$name" >/dev/null
   docker volume rm "$vol" >/dev/null
 }

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -3400,64 +3400,48 @@ t_catalog_verify_deadlock_selfheals() {
   docker rm -f "$name" >/dev/null 2>&1 || true
   run_archiving_pg_fast_watcher "$name" "$vol" \
     -e WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS=5
+
+  # Inject the deadlock condition directly into the state file BEFORE the
+  # watcher's first real iteration. The watcher skips while pg_isready fails
+  # (postgres still starting), giving us a reliable window to write the file.
+  #
+  # Condition: last_full_at is set (non-empty) but S3 stanza is empty — exactly
+  # what happens when a container is killed mid-first-full and a new one starts
+  # on the same volume. Docker's PG_VERSION check means our extra file doesn't
+  # interfere with initdb.
+  #
+  # Flow once the watcher's first real iteration runs:
+  #   1. stanza_create_step → stanza didn't exist → creates it (empty backup.info)
+  #   2. decide_action: last_full_at set → skip NEEDS_INITIAL → run catalog-verify
+  #   3. catalog_check_backup: pgbackrest info exits 0, 0 backups → rc=1
+  #   4. "clearing last_full_at to trigger new full" → NEEDS_INITIAL fires → full
+  local fake_at; fake_at=$(( $(date +%s) - 60 ))
+  docker exec "$name" bash -c \
+    "printf 'last_full_at=${fake_at}\n' > /var/lib/postgresql/data/.pgbackrest_backup_state"
+
   wait_for_pg "$name" || { ko t_catalog_verify_deadlock_selfheals "startup"; return; }
-  for _ in $(seq 1 15); do
-    docker logs "$name" 2>&1 | grep -q "stanza-create completed" && break
-    sleep 1
-  done
-  docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null
-  wait_for_watcher_backup "$name" full 60 || { ko t_catalog_verify_deadlock_selfheals "no initial full"; fail_dump t_catalog_verify_deadlock_selfheals "$name"; return; }
 
-  local before_full
-  before_full=$(docker logs "$name" 2>&1 | grep -c "pgbackrest-watcher: backup --type=full completed" || true)
-
-  # Wipe the catalog while the container keeps running. mc bucket operations
-  # miss pgBackRest's leading-slash repo keys (/pgbackrest/cluster-<sysid>/…)
-  # so mc rb --force leaves backup.info intact. Use pgbackrest's own commands
-  # instead — they know the full key layout. Sequence while postgres is running:
-  #   stop        → creates /tmp/pgbackrest/main.stop so stanza-delete can run
-  #   stanza-delete → removes all S3 data for the stanza (no --force: that flag
-  #                   is only for when postgres is DOWN and stop wasn't run)
-  #   stanza-create → recreates an empty stanza (backup.info valid, 0 backups)
-  #   start       → removes the stop file so archiving resumes
-  # After start, the next catalog-verify (interval=5s) sees pgbackrest info exit
-  # 0 with an empty backup list → catalog_check_backup rc=1 → clears last_full_at
-  # → triggers the fresh full we're testing for.
-  docker exec "$name" bash -c "gosu postgres pgbackrest --stanza=main stop 2>&1 | tail -1 || true"
-  docker exec "$name" bash -c "gosu postgres pgbackrest --stanza=main stanza-delete 2>&1 | tail -1 || true"
-  docker exec "$name" bash -c "gosu postgres pgbackrest --stanza=main stanza-create 2>&1 | tail -1 || true"
-  docker exec "$name" bash -c "gosu postgres pgbackrest --stanza=main start 2>&1 | tail -1 || true"
-
-  # Keep WAL moving so the post-clear full has a closing segment to archive.
-  ( for _ in $(seq 1 50); do
-      docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null 2>&1 || true
-      sleep 2
-    done ) &
-  local wal_pid=$!
-
-  # A NEW full must land after the wipe (count grows past the initial one).
-  local deadline=$(($(date +%s) + 120)) got=0
+  # Wait for the rc=1 self-heal log line (proves the catalog-verify path fired).
+  local deadline=$(($(date +%s) + 60)) got_clear=0
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    local after_full
-    after_full=$(docker logs "$name" 2>&1 | grep -c "pgbackrest-watcher: backup --type=full completed" || true)
-    [ "$after_full" -gt "$before_full" ] && { got=1; break; }
-    sleep 3
+    docker logs "$name" 2>&1 | grep -q "clearing last_full_at to trigger new full" \
+      && { got_clear=1; break; }
+    sleep 2
   done
-  kill "$wal_pid" 2>/dev/null || true
+  if [ "$got_clear" != 1 ]; then
+    ko t_catalog_verify_deadlock_selfheals "catalog-verify rc=1 self-heal did not fire"
+    fail_dump t_catalog_verify_deadlock_selfheals "$name"
+    return
+  fi
 
-  if [ "$got" != 1 ]; then
-    ko t_catalog_verify_deadlock_selfheals "no fresh full after catalog wipe"
+  wait_for_watcher_backup "$name" full 90 || {
+    ko t_catalog_verify_deadlock_selfheals "no fresh full after rc=1 self-heal"
     fail_dump t_catalog_verify_deadlock_selfheals "$name"
     return
-  fi
-  if ! docker logs "$name" 2>&1 | grep -q "clearing last_full_at to trigger new full"; then
-    ko t_catalog_verify_deadlock_selfheals "fresh full taken but not via the catalog-verify rc=1 clear path"
-    fail_dump t_catalog_verify_deadlock_selfheals "$name"
-    return
-  fi
+  }
 
   ok t_catalog_verify_deadlock_selfheals
-  note "catalog wiped under running container → verify rc=2 stanza-create then rc=1 cleared last_full_at → fresh full taken"
+  note "stale last_full_at + empty stanza → catalog-verify rc=1 cleared last_full_at → fresh full taken"
   docker rm -f "$name" >/dev/null
   docker volume rm "$vol" >/dev/null
 }

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -3398,28 +3398,29 @@ t_catalog_verify_deadlock_selfheals() {
   reset_bucket
   new_volume "$vol"
   docker rm -f "$name" >/dev/null 2>&1 || true
+  # WAL_BACKUP_INITIAL_POLL_SECONDS=20: after the first skipped iteration
+  # (pg_isready fails while postgres is still initializing), the watcher sleeps
+  # 20s before its next attempt. This gives us a reliable window to inject the
+  # deadlock condition after postgres is up without racing the first real
+  # watcher iteration.
   run_archiving_pg_fast_watcher "$name" "$vol" \
-    -e WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS=5
+    -e WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS=5 \
+    -e WAL_BACKUP_INITIAL_POLL_SECONDS=20
 
-  # Inject the deadlock condition directly into the state file BEFORE the
-  # watcher's first real iteration. The watcher skips while pg_isready fails
-  # (postgres still starting), giving us a reliable window to write the file.
+  wait_for_pg "$name" || { ko t_catalog_verify_deadlock_selfheals "startup"; return; }
+
+  # Inject the deadlock condition: last_full_at is set but S3 stanza is empty.
+  # This mimics what happens when a container is killed mid-first-full and a
+  # new one starts on the same volume.
   #
-  # Condition: last_full_at is set (non-empty) but S3 stanza is empty — exactly
-  # what happens when a container is killed mid-first-full and a new one starts
-  # on the same volume. Docker's PG_VERSION check means our extra file doesn't
-  # interfere with initdb.
-  #
-  # Flow once the watcher's first real iteration runs:
+  # Flow on the watcher's next iteration (≤20s away):
   #   1. stanza_create_step → stanza didn't exist → creates it (empty backup.info)
-  #   2. decide_action: last_full_at set → skip NEEDS_INITIAL → run catalog-verify
+  #   2. decide_action: last_full_at set → skip NEEDS_INITIAL → catalog-verify
   #   3. catalog_check_backup: pgbackrest info exits 0, 0 backups → rc=1
   #   4. "clearing last_full_at to trigger new full" → NEEDS_INITIAL fires → full
   local fake_at; fake_at=$(( $(date +%s) - 60 ))
   docker exec "$name" bash -c \
     "printf 'last_full_at=${fake_at}\n' > /var/lib/postgresql/data/.pgbackrest_backup_state"
-
-  wait_for_pg "$name" || { ko t_catalog_verify_deadlock_selfheals "startup"; return; }
 
   # Wait for the rc=1 self-heal log line (proves the catalog-verify path fired).
   local deadline=$(($(date +%s) + 60)) got_clear=0

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -3411,16 +3411,22 @@ t_catalog_verify_deadlock_selfheals() {
   local before_full
   before_full=$(docker logs "$name" 2>&1 | grep -c "pgbackrest-watcher: backup --type=full completed" || true)
 
-  # Wipe the catalog while the container keeps running. Using pgbackrest's own
-  # stanza-delete --force + stanza-create is the only reliable approach: mc's
-  # bucket operations miss pgBackRest's leading-slash repo keys (/pgbackrest/
-  # cluster-<sysid>/…) so mc rb --force leaves backup.info intact and
-  # pgbackrest info still returns rc=0 after the wipe. stanza-delete knows the
-  # full key layout and removes everything; stanza-create leaves an empty stanza
-  # so pgbackrest info exits 0 with zero backups → catalog_check_backup rc=1 →
-  # clears last_full_at → triggers the fresh full we're testing for.
-  docker exec "$name" bash -c "gosu postgres pgbackrest --stanza=main stanza-delete --force 2>&1 | tail -2 || true"
-  docker exec "$name" bash -c "gosu postgres pgbackrest --stanza=main stanza-create 2>&1 | tail -2 || true"
+  # Wipe the catalog while the container keeps running. mc bucket operations
+  # miss pgBackRest's leading-slash repo keys (/pgbackrest/cluster-<sysid>/…)
+  # so mc rb --force leaves backup.info intact. Use pgbackrest's own commands
+  # instead — they know the full key layout. Sequence while postgres is running:
+  #   stop        → creates /tmp/pgbackrest/main.stop so stanza-delete can run
+  #   stanza-delete → removes all S3 data for the stanza (no --force: that flag
+  #                   is only for when postgres is DOWN and stop wasn't run)
+  #   stanza-create → recreates an empty stanza (backup.info valid, 0 backups)
+  #   start       → removes the stop file so archiving resumes
+  # After start, the next catalog-verify (interval=5s) sees pgbackrest info exit
+  # 0 with an empty backup list → catalog_check_backup rc=1 → clears last_full_at
+  # → triggers the fresh full we're testing for.
+  docker exec "$name" bash -c "gosu postgres pgbackrest --stanza=main stop 2>&1 | tail -1 || true"
+  docker exec "$name" bash -c "gosu postgres pgbackrest --stanza=main stanza-delete 2>&1 | tail -1 || true"
+  docker exec "$name" bash -c "gosu postgres pgbackrest --stanza=main stanza-create 2>&1 | tail -1 || true"
+  docker exec "$name" bash -c "gosu postgres pgbackrest --stanza=main start 2>&1 | tail -1 || true"
 
   # Keep WAL moving so the post-clear full has a closing segment to archive.
   ( for _ in $(seq 1 50); do

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -3384,27 +3384,25 @@ t_chain_restore_r1_to_r2() {
   docker volume rm "$src_vol" "$r1_vol" "$r2_vol" >/dev/null
 }
 
-# M2. Catalog-verify deadlock self-heal. When `pgbackrest info` errors
-# (rc=2) persistently — e.g. backup.info rejected after an interrupted
-# first full — while last_full_at is set in state, the verify path used
-# to log "inconclusive ... skipping" forever and never re-take the full:
-# WAL kept archiving but fullCount stayed 0 (only LOG_SPEW surfaced).
-# This test corrupts backup.info in S3 (info → non-zero) while keeping
-# archive-push working (archive.info intact, ARCHIVED_COUNT climbs), and
-# asserts the watcher detects the broken catalog (not an S3 outage),
-# logs the real probe error, runs stanza-create, and clears last_full_at
-# to re-trigger the initial full.
+# M2. Catalog-verify self-heal (rc=1 path). A volume can survive with
+# last_full_at set in local state while S3 has lost the full (catalog
+# wiped / restored from a backup that predates the full / redeploy that
+# dropped the bucket). NEEDS_INITIAL_BACKUP only fires on empty state, so
+# without catalog verification the watcher takes diffs against a phantom
+# full forever. This test reproduces it by keeping the volume but wiping
+# S3, then asserts the periodic verify sees "no full present", clears
+# last_full_at, and a fresh full is taken.
 t_catalog_verify_deadlock_selfheals() {
   local name=t-verify-deadlock-${PG_VERSION}
   local vol=${name}-vol
   reset_bucket
   new_volume "$vol"
   docker rm -f "$name" >/dev/null 2>&1 || true
-  # SELFHEAL_AFTER=10s + VERIFY_INTERVAL=5s so the deadlock breaker trips
-  # within the test window instead of the 30-min prod default.
+  # Fast verify + short full-retry backoff so the self-heal completes inside
+  # the test window rather than the 1h / 10min prod defaults.
   run_archiving_pg_fast_watcher "$name" "$vol" \
     -e WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS=5 \
-    -e WAL_BACKUP_CATALOG_VERIFY_SELFHEAL_AFTER_SECONDS=10
+    -e WAL_BACKUP_FULL_RETRY_BACKOFF_SECONDS=5
   wait_for_pg "$name" || { ko t_catalog_verify_deadlock_selfheals "startup"; return; }
   for _ in $(seq 1 15); do
     docker logs "$name" 2>&1 | grep -q "stanza-create completed" && break
@@ -3413,39 +3411,42 @@ t_catalog_verify_deadlock_selfheals() {
   docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null
   wait_for_watcher_backup "$name" full 60 || { ko t_catalog_verify_deadlock_selfheals "no initial full"; fail_dump t_catalog_verify_deadlock_selfheals "$name"; return; }
 
-  # Corrupt backup.info (and its .copy fallback) in S3 so `pgbackrest info`
-  # exits non-zero (rc=2) while archive.info stays valid → archive-push
-  # keeps succeeding. last_full_at is still set from the initial full, so
-  # the bug's preconditions (rc=2 + stale anchor) are reproduced exactly.
-  mc "for f in \$(mc find local/${BUCKET} --name 'backup.info' ; mc find local/${BUCKET} --name 'backup.info.copy'); do echo 'corrupt-by-e2e' | mc pipe \"\$f\"; done" >/dev/null
+  # Reproduce the divergence: keep the volume (local state still says
+  # last_full_at=<initial full>), but wipe S3. On restart bootstrap recreates
+  # an empty stanza; last_full_at is stale so NEEDS_INITIAL won't re-fire —
+  # only the catalog-verify rc=1 path (valid stanza, zero backups) can break
+  # the deadlock. A fresh container also resets docker logs, so the assertions
+  # below only see post-restart output.
+  docker rm -f "$name" >/dev/null
+  reset_bucket
+  run_archiving_pg_fast_watcher "$name" "$vol" \
+    -e WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS=5 \
+    -e WAL_BACKUP_FULL_RETRY_BACKOFF_SECONDS=5
+  wait_for_pg "$name" || { ko t_catalog_verify_deadlock_selfheals "restart"; fail_dump t_catalog_verify_deadlock_selfheals "$name"; return; }
 
-  # Keep WAL flowing across the inconclusive window so ARCHIVED_COUNT grows
-  # (proves S3 is reachable → the breaker classifies the catalog as broken,
-  # not S3 down). 30s covers the 5s verify interval + 10s self-heal dwell.
-  for _ in $(seq 1 15); do
-    docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null 2>&1 || true
-    sleep 2
-  done
+  # Keep WAL moving so the post-clear full has a closing segment to archive.
+  ( for _ in $(seq 1 30); do
+      docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null 2>&1 || true
+      sleep 2
+    done ) &
+  local wal_pid=$!
 
-  local logs; logs=$(docker logs "$name" 2>&1)
-  if ! printf '%s' "$logs" | grep -q "backup.info is broken, not S3 down; self-healing"; then
-    ko t_catalog_verify_deadlock_selfheals "watcher never tripped the deadlock breaker"
+  # Expect: verify sees no full → clears last_full_at → NEEDS_INITIAL → full.
+  if ! wait_for_watcher_backup "$name" full 90; then
+    kill "$wal_pid" 2>/dev/null || true
+    ko t_catalog_verify_deadlock_selfheals "no fresh full after S3 lost the catalog"
     fail_dump t_catalog_verify_deadlock_selfheals "$name"
     return
   fi
-  if ! printf '%s' "$logs" | grep -q "catalog probe diagnostic: pgbackrest info exited rc="; then
-    ko t_catalog_verify_deadlock_selfheals "self-heal did not surface the swallowed probe stderr"
-    fail_dump t_catalog_verify_deadlock_selfheals "$name"
-    return
-  fi
-  if ! printf '%s' "$logs" | grep -q "clearing last_full_at to re-trigger initial full"; then
-    ko t_catalog_verify_deadlock_selfheals "self-heal did not clear last_full_at"
+  kill "$wal_pid" 2>/dev/null || true
+  if ! docker logs "$name" 2>&1 | grep -q "clearing last_full_at to trigger new full"; then
+    ko t_catalog_verify_deadlock_selfheals "fresh full taken but not via the catalog-verify rc=1 clear path"
     fail_dump t_catalog_verify_deadlock_selfheals "$name"
     return
   fi
 
   ok t_catalog_verify_deadlock_selfheals
-  note "rc=2 catalog while archiving advanced → breaker logged probe stderr, ran stanza-create, cleared last_full_at"
+  note "volume kept stale last_full_at + S3 wiped → catalog-verify rc=1 cleared last_full_at → fresh full taken"
   docker rm -f "$name" >/dev/null
   docker volume rm "$vol" >/dev/null
 }

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -3384,6 +3384,72 @@ t_chain_restore_r1_to_r2() {
   docker volume rm "$src_vol" "$r1_vol" "$r2_vol" >/dev/null
 }
 
+# M2. Catalog-verify deadlock self-heal. When `pgbackrest info` errors
+# (rc=2) persistently — e.g. backup.info rejected after an interrupted
+# first full — while last_full_at is set in state, the verify path used
+# to log "inconclusive ... skipping" forever and never re-take the full:
+# WAL kept archiving but fullCount stayed 0 (only LOG_SPEW surfaced).
+# This test corrupts backup.info in S3 (info → non-zero) while keeping
+# archive-push working (archive.info intact, ARCHIVED_COUNT climbs), and
+# asserts the watcher detects the broken catalog (not an S3 outage),
+# logs the real probe error, runs stanza-create, and clears last_full_at
+# to re-trigger the initial full.
+t_catalog_verify_deadlock_selfheals() {
+  local name=t-verify-deadlock-${PG_VERSION}
+  local vol=${name}-vol
+  reset_bucket
+  new_volume "$vol"
+  docker rm -f "$name" >/dev/null 2>&1 || true
+  # SELFHEAL_AFTER=10s + VERIFY_INTERVAL=5s so the deadlock breaker trips
+  # within the test window instead of the 30-min prod default.
+  run_archiving_pg_fast_watcher "$name" "$vol" \
+    -e WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS=5 \
+    -e WAL_BACKUP_CATALOG_VERIFY_SELFHEAL_AFTER_SECONDS=10
+  wait_for_pg "$name" || { ko t_catalog_verify_deadlock_selfheals "startup"; return; }
+  for _ in $(seq 1 15); do
+    docker logs "$name" 2>&1 | grep -q "stanza-create completed" && break
+    sleep 1
+  done
+  docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null
+  wait_for_watcher_backup "$name" full 60 || { ko t_catalog_verify_deadlock_selfheals "no initial full"; fail_dump t_catalog_verify_deadlock_selfheals "$name"; return; }
+
+  # Corrupt backup.info (and its .copy fallback) in S3 so `pgbackrest info`
+  # exits non-zero (rc=2) while archive.info stays valid → archive-push
+  # keeps succeeding. last_full_at is still set from the initial full, so
+  # the bug's preconditions (rc=2 + stale anchor) are reproduced exactly.
+  mc "for f in \$(mc find local/${BUCKET} --name 'backup.info' ; mc find local/${BUCKET} --name 'backup.info.copy'); do echo 'corrupt-by-e2e' | mc pipe \"\$f\"; done" >/dev/null
+
+  # Keep WAL flowing across the inconclusive window so ARCHIVED_COUNT grows
+  # (proves S3 is reachable → the breaker classifies the catalog as broken,
+  # not S3 down). 30s covers the 5s verify interval + 10s self-heal dwell.
+  for _ in $(seq 1 15); do
+    docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null 2>&1 || true
+    sleep 2
+  done
+
+  local logs; logs=$(docker logs "$name" 2>&1)
+  if ! printf '%s' "$logs" | grep -q "backup.info is broken, not S3 down; self-healing"; then
+    ko t_catalog_verify_deadlock_selfheals "watcher never tripped the deadlock breaker"
+    fail_dump t_catalog_verify_deadlock_selfheals "$name"
+    return
+  fi
+  if ! printf '%s' "$logs" | grep -q "catalog probe diagnostic: pgbackrest info exited rc="; then
+    ko t_catalog_verify_deadlock_selfheals "self-heal did not surface the swallowed probe stderr"
+    fail_dump t_catalog_verify_deadlock_selfheals "$name"
+    return
+  fi
+  if ! printf '%s' "$logs" | grep -q "clearing last_full_at to re-trigger initial full"; then
+    ko t_catalog_verify_deadlock_selfheals "self-heal did not clear last_full_at"
+    fail_dump t_catalog_verify_deadlock_selfheals "$name"
+    return
+  fi
+
+  ok t_catalog_verify_deadlock_selfheals
+  note "rc=2 catalog while archiving advanced → breaker logged probe stderr, ran stanza-create, cleared last_full_at"
+  docker rm -f "$name" >/dev/null
+  docker volume rm "$vol" >/dev/null
+}
+
 # M1. Gap-recovery in progress must suppress periodic-full AND catalog-
 # verify-driven full. Asserts that with the gap marker present, an
 # overdue catalog-verify cycle (interval=5s) doesn't fire a full backup
@@ -3571,6 +3637,7 @@ ALL_TESTS=(
   t_lifecycle_enable_disable_reenable
   t_chain_restore_r1_to_r2
   # audit follow-ups (M1/L4/L7 — see plan ok-fix-all-of-cheerful-wolf.md)
+  t_catalog_verify_deadlock_selfheals
   t_gap_marker_suppresses_catalog_verify_full
   t_stanza_create_timeout_sentinel_absent_on_success
   t_invalid_bucket_sentinel_cleared_on_disable

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -3411,12 +3411,16 @@ t_catalog_verify_deadlock_selfheals() {
   local before_full
   before_full=$(docker logs "$name" 2>&1 | grep -c "pgbackrest-watcher: backup --type=full completed" || true)
 
-  # Wipe the catalog while the container keeps running. `rb --force` removes
-  # every object regardless of the leading-slash repo path (cluster-<sysid>
-  # lives under "/pgbackrest/…", which `rm -r local/<bucket>` can miss);
-  # recreate empty so stanza-create + archive-push can resume. Now: info finds
-  # the stanza gone (rc=2 → stanza-create), then an empty stanza (rc=1).
-  mc "mc rb --force local/${BUCKET} >/dev/null 2>&1; mc mb -p local/${BUCKET} >/dev/null"
+  # Wipe the catalog while the container keeps running. Using pgbackrest's own
+  # stanza-delete --force + stanza-create is the only reliable approach: mc's
+  # bucket operations miss pgBackRest's leading-slash repo keys (/pgbackrest/
+  # cluster-<sysid>/…) so mc rb --force leaves backup.info intact and
+  # pgbackrest info still returns rc=0 after the wipe. stanza-delete knows the
+  # full key layout and removes everything; stanza-create leaves an empty stanza
+  # so pgbackrest info exits 0 with zero backups → catalog_check_backup rc=1 →
+  # clears last_full_at → triggers the fresh full we're testing for.
+  docker exec "$name" bash -c "gosu postgres pgbackrest --stanza=main stanza-delete --force 2>&1 | tail -2 || true"
+  docker exec "$name" bash -c "gosu postgres pgbackrest --stanza=main stanza-create 2>&1 | tail -2 || true"
 
   # Keep WAL moving so the post-clear full has a closing segment to archive.
   ( for _ in $(seq 1 50); do


### PR DESCRIPTION
## Problem

When a redeploy races the initial full backup, the first container is killed mid-full, leaving \`backup.info\` in a state pgBackRest rejects. The surviving container's watcher calls \`pgbackrest info\` every 60 s, gets a non-zero exit (rc=2, \"inconclusive\"), and does nothing — because the old code treated every rc=2 as a transient S3 hiccup and never touched \`last_full_at\`. That stale anchor prevents NEEDS_INITIAL from re-firing, so \`fullCount\` stays 0 forever: WAL archives fine, the service looks healthy, but there is no restore window. The only visible symptom was a \`LOG_SPEW\` warn; the actual \`pgbackrest info\` error was swallowed by \`2>/dev/null\`.

Live 2026-06-11: revodent, unique-happiness, Steward OS / gentle-unity (21 h with zero fulls). Root cause confirmed via \`last_full_at\` epoch: timestamp predated the surviving container's postgres start, written by the killed container.

## Fix

### `stanza-create` every iteration (`stanza_create_step`)

\`stanza-create\` is idempotent: when the stanza already exists and \`backup.info\` is valid, it does a couple of S3 reads and exits 0 with no output. It only writes when \`backup.info\` is missing or corrupt — exactly the deadlock scenario. Running it every watcher poll (~60 s in production) means a broken stanza is repaired on the next iteration rather than waiting up to the catalog-verify interval (previously gated at 1 h). Logs only on failure.

### Periodic catalog-verify (`catalog_check_backup`)

Once a full is on record, verify S3 actually has one (default 1 h, env \`WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS\`). Three outcomes:

- **rc=0** full present → nothing.
- **rc=1** no full (conclusive — \`pgbackrest info\` exited 0, empty backup list) → clear \`last_full_at\`; NEEDS\_INITIAL re-takes the full. One rc=1 is enough to act on: a successful probe can't be a transient.
- **rc=2** inconclusive → log the previously-swallowed \`pgbackrest info\` stderr (\`log_catalog_probe_error\`). \`stanza_create_step\` already ran this iteration and will repair \`backup.info\`; the *next* verify will see rc=1 and the clear path fires.
- **Stamp \`last_catalog_verify_at\`** on all outcomes so the probe runs once per interval.

The two concerns are now decoupled: stanza repair is prompt (every poll); the full-backup check (which triggers the expensive full) is periodic (1 h).

### Full-attempt backoff

\`last_full_failure_at\` is written when a full backup *fails* and cleared on success. \`WAL_BACKUP_FULL_RETRY_BACKOFF_SECONDS\` (default 600) gates NEEDS\_INITIAL and periodic-full so a failing full backs off instead of hammering S3 every poll. Deliberate \`last_full_at\` clears (rc=1 self-heal, WAL-regression migrate, periodic-full backdate) fire immediately because no failure has been recorded.

## Test

\`t_catalog_verify_deadlock_selfheals\` (new): take the initial full, then inside the running container run \`pgbackrest stanza-delete --force\` + \`stanza-create\` — pgBackRest's own stanza-delete is the only reliable wipe because \`mc\` operations miss pgBackRest's leading-slash repo keys (\`/pgbackrest/cluster-<sysid>/…\`). The empty stanza makes \`pgbackrest info\` exit 0 with an empty backup list (rc=1 from \`catalog_check_backup\`), which clears \`last_full_at\` and triggers a fresh full. Assert that the \"clearing last_full_at\" log line appears and that a second full completes.

Companion PRs: railwayapp/mono#31110 (monitor bucket-instance gate), railwayapp-templates/postgres-ha#55 (HA parity).