### PR TITLE
fix(pitr): pin pgBackRest pg1-database to template1, not the customer's PGDATABASE

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -506,6 +506,15 @@ render_pgbackrest_conf() {
     retention_block="repo1-retention-full=${retention_full}"$'\n'"repo1-retention-diff=${retention_diff}"$'\n'
   fi
 
+  # pg1-database is hardcoded to template1 rather than honoring PGDATABASE.
+  # pgBackRest only needs *a* connectable database to reach the postmaster —
+  # backups are physical/cluster-wide and pg_backup_start/stop are cluster-global
+  # — so its connection target must not depend on the customer's
+  # POSTGRES_DB/PGDATABASE existing. When PGDATABASE pointed at a renamed or
+  # dropped app DB, stanza-create and every archive-push failed [103] and WAL
+  # piled up in pg_wal. template1 is the one database that always exists and
+  # can't be dropped, so the connection can never break. pg1-user still honors
+  # PGUSER.
   cat > "$PGBACKREST_CONF_FILE" <<EOF
 [global]
 repo1-type=s3
@@ -542,7 +551,7 @@ process-max=${restore_max}
 pg1-path=${PGDATA}
 pg1-port=5432
 pg1-user=${PGUSER:-postgres}
-pg1-database=${PGDATABASE:-postgres}
+pg1-database=template1
 EOF
   chown postgres:postgres "$PGBACKREST_CONF_FILE"
   chmod 0640 "$PGBACKREST_CONF_FILE"


### PR DESCRIPTION
## Problem

pgBackRest opens a libpq connection to run `stanza-create` and `pg_backup_start/stop()`. Those are **cluster-global** and backups are **physical** (the whole data directory), so the connection only needs *a* reachable database to talk to the postmaster — it does **not** need (and must not depend on) the customer's application database.

Today the conf honors `PGDATABASE`:
```ini
pg1-database=${PGDATABASE:-postgres}
```
Railway templates commonly set `PGDATABASE=${{POSTGRES_DB}}`. If a customer renames or drops that database, pgBackRest's connection target no longer exists → `stanza-create` fails ("unable to find primary cluster"), `archive.info` is never written, and **every** archive-push fails with `[103]`. WAL then accumulates in `pg_wal` and PITR silently breaks for the whole instance (admin monitor: `STANZA_DB_MISSING` — apex, NeuronHub, goudzaken-medusa, Soontip in the current fleet).

## Fix

Hardcode the connection target to **`template1`** — the one database that always exists and can't be dropped:
```ini
pg1-database=template1
```
Same class of fix as the existing `unset PGHOST`/`PGPORT` guard: stop customer libpq env from leaking into pgBackRest's own connection. `pg1-user` is unchanged (still honors `PGUSER`). Backups are physical/cluster-wide, so coverage is unaffected by which DB is the connection target. Recovery-source conf untouched — archive-get during restore doesn't open a postmaster connection.

⚠️ **Tradeoff to weigh:** pgBackRest holds the `pg1-database` connection open for the duration of a backup (`pg_backup_start`…`pg_backup_stop` must share one session). While connected to `template1`, a concurrent `CREATE DATABASE` (which defaults to `TEMPLATE template1`) will fail with *"source database template1 is being accessed by other users"*. `postgres` avoids that but can theoretically be dropped. Flagging so we pick deliberately.

## Test plan
- [x] `bash -n wrapper.sh`
- [ ] e2e archiving boot with a custom `POSTGRES_DB` that does not exist
- [ ] verify `CREATE DATABASE` during a backup window
