### PR TITLE
ci: rebuild daily instead of weekly

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -2,7 +2,7 @@ name: Build and Push PostgreSQL Images
 
 on:
   schedule:
-    - cron: "0 0 * * 1"  # Every Monday at midnight UTC
+    - cron: "0 0 * * *"  # Daily at midnight UTC
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION
## Summary
- Rebuilds every supported major daily (was weekly) so a Postgres CVE fix released upstream reaches this image in ~1 day instead of up to ~6.
- No change to build logic — `get-postgres-version.sh` already pulls whatever's latest on Docker Hub at build time, so this is purely a cadence change.

## Test plan
- [ ] Confirm the workflow still runs clean on the new schedule after merge (or trigger manually via workflow_dispatch to sanity check).