### PR TITLE
fix(wrapper): make collation-refresh tmpfile readable by postgres user

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1042,6 +1042,9 @@ fork_collation_refresh() {
 
     local tmpfile
     tmpfile=$(mktemp /tmp/collation-refresh.XXXXXX.sql)
+    # mktemp creates 0600 root-owned files; psql runs as postgres via gosu and
+    # cannot read it ("Permission denied"), silently skipping the refresh.
+    chmod 644 "$tmpfile"
     cat > "$tmpfile" << 'ENDSQL'
 DO $body$
 DECLARE


### PR DESCRIPTION
## Problem

`refresh_collation_versions` writes its SQL to a `mktemp` file (mode 0600, owned by root) and then executes it via `gosu postgres psql -f`. The postgres user cannot read the file, so every boot logs:

```
collation-refresh: psql: error: /tmp/collation-refresh.XXXXXX.sql: Permission denied
```

and the collation version refresh is silently skipped.

## Fix

`chmod 644` the tmpfile right after `mktemp` so the `gosu postgres` invocation can read it.

## Validation

Deployed this patch on a production Railway Postgres 18 service (pre-existing volume). Boot logs before the fix show the `Permission denied` error; after the fix:

```
collation-refresh: psql:/tmp/collation-refresh.ZgkXnb.sql:16: NOTICE:  version has not changed
```

(one NOTICE per database, as intended).