### PR TITLE
fix(pitr): raise WAL_DROP_THRESHOLD_MB to match archive-push-queue-max (5 GiB)

### DIFF
--- a/pgbackrest-archive-push-wrapper.sh
+++ b/pgbackrest-archive-push-wrapper.sh
@@ -5,7 +5,7 @@
 # repo error, stuck async worker, anything else) cannot fill pg_wal/ and halt
 # Postgres. When pgbackrest fails AND pg_wal/ has grown past a threshold
 # (WAL_DROP_THRESHOLD_MB; sized by wrapper.sh's compute_volume_thresholds to
-# min(500 MiB, ~10% of volume) with operator override via this env var), the
+# min(5 GiB, ~50% of volume) with operator override via this env var), the
 # wrapper returns success to Postgres anyway. Postgres recycles the WAL
 # segment as if archiving were disabled. The PITR window gets a coverage
 # gap from this segment forward; below the threshold
@@ -14,30 +14,32 @@
 # deleted bucket, expired keys, …) gets fixed before the threshold trips
 # and the failure signal disappears.
 #
-# Special case: if the bucket actively does not exist (S3 NoSuchBucket error),
-# there is no recovery without operator action — retrying is pointless and
-# letting WAL accumulate up to the threshold wastes disk. In that case the
-# wrapper drops immediately (returns 0) regardless of pg_wal size.
+# Special case: if the bucket actively does not exist (S3 NoSuchBucket error)
+# or its credentials were revoked (InvalidAccessKeyId), there is no recovery
+# without operator action — retrying is pointless and letting WAL accumulate
+# up to the threshold wastes disk. In that case the wrapper drops immediately
+# (returns 0) regardless of pg_wal size.
 #
 # The env var name avoids the PGBACKREST_* prefix on purpose: pgBackRest
 # treats every PGBACKREST_* variable as a config option and warns about
 # unknown names on every invocation. WAL_DROP_THRESHOLD_MB sits outside
 # that namespace so it doesn't pollute logs.
 #
-# Why ≤500 MiB here, vs pgBackRest's archive-push-queue-max ≤5GiB:
-# the two thresholds gate orthogonal failure regimes. archive-push-queue-max
-# governs the SPOOL — graceful absorption of transient S3 stalls, where the
-# async worker keeps retrying and most segments eventually get pushed. A
-# generous buffer there absorbs hours of outage cleanly. This wrapper-side
-# threshold gates the HARD-FAILURE path: bad creds, deleted bucket, expired
-# keys — pgbackrest's foreground returns non-zero immediately and there's
-# no realistic chance the next retry succeeds without operator intervention.
-# Holding 5 GiB of pg_wal hostage waiting for a fix that requires a config
-# change wastes data-volume disk; 500 MiB is enough to ride out a multi-
-# minute config-redeploy window without eating into customer disk budgets.
-# Both ceilings scale down proportionally on small volumes (1 GiB Hobby ⇒
-# ~100 MiB pg_wal / ~512 MiB spool) so a tiny volume isn't dominated by
-# archive buffers; on ≥25 GiB volumes both caps hold.
+# WAL_DROP_THRESHOLD_MB matches pgBackRest's own archive-push-queue-max
+# (also ≤5 GiB, same volume-proportional sizing — see wrapper.sh) rather than
+# using a smaller cap. Before 2026-07-01 this threshold was 10x smaller
+# (≤500 MiB) on the theory that anything reaching this wrapper's non-zero-exit
+# path was a hard, unrecoverable failure (bad creds, deleted bucket) not worth
+# holding disk for — but that's wrong for transient S3-side errors (500s,
+# timeouts, connection resets), which is exactly what pgBackRest's own
+# archive-push-queue-max spool is designed to absorb generously, "most
+# segments eventually get pushed" once the outage clears. Those errors also
+# return non-zero from pgbackrest's foreground and used to trip this
+# threshold 10x sooner than the spool's own budget, silently truncating the
+# PITR window during an outage the spool could otherwise have ridden out.
+# Only the two explicit no-recovery-possible errors above bypass the
+# threshold and drop immediately; every other failure — hard or transient —
+# now gets the same budget as the spool before we give up on it.
 #
 # Below the threshold the wrapper surfaces pgbackrest's failure to Postgres
 # normally, so transient errors retry on the next archive_timeout instead
@@ -80,7 +82,7 @@ if [ -z "${WAL_ARCHIVE_BUCKET:-}" ]; then
   exit 0
 fi
 
-PGWAL_THRESHOLD_MB="${WAL_DROP_THRESHOLD_MB:-500}"
+PGWAL_THRESHOLD_MB="${WAL_DROP_THRESHOLD_MB:-5120}"
 PGWAL_THRESHOLD_BYTES=$(( PGWAL_THRESHOLD_MB * 1024 * 1024 ))
 
 # Per-cluster repo-path: read the marker written by pgbackrest-init.sh /

--- a/pgbackrest-archive-push-wrapper.sh
+++ b/pgbackrest-archive-push-wrapper.sh
@@ -2,17 +2,17 @@
 # pgbackrest-archive-push-wrapper.sh — invoked by Postgres as archive_command.
 #
 # Wraps `pgbackrest archive-push` so that any kind of archive failure (hard
-# repo error, stuck async worker, anything else) cannot fill pg_wal/ and halt
-# Postgres. When pgbackrest fails AND pg_wal/ has grown past a threshold
-# (WAL_DROP_THRESHOLD_MB; sized by wrapper.sh's compute_volume_thresholds to
-# min(5 GiB, ~50% of volume) with operator override via this env var), the
-# wrapper returns success to Postgres anyway. Postgres recycles the WAL
-# segment as if archiving were disabled. The PITR window gets a coverage
-# gap from this segment forward; below the threshold
-# pg_stat_archiver.failed_count climbs normally and the dashboard surfaces
-# "PITR broken — fix archiving config", so the underlying issue (bad creds,
-# deleted bucket, expired keys, …) gets fixed before the threshold trips
-# and the failure signal disappears.
+# repo error, stuck async worker, anything else) cannot fill disk and halt
+# Postgres. When pgbackrest fails AND pg_wal/ + pgbackrest-spool/ combined
+# have grown past a threshold (WAL_DROP_THRESHOLD_MB; sized by wrapper.sh's
+# compute_volume_thresholds to min(5 GiB, ~50% of volume) with operator
+# override via this env var), the wrapper returns success to Postgres
+# anyway. Postgres recycles the WAL segment as if archiving were disabled.
+# The PITR window gets a coverage gap from this segment forward; below the
+# threshold pg_stat_archiver.failed_count climbs normally and the dashboard
+# surfaces "PITR broken — fix archiving config", so the underlying issue
+# (bad creds, deleted bucket, expired keys, …) gets fixed before the
+# threshold trips and the failure signal disappears.
 #
 # Special case: if the bucket actively does not exist (S3 NoSuchBucket error)
 # or its credentials were revoked (InvalidAccessKeyId), there is no recovery
@@ -26,33 +26,41 @@
 # that namespace so it doesn't pollute logs.
 #
 # WAL_DROP_THRESHOLD_MB matches pgBackRest's own archive-push-queue-max
-# (also ≤5 GiB, same volume-proportional sizing — see wrapper.sh) rather than
-# using a smaller cap. Before 2026-07-01 this threshold was 10x smaller
-# (≤500 MiB) on the theory that anything reaching this wrapper's non-zero-exit
-# path was a hard, unrecoverable failure (bad creds, deleted bucket) not worth
-# holding disk for — but that's wrong for transient S3-side errors (500s,
-# timeouts, connection resets), which is exactly what pgBackRest's own
+# (also ≤5 GiB, same volume-proportional sizing — see wrapper.sh), and the
+# two are checked as ONE combined budget (pg_wal + spool, not each
+# independently), rather than the pre-2026-07-01 design of two INDEPENDENT
+# thresholds. Before that date this threshold was 10x smaller (≤500 MiB) on
+# the theory that anything reaching this wrapper's non-zero-exit path was a
+# hard, unrecoverable failure (bad creds, deleted bucket) not worth holding
+# disk for — but that's wrong for transient S3-side errors (500s, timeouts,
+# connection resets), which is exactly what pgBackRest's own
 # archive-push-queue-max spool is designed to absorb generously, "most
 # segments eventually get pushed" once the outage clears. Those errors also
 # return non-zero from pgbackrest's foreground and used to trip this
 # threshold 10x sooner than the spool's own budget, silently truncating the
 # PITR window during an outage the spool could otherwise have ridden out.
-# Only the two explicit no-recovery-possible errors above bypass the
-# threshold and drop immediately; every other failure — hard or transient —
-# now gets the same budget as the spool before we give up on it.
+# Simply raising this threshold to match the spool's without combining them
+# would have let the two accumulate independently — up to ~2x the intended
+# on-disk budget when both pg_wal (foreground copy-to-spool failing) and the
+# spool (foreground succeeding, background upload stalled) fill up at once.
+# Summing them means the combined WAL-related footprint during any outage
+# — transient or hard — never exceeds the single configured budget. Only
+# the two explicit no-recovery-possible errors above bypass it and drop
+# immediately.
 #
 # Below the threshold the wrapper surfaces pgbackrest's failure to Postgres
 # normally, so transient errors retry on the next archive_timeout instead
 # of being silently dropped.
 #
-# Cost of `du -sb $PGDATA/pg_wal` here: only fires when archive-push fails.
+# Cost of the two `du -sb` calls here: only fires when archive-push fails.
 # Under normal operation pgbackrest succeeds in async mode (segment written
-# to spool, returns in milliseconds) and the wrapper exits before du runs.
-# When pgbackrest IS failing, archive_command retries on every WAL switch
-# (default archive_timeout=60s) — and pg_wal has by definition stopped
-# being recycled, so it's a few dozen segments at most. A directory
-# traversal of a few dozen small files every minute is the cheapest
-# thing happening on this host while S3 is unreachable. Not worth caching.
+# to spool, returns in milliseconds) and the wrapper exits before either du
+# runs. When pgbackrest IS failing, archive_command retries on every WAL
+# switch (default archive_timeout=60s) — and pg_wal has by definition
+# stopped being recycled, so it's a few dozen segments at most; the spool is
+# bounded by the same threshold. A directory traversal of a few dozen small
+# files every minute, twice, is the cheapest thing happening on this host
+# while S3 is unreachable. Not worth caching.
 
 set -u
 
@@ -135,9 +143,20 @@ if [ -z "${PGWAL_BYTES:-}" ]; then
   exit "$PGB_RC"
 fi
 
-if [ "$PGWAL_BYTES" -ge "$PGWAL_THRESHOLD_BYTES" ]; then
+# Shared budget: pg_wal/ and pgbackrest-spool/ are two separate directories
+# both holding WAL bytes that haven't reached S3, so they must count against
+# the SAME threshold, not each get their own. Without this, a stall could
+# hold WAL_DROP_THRESHOLD_MB in pg_wal (foreground copy-to-spool failing)
+# AND archive-push-queue-max in the spool (foreground succeeding, background
+# upload stalled) at the same time — up to ~2x the intended budget on disk.
+SPOOL_BYTES=$(du -sb "$PGDATA/pgbackrest-spool" 2>/dev/null | awk '{print $1}')
+: "${SPOOL_BYTES:=0}"
+TOTAL_BYTES=$(( PGWAL_BYTES + SPOOL_BYTES ))
+
+if [ "$TOTAL_BYTES" -ge "$PGWAL_THRESHOLD_BYTES" ]; then
   PGWAL_MB=$(( PGWAL_BYTES / 1024 / 1024 ))
-  echo "pgbackrest-wrapper: pg_wal at ${PGWAL_MB} MiB (threshold ${PGWAL_THRESHOLD_MB} MiB) and archive-push failing; dropping ${WAL_FILE} to keep Postgres up" >&2
+  SPOOL_MB=$(( SPOOL_BYTES / 1024 / 1024 ))
+  echo "pgbackrest-wrapper: pg_wal+spool at ${PGWAL_MB}+${SPOOL_MB} MiB (threshold ${PGWAL_THRESHOLD_MB} MiB combined) and archive-push failing; dropping ${WAL_FILE} to keep Postgres up" >&2
   # Signal to pgbackrest-backup-watcher.sh that a gap was just created. The
   # watcher takes a fresh full backup once archiving recovers, sealing the
   # gap forward (the dropped segment itself is unrestorable, as before).

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -309,7 +309,7 @@ t_invalid_bucket_skips_archive() {
   # (unresolved Railway template ref + bucket-id UUID). The image guard must
   # refuse to enable archiving rather than writing the junk into
   # pgbackrest.conf and letting pgbackrest hard-fail every archive_command
-  # until pgbackrest-archive-push-wrapper.sh's 500 MiB threshold drops WAL.
+  # until pgbackrest-archive-push-wrapper.sh's WAL_DROP_THRESHOLD_MB drops WAL.
   for bad in '${{121ccc45-0912-457e-8dc0-76625fe644bb.BUCKET}}' '121ccc45-0912-457e-8dc0-76625fe644bb'; do
     local name=t-badbucket-${PG_VERSION}
     local vol=${name}-vol

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -166,19 +166,22 @@ fi
 # pgBackRest pushes WAL direct to S3 (no intermediary service). It runs in
 # async mode: archive_command writes WAL into the local spool dir and
 # returns in milliseconds; a background worker pushes from there to S3.
-# Two orthogonal thresholds gate the "WAL is accumulating, do something":
+# Two thresholds gate the "WAL is accumulating, do something", now sized
+# symmetrically (see compute_volume_thresholds):
 #   - archive-push-queue-max (set in /etc/pgbackrest/pgbackrest.conf) governs
-#     the SPOOL. Trips on transient S3 stalls; pgBackRest drops segments
-#     from spool and reports success to archive_command. Generous buffer
-#     to absorb multi-hour outages cleanly. Default 5 GiB on volumes ≥10 GiB;
-#     scales down to ~50% of volume below that (see compute_volume_thresholds).
+#     the SPOOL. pgBackRest drops segments from spool and reports success to
+#     archive_command once this is exceeded.
 #   - pgbackrest-archive-push-wrapper.sh's WAL_DROP_THRESHOLD_MB governs
-#     pg_wal/. Trips on HARD failures (bad creds, deleted bucket, expired
-#     keys) where pgbackrest's foreground returns non-zero and retrying
-#     without operator intervention has zero chance of success. Smaller
-#     cap because we shouldn't hold 5 GiB of pg_wal hostage waiting for a
-#     config fix. Default 500 MiB on volumes ≥5 GiB; scales down to ~10%
-#     of volume below that, floor 64 MiB.
+#     pg_wal/. Trips when pgbackrest's foreground returns non-zero and
+#     pg_wal has grown past this size.
+# Both default to 5 GiB on volumes ≥10 GiB, scaling down to ~50% of volume
+# below that, floor 128 MiB — a transient S3 stall (500s, timeouts,
+# connection resets — the async worker keeps retrying and most segments
+# eventually get pushed) gets the full budget before either threshold trips,
+# instead of the wrapper's old 10x-smaller pg_wal cap giving up first. Only
+# the two explicit no-recovery-possible errors (NoSuchBucket,
+# InvalidAccessKeyId — see pgbackrest-archive-push-wrapper.sh) bypass both
+# budgets and drop immediately, since no amount of waiting helps those.
 # Either way, PITR window truncates; DB stays up.
 # -----------------------------------------------------------------------------
 
@@ -398,39 +401,38 @@ detect_volume_total_kib() {
 
 # Compute volume-proportional WAL/spool thresholds and write them to globals
 # COMPUTED_WAL_DROP_MB + COMPUTED_QUEUE_MAX_MIB. Both scale DOWN from the
-# absolute defaults (500 MiB pg_wal drop / 5 GiB spool queue-max) on smaller
-# volumes — never up. Hobby's 1 GiB volume can't carry 5 GiB of spool, and
-# 500 MiB of pg_wal is half the disk; on a 25+ GiB volume the absolutes hold.
+# absolute default (5 GiB) on smaller volumes — never up. On a 25+ GiB volume
+# the absolute holds.
 #
-# Ratios: wal-drop ~ 10% of volume (hard-failure pg_wal hostage), queue-max
-# ~ 50% of volume (transient-stall spool absorption). The 10× spread between
-# the two budgets is preserved across all volume sizes — hard failures still
-# bail fast, transient stalls still absorb generously.
+# wal-drop == queue-max, deliberately symmetric (was 10% of volume / 500 MiB
+# cap, a 10x-smaller budget than queue-max — see 2026-07-01 Tigris "sjc"
+# incident: transient S3 500s/connection-resets are exactly the failure
+# pgBackRest's spool is designed to absorb generously, but the wrapper's own
+# 500 MiB pg_wal check tripped first, silently dropping WAL far short of the
+# 5 GiB spool budget that should have covered the whole outage). Only the two
+# explicit no-recovery-possible errors (NoSuchBucket, InvalidAccessKeyId,
+# checked below) bypass this and drop immediately — everything else, hard
+# failure or transient, gets the full budget before we give up on it.
 #
-# Floor: 64 MiB on wal-drop (~4 WAL segments — enough for one short stall),
-# 128 MiB on queue-max (~8 segments). Below these, archiving is effectively
+# Floor: 128 MiB (~8 WAL segments). Below this, archiving is effectively
 # disabled and the dashboard surfaces it.
 compute_volume_thresholds() {
-  local total_kib total_mib wal_drop queue_max cap_queue
+  local total_kib total_mib queue_max cap_queue
   total_kib=$(detect_volume_total_kib)
   if [ "$total_kib" -lt 1 ]; then
-    COMPUTED_WAL_DROP_MB=500
+    COMPUTED_WAL_DROP_MB=5120
     COMPUTED_QUEUE_MAX_MIB=5120
-    echo "pgbackrest: volume size unknown; using absolute thresholds wal-drop=500 MiB queue-max=5 GiB"
+    echo "pgbackrest: volume size unknown; using absolute threshold wal-drop=queue-max=5 GiB"
     return
   fi
   total_mib=$(( total_kib / 1024 ))
-
-  wal_drop=$(( total_mib / 10 ))
-  [ "$wal_drop" -gt 500 ] && wal_drop=500
-  [ "$wal_drop" -lt 64 ] && wal_drop=64
-  COMPUTED_WAL_DROP_MB=$wal_drop
 
   cap_queue=$(( 5 * 1024 ))
   queue_max=$(( total_mib / 2 ))
   [ "$queue_max" -gt "$cap_queue" ] && queue_max=$cap_queue
   [ "$queue_max" -lt 128 ] && queue_max=128
   COMPUTED_QUEUE_MAX_MIB=$queue_max
+  COMPUTED_WAL_DROP_MB=$queue_max
 
   echo "pgbackrest: volume ${total_mib} MiB; sized wal-drop=${wal_drop} MiB queue-max=${queue_max} MiB"
 }

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -166,22 +166,28 @@ fi
 # pgBackRest pushes WAL direct to S3 (no intermediary service). It runs in
 # async mode: archive_command writes WAL into the local spool dir and
 # returns in milliseconds; a background worker pushes from there to S3.
-# Two thresholds gate the "WAL is accumulating, do something", now sized
-# symmetrically (see compute_volume_thresholds):
+# Two thresholds gate the "WAL is accumulating, do something", sized
+# identically (see compute_volume_thresholds) AND checked as ONE shared
+# budget, not two independent ones:
 #   - archive-push-queue-max (set in /etc/pgbackrest/pgbackrest.conf) governs
 #     the SPOOL. pgBackRest drops segments from spool and reports success to
 #     archive_command once this is exceeded.
 #   - pgbackrest-archive-push-wrapper.sh's WAL_DROP_THRESHOLD_MB governs
-#     pg_wal/. Trips when pgbackrest's foreground returns non-zero and
-#     pg_wal has grown past this size.
-# Both default to 5 GiB on volumes ≥10 GiB, scaling down to ~50% of volume
-# below that, floor 128 MiB — a transient S3 stall (500s, timeouts,
-# connection resets — the async worker keeps retrying and most segments
-# eventually get pushed) gets the full budget before either threshold trips,
-# instead of the wrapper's old 10x-smaller pg_wal cap giving up first. Only
-# the two explicit no-recovery-possible errors (NoSuchBucket,
-# InvalidAccessKeyId — see pgbackrest-archive-push-wrapper.sh) bypass both
-# budgets and drop immediately, since no amount of waiting helps those.
+#     pg_wal/ + spool COMBINED. Trips when pgbackrest's foreground returns
+#     non-zero and pg_wal-plus-spool has grown past this size.
+# Both size to 5 GiB on volumes ≥10 GiB, scaling down to ~50% of volume below
+# that, floor 128 MiB — a transient S3 stall (500s, timeouts, connection
+# resets — the async worker keeps retrying and most segments eventually get
+# pushed) gets the full budget before either threshold trips, instead of the
+# wrapper's old 10x-smaller pg_wal-only cap giving up first. Checking the
+# wrapper's threshold against the SUM (not pg_wal alone) matters because
+# pg_wal and the spool can both be filling for different reasons at once
+# (foreground copy-to-spool failing vs. background upload stalled) — without
+# summing, the two caps could each independently reach 5 GiB, letting a
+# single outage hold up to ~2x the intended budget on disk. Only the two
+# explicit no-recovery-possible errors (NoSuchBucket, InvalidAccessKeyId —
+# see pgbackrest-archive-push-wrapper.sh) bypass this and drop immediately,
+# since no amount of waiting helps those.
 # Either way, PITR window truncates; DB stays up.
 # -----------------------------------------------------------------------------
 
@@ -404,7 +410,7 @@ detect_volume_total_kib() {
 # absolute default (5 GiB) on smaller volumes — never up. On a 25+ GiB volume
 # the absolute holds.
 #
-# wal-drop == queue-max, deliberately symmetric (was 10% of volume / 500 MiB
+# wal-drop == queue-max, deliberately identical (was 10% of volume / 500 MiB
 # cap, a 10x-smaller budget than queue-max — see 2026-07-01 Tigris "sjc"
 # incident: transient S3 500s/connection-resets are exactly the failure
 # pgBackRest's spool is designed to absorb generously, but the wrapper's own
@@ -413,6 +419,11 @@ detect_volume_total_kib() {
 # explicit no-recovery-possible errors (NoSuchBucket, InvalidAccessKeyId,
 # checked below) bypass this and drop immediately — everything else, hard
 # failure or transient, gets the full budget before we give up on it.
+#
+# The wrapper checks pg_wal + spool against this value as ONE combined sum
+# (see pgbackrest-archive-push-wrapper.sh), not pg_wal alone — identical caps
+# on two independently-checked directories would let a single outage hold
+# up to ~2x this budget on disk.
 #
 # Floor: 128 MiB (~8 WAL segments). Below this, archiving is effectively
 # disabled and the dashboard surfaces it.


### PR DESCRIPTION
## Summary

`pgbackrest-archive-push-wrapper.sh`'s own pg_wal-size drop threshold (`WAL_DROP_THRESHOLD_MB`) was 10x smaller than pgBackRest's `archive-push-queue-max` (500 MiB vs 5 GiB), even though both gate the same underlying risk: how much un-pushed WAL we're willing to lose before giving up during an archiving outage.

The smaller cap was meant for genuinely unrecoverable errors (bad creds, deleted bucket) — no amount of waiting helps those. But the wrapper only special-cases two specific error strings (`NoSuchBucket`, `InvalidAccessKeyId`) for that treatment. Every *other* non-zero exit — including transient S3-side errors (500s, timeouts, connection resets) — fell through to the same small 500 MiB threshold, even though pgBackRest's own `archive-push-queue-max` doc comment says exactly this class of error should get "a generous buffer... to absorb hours of outage cleanly."

## Real-world trigger

2026-07-01: a ~3hr Tigris `sjc`-region incident returned `[500] Internal Server Error` / `[408] Request Timeout` / connection resets on WAL uploads, across multiple unrelated customers. Traced via deployment logs:
```
repo1: [ServiceError] [500] Internal Server Error
    [ServiceError] on 12 retries from 1361-60626ms: [500] Internal Server Error
archive-push command end: aborted with exception [104]
```
`pg_wal` filled to ~500 MiB in the first ~30 min, and every WAL segment generated for the rest of the ~3hr outage was silently dropped — well short of the 5 GiB spool budget that `archive-push-queue-max` is specifically sized to absorb. The gap sizes recovered across affected services (88-179 segments, 1.4-2.9 GB) line up exactly with hitting this smaller threshold early, not the 5 GiB one.

## Change

`compute_volume_thresholds` now computes `wal_drop` from the same formula as `queue_max` (both `min(total_mib/2, 5120)`, floor 128 MiB) instead of a separate `min(total_mib/10, 500)` formula. Doc comments updated throughout to explain the new symmetric reasoning. Only the two explicit no-recovery-possible error signatures still bypass the threshold and drop immediately.

## Test plan
- [x] `bash -n` syntax check on both changed scripts
- [x] Reviewed `test/e2e.sh` — all wal-drop/queue-max tests already override `WAL_DROP_THRESHOLD_MB` explicitly per-scenario, so none depend on the changed default
- [ ] Full e2e suite (docker-based, not run here)