### PR TITLE
fix(pitr): re-render recovery-source conf on restarts still mid-replay

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -2813,6 +2813,192 @@ t_restored_marker_persists_across_restarts() {
   docker volume rm "$src_vol" "$rest_vol" >/dev/null
 }
 
+# E6. Restarting WHILE still mid-replay (recovery.signal still present) must
+# re-render pgbackrest-recovery-source.conf, even though .pgbackrest_restored
+# is already set from the first boot's successful `pgbackrest restore` call.
+# Production regression: a restore that crashed before promoting (e.g. ran
+# out of disk) and got redeployed (fresh container, same volume) came back
+# with pgbackrest-recovery-source.conf missing — configure_pgbackrest_recovery
+# bailed on the marker alone, without checking whether recovery had actually
+# finished. Postgres could then only replay local WAL and FATALed with
+# "recovery ended before configured recovery target was reached", unable to
+# reach the archive at all. This must NOT regress: the marker alone is not
+# sufficient to skip re-rendering; recovery.signal must also be gone.
+#
+# Doesn't reuse setup_pitr_source: that source's backup-to-target gap is a
+# handful of INSERTs, which promotes in well under a second — nowhere near
+# enough of a replay window to reliably catch mid-flight. This test builds
+# its own source with a bulk insert between the base backup and the target
+# so recovery has real, measurable replay work, then force-kills the
+# restore as soon as it accepts connections (wait_for_pg returns true
+# during recovery, before promote) rather than racing a fixed sleep.
+t_recovery_conf_persists_across_restart_mid_replay() {
+  local src_name=t-src-heavy-${PG_VERSION}
+  local src_vol=${src_name}-vol
+  reset_bucket
+  new_volume "$src_vol"
+  docker rm -f "$src_name" >/dev/null 2>&1 || true
+  run_archiving_pg "$src_name" "$src_vol" -e "WAL_HEARTBEAT_DISABLED=1"
+  wait_for_pg "$src_name" || { ko t_recovery_conf_persists_across_restart_mid_replay "source did not start"; return; }
+  for _ in $(seq 1 15); do
+    docker logs "$src_name" 2>&1 | grep -q "stanza-create completed" && break
+    sleep 1
+  done
+  wait_for_watcher_backup "$src_name" full 60 || {
+    ko t_recovery_conf_persists_across_restart_mid_replay "watcher initial full did not land within 60s"
+    docker rm -f "$src_name" >/dev/null; docker volume rm "$src_vol" >/dev/null
+    return
+  }
+
+  docker exec -u postgres "$src_name" bash -c '
+    if [ -f /var/lib/postgresql/data/.pgbackrest_repo_path ]; then
+      export PGBACKREST_REPO1_PATH="$(cat /var/lib/postgresql/data/.pgbackrest_repo_path)"
+    else
+      export PGBACKREST_REPO1_PATH="$WAL_ARCHIVE_PATH"
+    fi
+    export PGBACKREST_REPO1_S3_BUCKET="$WAL_ARCHIVE_BUCKET"
+    export PGBACKREST_REPO1_S3_KEY="$WAL_ARCHIVE_KEY"
+    export PGBACKREST_REPO1_S3_KEY_SECRET="$WAL_ARCHIVE_SECRET"
+    export PGBACKREST_REPO1_S3_REGION="$WAL_ARCHIVE_REGION"
+    export PGBACKREST_REPO1_S3_ENDPOINT="$WAL_ARCHIVE_ENDPOINT"
+    pgbackrest --stanza=main backup --type=full
+  ' >/dev/null 2>&1
+  local src_path
+  src_path=$(docker exec "$src_name" cat /var/lib/postgresql/data/.pgbackrest_repo_path 2>/dev/null || echo "/pgbackrest")
+
+  # Bulk insert between the base backup and the target — gives the restore
+  # real WAL to replay instead of a handful of rows, so recovery takes long
+  # enough (seconds, not milliseconds) to reliably catch it mid-flight.
+  docker exec "$src_name" psql -U postgres -c "
+    CREATE TABLE bigdata (id serial, payload text);
+    INSERT INTO bigdata (payload) SELECT repeat('x', 500) FROM generate_series(1, 400000);
+  " >/dev/null
+  docker exec "$src_name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null
+  local target
+  target=$(docker exec "$src_name" psql -U postgres -At -c "SELECT now()::timestamptz(0)")
+  sleep 4
+  docker exec "$src_name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null
+
+  local last_segment
+  last_segment=$(docker exec "$src_name" psql -U postgres -At -c "SELECT pg_walfile_name(pg_current_wal_lsn())")
+  local archive_deadline=$(($(date +%s) + 90)) shipped=0
+  while [ "$(date +%s)" -lt "$archive_deadline" ]; do
+    local last_archived_wal
+    last_archived_wal=$(docker exec "$src_name" psql -U postgres -At -c "SELECT last_archived_wal FROM pg_stat_archiver" 2>/dev/null || echo "")
+    if [ -n "$last_archived_wal" ] && { [ "$last_archived_wal" = "$last_segment" ] || [ "$last_archived_wal" \> "$last_segment" ]; }; then
+      shipped=1; break
+    fi
+    docker exec "$src_name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null 2>&1 || true
+    sleep 2
+  done
+  if [ "$shipped" != 1 ]; then
+    ko t_recovery_conf_persists_across_restart_mid_replay "bulk-insert segment did not ship within 90s"
+    docker rm -f "$src_name" >/dev/null; docker volume rm "$src_vol" >/dev/null
+    return
+  fi
+
+  local rest_name=t-midreplay-restart-${PG_VERSION}
+  local rest_vol=${rest_name}-vol
+  new_volume "$rest_vol"
+  docker rm -f "$rest_name" >/dev/null 2>&1 || true
+
+  local restore_env=(
+    -e POSTGRES_PASSWORD=test
+    -e "WAL_RECOVER_FROM_BUCKET=$BUCKET"
+    -e "WAL_RECOVER_FROM_ENDPOINT=http://${MINIO}:9000"
+    -e WAL_RECOVER_FROM_REGION=us-east-1
+    -e "WAL_RECOVER_FROM_KEY=$MINIO_USER"
+    -e "WAL_RECOVER_FROM_SECRET=$MINIO_PASS"
+    -e "WAL_RECOVER_FROM_PATH=$src_path"
+    -e PGBACKREST_REPO1_S3_URI_STYLE=path
+    -e "POSTGRES_RECOVERY_TARGET_TIME=$target"
+  )
+
+  docker run -d --name "$rest_name" --label postgres-ssl-e2e=1 --network "$NET" \
+    "${restore_env[@]}" \
+    -v "$rest_vol:/var/lib/postgresql/data" \
+    "$IMAGE" >/dev/null
+
+  # Tight-poll pg_isready and kill the instant it succeeds — wait_for_pg
+  # returns true during recovery, before promote, so this catches the
+  # restore genuinely mid-replay instead of racing a fixed sleep against
+  # an unknown promote time.
+  local caught=0 i
+  for i in $(seq 1 600); do
+    if docker exec "$rest_name" pg_isready -U postgres -q 2>/dev/null; then
+      caught=1
+      break
+    fi
+    local status
+    status=$(docker inspect -f '{{.State.Status}}' "$rest_name" 2>/dev/null || echo "")
+    if [ "$status" = "exited" ]; then
+      ko t_recovery_conf_persists_across_restart_mid_replay "1st boot exited before becoming ready"
+      fail_dump t_recovery_conf_persists_across_restart_mid_replay "$rest_name"
+      docker rm -f "$src_name" "$rest_name" >/dev/null; docker volume rm "$src_vol" "$rest_vol" >/dev/null
+      return
+    fi
+    sleep 0.2
+  done
+  if [ "$caught" -ne 1 ]; then
+    ko t_recovery_conf_persists_across_restart_mid_replay "1st boot never became ready"
+    fail_dump t_recovery_conf_persists_across_restart_mid_replay "$rest_name"
+    docker rm -f "$src_name" "$rest_name" >/dev/null; docker volume rm "$src_vol" "$rest_vol" >/dev/null
+    return
+  fi
+
+  if ! docker exec "$rest_name" test -f /var/lib/postgresql/data/recovery.signal; then
+    ko t_recovery_conf_persists_across_restart_mid_replay "test setup: promoted too fast to catch mid-replay (recovery.signal already gone)"
+    docker rm -f "$src_name" "$rest_name" >/dev/null; docker volume rm "$src_vol" "$rest_vol" >/dev/null
+    return
+  fi
+  if ! docker exec "$rest_name" test -f /var/lib/postgresql/data/.pgbackrest_restored; then
+    ko t_recovery_conf_persists_across_restart_mid_replay "1st boot didn't write .pgbackrest_restored"
+    docker rm -f "$src_name" "$rest_name" >/dev/null; docker volume rm "$src_vol" "$rest_vol" >/dev/null
+    return
+  fi
+
+  # Simulate a crash + resize + redeploy: forcibly remove the container
+  # (same volume, same env) and boot a fresh one — /etc/pgbackrest is on
+  # the container's root filesystem, so this wipes the recovery conf that
+  # was in place, exactly like a real redeploy would.
+  docker kill "$rest_name" >/dev/null 2>&1 || true
+  docker rm -f "$rest_name" >/dev/null
+  docker run -d --name "$rest_name" --label postgres-ssl-e2e=1 --network "$NET" \
+    "${restore_env[@]}" \
+    -v "$rest_vol:/var/lib/postgresql/data" \
+    "$IMAGE" >/dev/null
+  wait_for_pg "$rest_name" || { ko t_recovery_conf_persists_across_restart_mid_replay "2nd boot"; fail_dump t_recovery_conf_persists_across_restart_mid_replay "$rest_name"; docker rm -f "$src_name" "$rest_name" >/dev/null; docker volume rm "$src_vol" "$rest_vol" >/dev/null; return; }
+
+  if ! docker exec "$rest_name" test -f /etc/pgbackrest/pgbackrest-recovery-source.conf; then
+    ko t_recovery_conf_persists_across_restart_mid_replay "pgbackrest-recovery-source.conf missing on restart mid-replay (marker bailed without checking recovery.signal)"
+    fail_dump t_recovery_conf_persists_across_restart_mid_replay "$rest_name"
+    docker rm -f "$src_name" "$rest_name" >/dev/null; docker volume rm "$src_vol" "$rest_vol" >/dev/null
+    return
+  fi
+
+  # The real proof: recovery must be able to actually finish now that it
+  # can still reach the archive, not just have the conf file present.
+  if ! wait_for_promoted "$rest_name"; then
+    ko t_recovery_conf_persists_across_restart_mid_replay "did not promote after restart mid-replay"
+    fail_dump t_recovery_conf_persists_across_restart_mid_replay "$rest_name"
+    docker rm -f "$src_name" "$rest_name" >/dev/null; docker volume rm "$src_vol" "$rest_vol" >/dev/null
+    return
+  fi
+
+  local missing_file_count
+  missing_file_count=$(docker logs "$rest_name" 2>&1 | grep -c "unable to open missing file.*pgbackrest-recovery-source.conf" || true)
+  if [ "${missing_file_count:-0}" -gt 0 ]; then
+    ko t_recovery_conf_persists_across_restart_mid_replay "logs show missing-file errors despite eventual promote (count=$missing_file_count)"
+    docker rm -f "$src_name" "$rest_name" >/dev/null; docker volume rm "$src_vol" "$rest_vol" >/dev/null
+    return
+  fi
+
+  ok t_recovery_conf_persists_across_restart_mid_replay
+  note "recovery conf re-rendered on mid-replay restart; recovery completed and promoted"
+  docker rm -f "$src_name" "$rest_name" >/dev/null
+  docker volume rm "$src_vol" "$rest_vol" >/dev/null
+}
+
 # ----- learnings from test-postgres-pitr (railway-side e2e harness) ----------
 #
 # These mirror flows from ../test-postgres-pitr/e2e/run-test.ts at the image
@@ -3627,6 +3813,7 @@ ALL_TESTS=(
   t_restore_then_wipe_volume_redoes_restore
   t_restored_service_can_enable_archive_after_promote
   t_restored_marker_persists_across_restarts
+  t_recovery_conf_persists_across_restart_mid_replay
   # learnings from test-postgres-pitr (image-level mirrors of the railway
   # mutation-driven e2e flows)
   t_pitr_target_xid_routes_xid_through_stack

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -242,6 +242,23 @@ wait_for_promoted() {
   return 1
 }
 
+# Poll `docker logs` for a pattern rather than checking once. Guards against
+# a real (if narrow) race: a container can flip to State.Status=exited a
+# beat before the docker log driver has drained its last buffered stdout,
+# so a single grep taken right after detecting "exited" can miss a line
+# that's actually there — a moment later fail_dump's own `docker logs` call
+# on the same container sees it fine. Tests that assert on a log message
+# following an expected-exit should use this instead of a one-shot grep.
+wait_for_log_line() {
+  local container="$1" pattern="$2" timeout="${3:-10}"
+  local deadline=$(($(date +%s) + timeout))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    docker logs "$container" 2>&1 | grep -q -- "$pattern" && return 0
+    sleep 0.5
+  done
+  return 1
+}
+
 cleanup_test_resources() {
   docker rm -f $(docker ps -aq --filter "label=postgres-ssl-e2e=1") 2>/dev/null >/dev/null || true
   for v in $(docker volume ls -q --filter "label=postgres-ssl-e2e=1" 2>/dev/null); do
@@ -923,7 +940,7 @@ t_empty_volume_restore_refuses_when_no_backup() {
     return
   fi
 
-  if ! docker logs "$name" 2>&1 | grep -q "restore from source bucket failed"; then
+  if ! wait_for_log_line "$name" "restore from source bucket failed"; then
     ko t_empty_volume_restore_refuses_when_no_backup "expected 'restore from source bucket failed' in logs"
     fail_dump t_empty_volume_restore_refuses_when_no_backup "$name"
     return
@@ -2213,7 +2230,7 @@ t_pitr_target_before_retention_window_refuses() {
     ko t_pitr_target_before_retention_window_refuses "wrapper exited 0; expected non-zero refusal"
     return
   fi
-  if ! docker logs "$rest_name" 2>&1 | grep -q "unable to find backup set"; then
+  if ! wait_for_log_line "$rest_name" "unable to find backup set"; then
     ko t_pitr_target_before_retention_window_refuses "expected 'unable to find backup set' from pgbackrest; logs:"
     fail_dump t_pitr_target_before_retention_window_refuses "$rest_name"
     return
@@ -2335,7 +2352,7 @@ t_empty_volume_restore_refuses_on_bad_creds() {
     ko t_empty_volume_restore_refuses_on_bad_creds "wrapper exited 0; expected non-zero refusal"
     return
   fi
-  if ! docker logs "$rest_name" 2>&1 | grep -q "restore from source bucket failed"; then
+  if ! wait_for_log_line "$rest_name" "restore from source bucket failed"; then
     ko t_empty_volume_restore_refuses_on_bad_creds "expected 'restore from source bucket failed' in logs"
     fail_dump t_empty_volume_restore_refuses_on_bad_creds "$rest_name"
     return

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -2877,10 +2877,20 @@ t_recovery_conf_persists_across_restart_mid_replay() {
   local target
   target=$(docker exec "$src_name" psql -U postgres -At -c "SELECT now()::timestamptz(0)")
   sleep 4
-  docker exec "$src_name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null
+  docker exec "$src_name" psql -U postgres -c "INSERT INTO bigdata (payload) VALUES ('post-target');" >/dev/null
 
+  # Capture the segment BEFORE switching — pg_current_wal_lsn() points at
+  # the post-target commit's LSN, and pg_walfile_name resolves that LSN to
+  # the segment presently holding it. Recovery only stops-and-promotes on a
+  # record timestamped strictly after target (a commit, not a bare segment
+  # switch); without a post-target commit there's nothing to satisfy that,
+  # and replay runs out of WAL and FATALs with "recovery ended before
+  # configured recovery target was reached" instead of promoting — same
+  # pattern every other target-time restore test in this file relies on
+  # (see id2_segment / id11_segment above).
   local last_segment
   last_segment=$(docker exec "$src_name" psql -U postgres -At -c "SELECT pg_walfile_name(pg_current_wal_lsn())")
+  docker exec "$src_name" psql -U postgres -c "SELECT pg_switch_wal(); SELECT pg_switch_wal();" >/dev/null
   local archive_deadline=$(($(date +%s) + 90)) shipped=0
   while [ "$(date +%s)" -lt "$archive_deadline" ]; do
     local last_archived_wal

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -754,23 +754,29 @@ configure_pgbackrest_recovery() {
   [ -z "$POSTGRES_RECOVERY_TARGET_TIME" ] && return 0
   [ ! -f "$POSTGRES_CONF_FILE" ] && return 0
 
-  # Recovery already done on this volume: skip both the conf write AND the
-  # staging path. Post-promote services have $PGBACKREST_RESTORED_MARKER
-  # (empty-volume restore handed off its own recovery params) or
-  # $PITR_DONE_MARKER (post-promote, picker-routed cleanup already ran).
-  # Rewriting the source-bucket creds on every boot of a long-promoted
-  # service leaks them onto disk for no functional benefit — archive_command
-  # uses the default conf, not this one, post-promote.
-  if [ -f "$PGBACKREST_RESTORED_MARKER" ] || [ -f "$PITR_DONE_MARKER" ]; then
-    return 0
+  # /etc/pgbackrest is rebuilt on every boot, so the S3-creds recovery conf
+  # must be re-rendered on every boot while recovery could still be in
+  # progress — postgres' restore_command (persisted in postgresql.auto.conf,
+  # whether written by this wrapper's own pgbackrest restore or an external
+  # one) references this path by name and needs it to exist to keep
+  # fetching WAL. $PGBACKREST_RESTORED_MARKER alone does NOT mean recovery
+  # finished — it means the empty-volume restore ran once, which can be
+  # true while still replaying (e.g. it crashed mid-replay and got
+  # redeployed). Only skip re-rendering once genuinely done: marker (or
+  # $PITR_DONE_MARKER) present AND recovery.signal gone, i.e. postgres has
+  # actually consumed it and promoted — that's also when we stop, to avoid
+  # leaking source-bucket creds onto disk for a long-running promoted
+  # service with no functional benefit.
+  local recovery_genuinely_done=0
+  if [ -f "$PITR_DONE_MARKER" ]; then
+    recovery_genuinely_done=1
+  elif [ -f "$PGBACKREST_RESTORED_MARKER" ] && [ ! -f "$PGDATA/recovery.signal" ]; then
+    recovery_genuinely_done=1
   fi
 
-  # /etc/pgbackrest is rebuilt on every boot, so always re-render the
-  # recovery conf when WAL_RECOVER_FROM_* is set — postgres' restore_command
-  # references it whether the auto.conf was written by the wrapper's own
-  # pgbackrest restore or by an external one (e.g. test pgbackrest_restore_into).
-  install -d -m 0750 -o postgres -g postgres /etc/pgbackrest
-  cat > "$PGBACKREST_RECOVERY_S3_CONF" <<EOF
+  if [ "$recovery_genuinely_done" -eq 0 ]; then
+    install -d -m 0750 -o postgres -g postgres /etc/pgbackrest
+    cat > "$PGBACKREST_RECOVERY_S3_CONF" <<EOF
 [global]
 log-level-console=info
 log-level-file=off
@@ -788,8 +794,19 @@ repo1-path=${WAL_RECOVER_FROM_PATH:-/pgbackrest}
 pg1-path=${PGDATA}
 pg1-port=5432
 EOF
-  chown postgres:postgres "$PGBACKREST_RECOVERY_S3_CONF"
-  chmod 0640 "$PGBACKREST_RECOVERY_S3_CONF"
+    chown postgres:postgres "$PGBACKREST_RECOVERY_S3_CONF"
+    chmod 0640 "$PGBACKREST_RECOVERY_S3_CONF"
+  fi
+
+  # Recovery already done on this volume, OR the conf.d write below would
+  # duplicate what pgbackrest restore already wrote directly into
+  # postgresql.auto.conf: skip the conf.d write AND the staging path.
+  # Unchanged from before — this gate is about the empty-volume-restore
+  # case having already written its own restore_command directly, not about
+  # whether recovery has actually finished (that's handled above).
+  if [ -f "$PGBACKREST_RESTORED_MARKER" ] || [ -f "$PITR_DONE_MARKER" ]; then
+    return 0
+  fi
 
   # PGBACKREST_RESTORED_MARKER / PITR_DONE_MARKER short-circuited above, so
   # the only paths reaching here are (a) first-time staging or (b) the

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -754,18 +754,20 @@ configure_pgbackrest_recovery() {
   [ -z "$POSTGRES_RECOVERY_TARGET_TIME" ] && return 0
   [ ! -f "$POSTGRES_CONF_FILE" ] && return 0
 
-  # /etc/pgbackrest is rebuilt on every boot, so the S3-creds recovery conf
-  # must be re-rendered on every boot while recovery could still be in
-  # progress — postgres' restore_command (persisted in postgresql.auto.conf,
-  # whether written by this wrapper's own pgbackrest restore or an external
-  # one) references this path by name and needs it to exist to keep
-  # fetching WAL. $PGBACKREST_RESTORED_MARKER alone does NOT mean recovery
-  # finished — it means the empty-volume restore ran once, which can be
-  # true while still replaying (e.g. it crashed mid-replay and got
-  # redeployed). Only skip re-rendering once genuinely done: marker (or
-  # $PITR_DONE_MARKER) present AND recovery.signal gone, i.e. postgres has
-  # actually consumed it and promoted — that's also when we stop, to avoid
-  # leaking source-bucket creds onto disk for a long-running promoted
+  # /etc/pgbackrest lives on the container's root filesystem, not the
+  # mounted volume, so it's gone on a genuine redeploy (a brand-new
+  # container) even though it'd survive a plain in-place restart of the
+  # same container. A crashed-mid-replay restore that gets redeployed (e.g.
+  # after a manual resize) hits exactly that case: $PGBACKREST_RESTORED_MARKER
+  # is already set on the (persistent) volume from the first boot's
+  # successful `pgbackrest restore`, but that marker means "the restore
+  # command ran once," not "recovery finished" — postgres hasn't consumed
+  # recovery.signal yet, so it still needs this conf's restore_command to
+  # keep fetching WAL, and the redeploy just wiped it. Re-render on every
+  # boot while that's still possibly true, and only skip once genuinely
+  # done: marker (or $PITR_DONE_MARKER) present AND recovery.signal gone,
+  # i.e. postgres has actually promoted — that's also when we stop, to
+  # avoid leaking source-bucket creds onto disk for a long-running promoted
   # service with no functional benefit.
   local recovery_genuinely_done=0
   if [ -f "$PITR_DONE_MARKER" ]; then


### PR DESCRIPTION
## Summary
- `configure_pgbackrest_recovery` bailed on `$PGBACKREST_RESTORED_MARKER` alone, treating "the empty-volume restore ran once" as equivalent to "recovery finished." Those aren't the same thing.
- A restore that crashes before promoting (e.g. runs out of disk mid-replay) and gets **redeployed** (a brand-new container, not just an in-place restart of the same one) comes back with the marker already set but `recovery.signal` still on disk. `/etc/pgbackrest` lives on the container's root filesystem, so a genuine redeploy wipes it even though a plain restart of the same container wouldn't — the marker-only bail meant `pgbackrest-recovery-source.conf` never got rewritten on the next boot, and postgres could no longer reach the archive to keep replaying WAL. Production symptom: repeated `unable to open missing file '/etc/pgbackrest/pgbackrest-recovery-source.conf'` followed by `FATAL: recovery ended before configured recovery target was reached`, permanently stuck. (The support ticket's own timeline confirms the redeploy-specific trigger: the initial crash-loop, disk-full, no redeploy involved, never hit the missing-file error — it only appeared after the customer's explicit resize + redeploy.)
- Split the gate: the S3-creds conf now re-renders on every boot until recovery is genuinely done (marker or `$PITR_DONE_MARKER` present **and** `recovery.signal` gone — i.e. postgres actually promoted). Re-rendering is idempotent whether or not the file actually needed rebuilding, so this is safe regardless of restart vs. redeploy. The conf.d duplicate-write guard right below it keeps its original, unchanged marker-only check, since that's a separate concern (avoiding a redundant `restore_command` write, not a recovery-progress check).

Companion to railwayapp/mono#32564, which fixes the volume-headroom bug that was the primary trigger for hitting this (crash-loop → manual resize → redeploy). With that fix, restores should mostly reach the target on the first attempt and rarely need this path — but this bug is real on its own and can still be hit any time a restore-in-progress service gets redeployed (resize, manual redeploy, an env var change, etc.) before it's finished replaying.

## Test plan
- [x] New e2e test `t_recovery_conf_persists_across_restart_mid_replay`: builds its own source with a bulk insert between the base backup and target (the shared `setup_pitr_source` fixture promotes in well under a second — too fast to reliably catch mid-replay), kills the restore the instant it starts accepting connections (still mid-replay), restarts it, and asserts the recovery conf reappears and recovery actually finishes.
- [x] Existing regression test `t_restored_marker_persists_across_restarts` (already-promoted restart must NOT re-render the conf, to avoid leaking source-bucket creds) still passes unchanged.
- [x] Both verified against a real build+run of the e2e suite, plus manual reproduction catching the exact `recovery.signal=present` mid-replay state and confirming: before the fix, the conf is missing and recovery gets stuck; after the fix, the conf reappears and the container promotes successfully.
