### PR TITLE
fix(pitr): decouple expire failure from backup failure in watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,9 +278,17 @@ periodic full (#85, hardened by #86).
 `pgbackrest backup` is invoked with `--type=full` or `--type=diff`
 depending on the trigger; the `process-max=backup` setting (default
 `clamp(cpus/4, 1, 16)`) caps copy concurrency to leave CPU for live DB
-traffic. `pgbackrest expire` runs automatically after each backup and
-removes fulls/diffs beyond `WAL_BACKUP_RETENTION_FULL` /
-`_DIFF`, plus the WAL their manifests no longer pin.
+traffic. Backups run with `--no-expire-auto`; `pgbackrest expire` is then
+called as its own step right after a *successful* backup, and removes
+fulls/diffs beyond `WAL_BACKUP_RETENTION_FULL` / `_DIFF`, plus the WAL
+their manifests no longer pin. Splitting the two matters because
+pgBackRest's default (`expire-auto=y`) folds expire into the same
+command, so a transient expire failure (e.g. a slow S3-compatible
+endpoint on the post-backup listing) would otherwise fail the whole
+`backup` invocation even though the backup itself landed and is durable
+— leaving the watcher's `last_full_at` unset and re-triggering a brand
+new full upload every retry cycle instead of just deferring retention to
+the next backup.
 
 #### Retention
 

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -260,7 +260,20 @@ run_backup() {
   # --repo=1 scopes backup + post-backup expire to this service's own bucket.
   # On a fork repo2 is source's read-only bucket; without the pin pgBackRest
   # would default to writing the new base into both repos.
-  pgbackrest --stanza=main --repo=1 backup --type="$type"
+  #
+  # --no-expire-auto: pgBackRest's default (expire-auto=y) runs retention
+  # cleanup as part of this same command, so a failure/timeout during expire
+  # (e.g. a slow S3-compatible endpoint on the post-backup bucket listing)
+  # makes `backup` itself return non-zero even though the backup already
+  # landed and is durable in the catalog. That false failure used to keep
+  # last_full_at empty forever, so decide_action treated the backup as
+  # permanently overdue and re-ran a brand-new FULL upload every retry
+  # cycle — unbounded egress from re-uploading the entire database in a
+  # loop, invisible to anything watching for backup *failures* because the
+  # backup itself kept succeeding. Expire now runs as its own explicit,
+  # non-gating step below, only after the backup is confirmed to have
+  # actually succeeded.
+  pgbackrest --stanza=main --repo=1 backup --type="$type" --no-expire-auto
   local exit_code=$?
 
   # Exit 55 = FileMissingError: backup.info absent — stanza was never
@@ -269,7 +282,7 @@ run_backup() {
   if [ "$exit_code" -eq 55 ]; then
     log "stanza not initialized (exit 55), running stanza-create then retrying backup..."
     pgbackrest --stanza=main stanza-create || true
-    pgbackrest --stanza=main --repo=1 backup --type="$type"
+    pgbackrest --stanza=main --repo=1 backup --type="$type" --no-expire-auto
     exit_code=$?
   fi
 
@@ -301,6 +314,19 @@ run_backup() {
       ;;
   esac
   log "backup --type=$type completed"
+
+  # Retention is best-effort and deliberately decoupled from backup success
+  # (see --no-expire-auto above): a failure here just leaves old
+  # backups/WAL around for one more cycle. The next scheduled backup (full
+  # or diff, per the normal cadence — no dedicated retry loop for expire
+  # alone) tries again; nothing about current restorability regresses in
+  # the meantime. Log line is deliberately distinct from "backup
+  # --type=$type failed" above so this can't be mistaken for a backup
+  # failure by anything grepping watcher logs.
+  if ! pgbackrest --stanza=main --repo=1 expire; then
+    log "pgbackrest expire failed after successful backup --type=$type (retention not enforced this cycle; will retry after next backup)"
+  fi
+
   emit_pitr_anchor
   return 0
 }


### PR DESCRIPTION
## Summary
- `pgbackrest backup` bundles the actual backup and the automatic post-backup `expire` (retention cleanup) into one command (pgBackRest's `expire-auto=y` default). A transient expire failure — e.g. a slow S3-compatible endpoint timing out on the post-backup listing — makes the whole `backup` invocation return non-zero even though the backup itself already landed durably in the catalog.
- `run_backup()` treated that non-zero exit as a total failure and never wrote `last_full_at`, so `decide_action()` saw the full backup as perpetually overdue and re-ran a brand-new full upload of the entire database every retry cycle. Since the backup itself kept succeeding, this never surfaced as a backup *failure* to anything watching for one — just unbounded egress from repeatedly re-uploading the whole database.
- Fix: run backup with `--no-expire-auto`, then call `pgbackrest expire` as its own decoupled, non-gating step right after a successful backup. A failed expire now just defers retention by one cycle (logged distinctly) instead of masking a successful backup as a failure.

## Test plan
- [x] `bash -n` + syntax check on the modified script
- [x] Local e2e subset against the patched image (all pass): `t_watcher_initial_full`, `t_watcher_periodic_full`, `t_watcher_periodic_diff`, `t_retention_expires_old_fulls`, `t_retention_expire_cascades_to_wal`, `t_watcher_gap_recovery_full`, `t_watcher_gap_recovery_failed_count_path`, `t_watcher_gap_recovery_lsn_lag_path`
- [ ] Full CI e2e suite