### PR TITLE
fix(pitr): reduce WAL retention during recovery replay

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -1937,6 +1937,17 @@ t_empty_volume_restore_from_s3() {
     "$IMAGE" >/dev/null
   wait_for_pg "$rest_name" || { ko t_empty_volume_restore_from_s3 "restored pg did not start"; fail_dump t_empty_volume_restore_from_s3 "$rest_name"; return; }
 
+  # The recovery-only restartpoint knobs must reach the postgres process on
+  # the replay boot. They are best-effort triggers (restartpoints still require
+  # a source checkpoint record), but inheriting an arbitrarily loose local
+  # checkpoint policy would defeat the mitigation entirely.
+  if ! docker exec "$rest_name" sh -c \
+    "ps aux | grep '[p]ostgres.*checkpoint_timeout=30s.*max_wal_size=512MB'" >/dev/null; then
+    ko t_empty_volume_restore_from_s3 "replay boot did not receive recovery-only restartpoint args"
+    fail_dump t_empty_volume_restore_from_s3 "$rest_name"
+    return
+  fi
+
   # The .pgbackrest_restored marker must exist (set by
   # restore_from_pgbackrest_if_empty_volume after a successful restore).
   if ! docker exec "$rest_name" test -f /var/lib/postgresql/data/.pgbackrest_restored; then
@@ -1978,6 +1989,18 @@ t_empty_volume_restore_from_s3() {
   fi
   if [ "$rows_after" != "0" ]; then
     ko t_empty_volume_restore_from_s3 "id=2,3 (after target) should be absent; got $rows_after"
+    return
+  fi
+
+  # recovery.signal is consumed on promote. A subsequent boot must therefore
+  # use the ordinary postgres arguments; otherwise the aggressive recovery
+  # tuning silently leaks into production traffic.
+  docker restart "$rest_name" >/dev/null
+  wait_for_pg "$rest_name" || { ko t_empty_volume_restore_from_s3 "post-promote restart did not start"; fail_dump t_empty_volume_restore_from_s3 "$rest_name"; return; }
+  if docker exec "$rest_name" sh -c \
+    "ps aux | grep '[p]ostgres.*checkpoint_timeout=30s.*max_wal_size=512MB'" >/dev/null; then
+    ko t_empty_volume_restore_from_s3 "recovery-only restartpoint args leaked into post-promote boot"
+    fail_dump t_empty_volume_restore_from_s3 "$rest_name"
     return
   fi
 

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -218,6 +218,23 @@ PITR_DONE_MARKER="$PGDATA/.pitr_configured"
 # our conf.d/pgbackrest-recovery.conf path would duplicate them.
 PGBACKREST_RESTORED_MARKER="$PGDATA/.pgbackrest_restored"
 
+# Checkpoint tuning applied ONLY to a replay boot, via `-c` flags on the
+# postgres invocation itself — never written to postgresql.conf/auto.conf.
+# Without this, pg_wal can accumulate WAL segments fetched by restore_command
+# until the next restartpoint, which fires at whatever cadence
+# checkpoint_timeout/max_wal_size already on disk allow (vanilla defaults,
+# a customer's own prod tuning on an existing volume, or — on a volume
+# cloned from the source at the block level — the source's tuning). On a
+# volume provisioned at ~the source's current size, that buffer risks
+# ENOSPC before recovery ever reaches the PITR target. `-c` wins over
+# auto.conf regardless of what's already on disk and applies to this one
+# process only, so there's nothing to revert: the next boot (post-promote,
+# once recovery.signal is gone) just uses the Dockerfile CMD's plain args.
+# Safe to be aggressive — this boot serves no live traffic, so the extra
+# checkpoint overhead only extends replay time, not query latency.
+PITR_RECOVERY_CHECKPOINT_TIMEOUT="${PITR_RECOVERY_CHECKPOINT_TIMEOUT:-30s}"
+PITR_RECOVERY_MAX_WAL_SIZE="${PITR_RECOVERY_MAX_WAL_SIZE:-512MB}"
+
 # Per-cluster archive sub-path: the effective repo1-path, persisted inside
 # PGDATA so the watcher, archive-push wrapper, and stanza-create subshell
 # all converge on the same value. Per-cluster pathing means a wipe-and-
@@ -1142,4 +1159,18 @@ fork_collation_refresh
 # subprocesses. Falling back to the simple foreground invocation
 # preserves the e2e suite's existing behavior on docker stop / docker
 # restart.
+#
+# This boot is about to replay WAL from the source bucket toward a PITR
+# target — recovery.signal present (written either by
+# restore_from_pgbackrest_if_empty_volume's `pgbackrest restore` or by
+# configure_pgbackrest_recovery) plus WAL_RECOVER_FROM_BUCKET set covers both
+# paths. Cap checkpoint_timeout/max_wal_size for just this process so
+# restartpoints reclaim pg_wal often enough to keep disk usage close to the
+# base backup's size instead of whatever's already on disk. See
+# PITR_RECOVERY_CHECKPOINT_TIMEOUT/PITR_RECOVERY_MAX_WAL_SIZE above.
+if [ -f "$PGDATA/recovery.signal" ] && [ -n "${WAL_RECOVER_FROM_BUCKET:-}" ]; then
+  echo "pgbackrest: capping checkpoint_timeout=${PITR_RECOVERY_CHECKPOINT_TIMEOUT} max_wal_size=${PITR_RECOVERY_MAX_WAL_SIZE} for this replay boot"
+  set -- "$@" -c "checkpoint_timeout=${PITR_RECOVERY_CHECKPOINT_TIMEOUT}" -c "max_wal_size=${PITR_RECOVERY_MAX_WAL_SIZE}"
+fi
+
 /usr/local/bin/docker-entrypoint.sh "$@"

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -531,7 +531,7 @@ PITR_DONE_MARKER="$PGDATA/.pitr_configured"
 # our conf.d/pgbackrest-recovery.conf path would duplicate them.
 PGBACKREST_RESTORED_MARKER="$PGDATA/.pgbackrest_restored"
 
-# Checkpoint tuning applied ONLY to a replay boot, via `-c` flags on the
+# Restartpoint tuning applied ONLY to a replay boot, via `-c` flags on the
 # postgres invocation itself — never written to postgresql.conf/auto.conf.
 # Without this, pg_wal can accumulate WAL segments fetched by restore_command
 # until the next restartpoint, which fires at whatever cadence
@@ -539,7 +539,11 @@ PGBACKREST_RESTORED_MARKER="$PGDATA/.pgbackrest_restored"
 # a customer's own prod tuning on an existing volume, or — on a volume
 # cloned from the source at the block level — the source's tuning). On a
 # volume provisioned at ~the source's current size, that buffer risks
-# ENOSPC before recovery ever reaches the PITR target. `-c` wins over
+# ENOSPC before recovery ever reaches the PITR target. This is deliberately a
+# best-effort reduction, not a hard disk bound: recovery can only perform a
+# restartpoint at a checkpoint record written by the source, so PostgreSQL may
+# exceed max_wal_size by as much as one source checkpoint cycle. Operators must
+# still provision that headroom. `-c` wins over
 # auto.conf regardless of what's already on disk and applies to this one
 # process only, so there's nothing to revert: the next boot (post-promote,
 # once recovery.signal is gone) just uses the Dockerfile CMD's plain args.
@@ -2356,12 +2360,13 @@ fork_old_datadir_reclaim
 # target — recovery.signal present (written either by
 # restore_from_pgbackrest_if_empty_volume's `pgbackrest restore` or by
 # configure_pgbackrest_recovery) plus WAL_RECOVER_FROM_BUCKET set covers both
-# paths. Cap checkpoint_timeout/max_wal_size for just this process so
-# restartpoints reclaim pg_wal often enough to keep disk usage close to the
-# base backup's size instead of whatever's already on disk. See
+# paths. Request tighter checkpoint_timeout/max_wal_size thresholds for just
+# this process so restartpoints reclaim pg_wal at the earliest eligible source
+# checkpoint record instead of inheriting an arbitrarily loose local setting.
+# These are triggers, not hard limits; see the headroom caveat above and
 # PITR_RECOVERY_CHECKPOINT_TIMEOUT/PITR_RECOVERY_MAX_WAL_SIZE above.
 if [ -f "$PGDATA/recovery.signal" ] && [ -n "${WAL_RECOVER_FROM_BUCKET:-}" ]; then
-  echo "pgbackrest: capping checkpoint_timeout=${PITR_RECOVERY_CHECKPOINT_TIMEOUT} max_wal_size=${PITR_RECOVERY_MAX_WAL_SIZE} for this replay boot"
+  echo "pgbackrest: requesting tighter restartpoints with checkpoint_timeout=${PITR_RECOVERY_CHECKPOINT_TIMEOUT} max_wal_size=${PITR_RECOVERY_MAX_WAL_SIZE} for this replay boot (best effort; retain one source checkpoint cycle of disk headroom)"
   set -- "$@" -c "checkpoint_timeout=${PITR_RECOVERY_CHECKPOINT_TIMEOUT}" -c "max_wal_size=${PITR_RECOVERY_MAX_WAL_SIZE}"
 fi
 

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -531,6 +531,23 @@ PITR_DONE_MARKER="$PGDATA/.pitr_configured"
 # our conf.d/pgbackrest-recovery.conf path would duplicate them.
 PGBACKREST_RESTORED_MARKER="$PGDATA/.pgbackrest_restored"
 
+# Checkpoint tuning applied ONLY to a replay boot, via `-c` flags on the
+# postgres invocation itself — never written to postgresql.conf/auto.conf.
+# Without this, pg_wal can accumulate WAL segments fetched by restore_command
+# until the next restartpoint, which fires at whatever cadence
+# checkpoint_timeout/max_wal_size already on disk allow (vanilla defaults,
+# a customer's own prod tuning on an existing volume, or — on a volume
+# cloned from the source at the block level — the source's tuning). On a
+# volume provisioned at ~the source's current size, that buffer risks
+# ENOSPC before recovery ever reaches the PITR target. `-c` wins over
+# auto.conf regardless of what's already on disk and applies to this one
+# process only, so there's nothing to revert: the next boot (post-promote,
+# once recovery.signal is gone) just uses the Dockerfile CMD's plain args.
+# Safe to be aggressive — this boot serves no live traffic, so the extra
+# checkpoint overhead only extends replay time, not query latency.
+PITR_RECOVERY_CHECKPOINT_TIMEOUT="${PITR_RECOVERY_CHECKPOINT_TIMEOUT:-30s}"
+PITR_RECOVERY_MAX_WAL_SIZE="${PITR_RECOVERY_MAX_WAL_SIZE:-512MB}"
+
 # Per-cluster archive sub-path: the effective repo1-path, persisted inside
 # PGDATA so the watcher, archive-push wrapper, and stanza-create subshell
 # all converge on the same value. Per-cluster pathing means a wipe-and-
@@ -2335,6 +2352,19 @@ fork_old_datadir_reclaim
 # preserves the e2e suite's existing behavior on docker stop / docker
 # restart.
 #
+# This boot is about to replay WAL from the source bucket toward a PITR
+# target — recovery.signal present (written either by
+# restore_from_pgbackrest_if_empty_volume's `pgbackrest restore` or by
+# configure_pgbackrest_recovery) plus WAL_RECOVER_FROM_BUCKET set covers both
+# paths. Cap checkpoint_timeout/max_wal_size for just this process so
+# restartpoints reclaim pg_wal often enough to keep disk usage close to the
+# base backup's size instead of whatever's already on disk. See
+# PITR_RECOVERY_CHECKPOINT_TIMEOUT/PITR_RECOVERY_MAX_WAL_SIZE above.
+if [ -f "$PGDATA/recovery.signal" ] && [ -n "${WAL_RECOVER_FROM_BUCKET:-}" ]; then
+  echo "pgbackrest: capping checkpoint_timeout=${PITR_RECOVERY_CHECKPOINT_TIMEOUT} max_wal_size=${PITR_RECOVERY_MAX_WAL_SIZE} for this replay boot"
+  set -- "$@" -c "checkpoint_timeout=${PITR_RECOVERY_CHECKPOINT_TIMEOUT}" -c "max_wal_size=${PITR_RECOVERY_MAX_WAL_SIZE}"
+fi
+
 # The traps below deliberately do NOT forward signals or restructure the
 # foreground invocation (that is the pattern CI rejected). They only
 # record that a stop was requested: bash runs a trap after the foreground


### PR DESCRIPTION
## Summary
- During PITR replay, `restore_command` can fetch WAL into `pg_wal` faster than old segments are reclaimed at restartpoints, increasing ENOSPC risk on tightly provisioned volumes.
- Applies `-c checkpoint_timeout=30s -c max_wal_size=512MB` only to the boot actively replaying from `WAL_RECOVER_FROM_BUCKET`. Command-line settings override inherited on-disk tuning and disappear automatically after promotion.
- This is a **best-effort restartpoint mitigation, not a hard disk bound**. During recovery PostgreSQL can only perform a restartpoint after replay reaches a checkpoint record written by the source, and `max_wal_size` may be exceeded by up to a source checkpoint cycle. Operators must retain that headroom.
- Base-backup restore remains direct-to-`PGDATA` via `pgbackrest restore --delta`; no staging copy is introduced.

## Test plan
- [x] `bash -n wrapper.sh`.
- [x] `git diff --check`.
- [x] `./test/e2e.sh t_empty_volume_restore_from_s3` — replay boot receives both recovery-only flags, restore/replay/promotion succeeds, and a post-promotion restart proves the flags do not leak into normal production operation.
- [x] Existing PITR regression suite previously green on this change; timing-sensitive source-target capture failures were also reproduced on the unmodified baseline.

## Operational note
The settings request earlier eligible restartpoints when inherited local tuning is loose. Capacity planning must still allow at least one source checkpoint cycle of WAL because neither setting can manufacture checkpoint records during recovery.
