### PR TITLE
feat: in-place major version upgrade job image + cross-major boot guards

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -68,3 +68,62 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.minor_version }}
             ${{ matrix.postgres_major == env.LATEST_POSTGRES_MAJOR && format('ghcr.io/{0}:latest', github.repository) || '' }}
 
+
+  # One image per (source, target) major pair, carrying both majors' server
+  # binaries so pg_upgrade can drive both clusters. The dashboard's upgrade
+  # workflow dispatches these by tag, so every pair a user can select must
+  # exist: any supported major to any NEWER supported major.
+  #
+  # 14 is the oldest major the upgrade flow offers (13 is past upstream EOL and
+  # is not an upgrade target), which keeps this at 10 pairs.
+  build-upgrade-jobs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    strategy:
+      matrix:
+        include:
+          - { from: 14, to: 15 }
+          - { from: 14, to: 16 }
+          - { from: 14, to: 17 }
+          - { from: 14, to: 18 }
+          - { from: 15, to: 16 }
+          - { from: 15, to: 17 }
+          - { from: 15, to: 18 }
+          - { from: 16, to: 17 }
+          - { from: 16, to: 18 }
+          - { from: 17, to: 18 }
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push the upgrade job image
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.upgrade
+          platforms: linux/arm64,linux/amd64
+          push: true
+          build-args: |
+            FROM_VERSION=${{ matrix.from }}
+            TO_VERSION=${{ matrix.to }}
+          tags: |
+            ghcr.io/${{ github.repository }}/upgrade:${{ matrix.from }}-${{ matrix.to }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,8 +74,15 @@ jobs:
   # 16→17 is the fleet's common pair; 17→18 pins the majors where initdb's
   # data-checksums default flipped (18) — every →18 upgrade would fail
   # --check without the explicit parity flag, which only a real 18 target
-  # can regress-test. The harness builds its own images (FROM, TO, and the
-  # dual-binary job image), so no buildx step is needed here.
+  # can regress-test. 15→16 exercises the reg*/aclitem blockers
+  # (t_check_blocker_pre16_types self-skips at FROM>=16), which the
+  # dashboard preflight also checks for and was otherwise never
+  # regression-tested anywhere in CI — pg_upgrade's own behavior here isn't
+  # a clean "any pre-16 source" rule (14→15 fires neither check; see the
+  # test's own docblock), so this cell is a pair confirmed to trigger both,
+  # not a stand-in for every pre-16 pair. The
+  # harness builds its own images (FROM, TO, and the dual-binary job image),
+  # so no buildx step is needed here.
   e2e-upgrade:
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -86,6 +93,7 @@ jobs:
         include:
           - { from: 16, to: 17 }
           - { from: 17, to: 18 }
+          - { from: 15, to: 16 }
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,3 +69,56 @@ jobs:
           name: e2e-logs-pg${{ matrix.pg_version }}
           path: failure-artifacts
           retention-days: 14
+
+  # Major-upgrade harness (test/e2e-upgrade.sh): one cell per version pair.
+  # 16→17 is the fleet's common pair; 17→18 pins the majors where initdb's
+  # data-checksums default flipped (18) — every →18 upgrade would fail
+  # --check without the explicit parity flag, which only a real 18 target
+  # can regress-test. The harness builds its own images (FROM, TO, and the
+  # dual-binary job image), so no buildx step is needed here.
+  e2e-upgrade:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { from: 16, to: 17 }
+          - { from: 17, to: 18 }
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Run upgrade e2e harness
+        shell: bash
+        env:
+          FROM_VERSION: ${{ matrix.from }}
+          TO_VERSION: ${{ matrix.to }}
+        run: |
+          ./test/e2e-upgrade.sh 2>&1 | tee "e2e-upgrade-${FROM_VERSION}-${TO_VERSION}.log"
+          exit "${PIPESTATUS[0]}"
+
+      - name: Collect failure diagnostics
+        if: failure()
+        env:
+          FROM_VERSION: ${{ matrix.from }}
+          TO_VERSION: ${{ matrix.to }}
+        run: |
+          mkdir -p failure-artifacts
+          mv "e2e-upgrade-${FROM_VERSION}-${TO_VERSION}.log" failure-artifacts/ 2>/dev/null || true
+          docker ps -a > failure-artifacts/docker-ps.txt 2>&1 || true
+          docker volume ls > failure-artifacts/docker-volumes.txt 2>&1 || true
+          for c in $(docker ps -aq --filter "label=postgres-upgrade-e2e=1"); do
+            name=$(docker inspect -f '{{.Name}}' "$c" | sed 's|^/||')
+            docker logs --tail 200 "$c" > "failure-artifacts/container-${name}.log" 2>&1 || true
+          done
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-upgrade-logs-${{ matrix.from }}-${{ matrix.to }}
+          path: failure-artifacts
+          retention-days: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,6 +96,11 @@ jobs:
         env:
           FROM_VERSION: ${{ matrix.from }}
           TO_VERSION: ${{ matrix.to }}
+          # Keep the harness's containers past its EXIT trap so the failure
+          # step below can still `docker logs` them (the trap otherwise
+          # removes them first, making that loop dead code). The runner VM
+          # is discarded either way.
+          E2E_KEEP_CONTAINERS: "1"
         run: |
           ./test/e2e-upgrade.sh 2>&1 | tee "e2e-upgrade-${FROM_VERSION}-${TO_VERSION}.log"
           exit "${PIPESTATUS[0]}"

--- a/Dockerfile.upgrade
+++ b/Dockerfile.upgrade
@@ -1,0 +1,37 @@
+# Dual-binary one-shot upgrade job image: carries the TARGET major as the
+# base plus the SOURCE major's server binaries, so pg_upgrade can drive both
+# clusters. Built per (FROM_VERSION, TO_VERSION) pair, e.g.:
+#
+#   docker build -f Dockerfile.upgrade \
+#     --build-arg FROM_VERSION=16 --build-arg TO_VERSION=17 \
+#     -t postgres-upgrade:16-17 .
+#
+# The entrypoint (upgrade-job.sh) is the whole program: check / upgrade /
+# status / manifest modes, documented in the script header. It runs against
+# the database service's own volume while the service is stopped.
+ARG TO_VERSION=17
+FROM postgres:${TO_VERSION}
+
+ARG FROM_VERSION=16
+ARG TO_VERSION
+ENV PG_UPGRADE_FROM=${FROM_VERSION}
+ENV PG_UPGRADE_TO=${TO_VERSION}
+
+# The official image's PGDG apt source is pinned to its own major's component;
+# widen it so the source major's packages resolve too. pgvector installs for
+# BOTH majors: pg_upgrade starts the old server (its loaded libraries must
+# resolve) and the new cluster must be able to load every library the old one
+# references, or --check fails with "loadable libraries" errors.
+RUN sed -ri "s/^(deb .*pgdg main).*$/\1 ${FROM_VERSION} ${TO_VERSION}/" /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+      postgresql-${FROM_VERSION} \
+      postgresql-${FROM_VERSION}-pgvector \
+      postgresql-${TO_VERSION}-pgvector \
+      jq \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --chmod=755 upgrade-job.sh /usr/local/bin/upgrade-job.sh
+
+ENTRYPOINT ["upgrade-job.sh"]
+CMD ["upgrade"]

--- a/Dockerfile.upgrade
+++ b/Dockerfile.upgrade
@@ -34,4 +34,11 @@ RUN sed -ri "s/^(deb .*pgdg main).*$/\1 ${FROM_VERSION} ${TO_VERSION}/" /etc/apt
 COPY --chmod=755 upgrade-job.sh /usr/local/bin/upgrade-job.sh
 
 ENTRYPOINT ["upgrade-job.sh"]
-CMD ["upgrade"]
+# Read-only default: production dispatch always sets UPGRADE_JOB_MODE, which
+# wins over this positional arg unconditionally (upgrade-job.sh resolves the
+# env var before ever looking at argv), so this CMD only matters for a bare
+# `docker run` with no mode specified — exactly the ad-hoc manual/incident-
+# response invocation the entrypoint's own mode-dispatch comments call out as
+# where a typo happens. Defaulting to the single most destructive mode there
+# is would be the one input this script's fail-stop design doesn't guard.
+CMD ["status"]

--- a/README.md
+++ b/README.md
@@ -562,6 +562,13 @@ expiry/cleanup for orphaned `cluster-*` prefixes (after a safety window) is
 an open follow-up, tracked for the dashboard/backboard side; the image does
 not delete archive data.
 
+There's also a small tail gap at the old prefix specifically: WAL written
+between the old cluster's last successful archive push and the upgrade
+never reaches the old prefix (the upgrade job's own quiesce step archives
+nothing new — see `ensure_clean_shutdown`'s docblock). The pre-upgrade
+backup this feature always takes is what covers that point, not the old
+archive.
+
 Tests: `./test/e2e-upgrade.sh` (add `FROM_VERSION=14 TO_VERSION=17` to cover a
 pre-16 source, where pg_upgrade's `reg*`/`aclitem` checks fire). CI runs the
 harness on 16→17 and 17→18 — the latter pins the initdb data-checksums

--- a/README.md
+++ b/README.md
@@ -377,13 +377,26 @@ takes a mode as its argument:
 | `status` | Prints the marker phase + on-disk major as JSON, for resume decisions. |
 | `manifest` | Prints the target major's installable extensions as JSON. |
 
-The job connects as the cluster's actual install user
-(`${POSTGRES_USER:-postgres}`), and initdb's the target cluster with the same
-name — a service deployed with a custom `POSTGRES_USER` has no `postgres`
-role at all, and pg_upgrade requires both clusters' install users to match.
+The job connects as the cluster's actual install user, and initdb's the
+target cluster with the same name — pg_upgrade requires both clusters'
+install users to match. Which env var names that user depends on the
+template family, and the two disagree: on postgres-ssl the official
+entrypoint initdb's with `--username="$POSTGRES_USER"` (a custom-user
+service has no `postgres` role at all), while on postgres-ha
+`POSTGRES_USER` is the **app** user Patroni creates and the install user is
+`PATRONI_SUPERUSER_USERNAME` (default `postgres`). The job disambiguates by
+the volume itself — a Patroni-managed data dir always carries
+`patroni.dynamic.json` — so the same inherited service env resolves
+correctly on both. The target initdb also replays the service's
+`POSTGRES_INITDB_ARGS` (evaled, exactly as the official entrypoint does at
+init time), because pg_upgrade refuses any locale/encoding mismatch and a
+cluster initialized with `--locale=C` could otherwise never pair with an
+image-default target.
 Every `RAILWAY_UPGRADE_RESULT:` payload is built with `jq --arg` (compact,
 one line) so no on-disk byte a database superuser can write reaches the
-workflow's JSON parser unescaped.
+workflow's JSON parser unescaped — and every passthrough of pg_upgrade
+output, server logs, or failure lists is indented, so no
+attacker-controlled byte can start a line with the result sentinel either.
 
 Volumes with `recovery.signal` or `standby.signal` are refused outright by
 both `check` and `upgrade` (exit 2): those shapes can't be upgraded in
@@ -437,7 +450,12 @@ reset to initdb's recognizable default shape — loopback host rules and
 nothing else. A config the operator narrowed by address, database/user, or
 TLS is an authored policy and is never silently re-widened; a file with no
 host rules at all is a deliberate local-only lockdown and is left alone
-too. The PITR lifecycle sentinels (`.pitr_configured`,
+too. One residual ambiguity is accepted knowingly: a config an operator
+deliberately narrowed to *exactly* initdb's loopback-only shape is
+byte-indistinguishable from a reset and gets the rule re-appended — on
+Railway a loopback-only Postgres is unreachable by every real client
+(private networking is a remote connection), so the shape reads as a reset,
+not a policy. The PITR lifecycle sentinels (`.pitr_configured`,
 `.pitr_staging`, `.pgbackrest_restored`) are carried across the swap too,
 and a `completed` upgrade marker is itself treated as proof that recovery
 already promoted — otherwise an upgraded PITR-restored fork (whose

--- a/README.md
+++ b/README.md
@@ -372,10 +372,18 @@ takes a mode as its argument:
 
 | Mode | Effect |
 |------|--------|
-| `check` | `pg_upgrade --check` against a throwaway target cluster. Exit 1 = blockers. **Not strictly read-only**: a cluster that wasn't shut down cleanly (the platform stops containers with SIGKILL, so that's the normal case) is first quiesced — WAL replayed with the old binaries, then a clean shutdown — exactly what the next boot would have done. Only a cleanly-shut-down volume is checked without writes. |
+| `check` | `pg_upgrade --check` against a throwaway target cluster. Exit 1 = blockers, exit 2 = precondition refusal, exit 3 = environment failure (the quiesce could not start or stop the old server — its log is printed). Also proves the real upgrade's sibling directory slot is creatable on the volume, so a green check can't hide a volume-root permission problem the real run would hit. **Not strictly read-only**: a cluster that wasn't shut down cleanly (the platform stops containers with SIGKILL, so that's the normal case) is first quiesced — WAL replayed with the old binaries, then a clean shutdown — exactly what the next boot would have done. Only a cleanly-shut-down volume is checked without writes. |
 | `upgrade` | `--check`, then `pg_upgrade --link`, then the completion marker and directory swap. |
 | `status` | Prints the marker phase + on-disk major as JSON, for resume decisions. |
 | `manifest` | Prints the target major's installable extensions as JSON. |
+
+The job connects as the cluster's actual install user
+(`${POSTGRES_USER:-postgres}`), and initdb's the target cluster with the same
+name — a service deployed with a custom `POSTGRES_USER` has no `postgres`
+role at all, and pg_upgrade requires both clusters' install users to match.
+Every `RAILWAY_UPGRADE_RESULT:` payload is built with `jq --arg` (compact,
+one line) so no on-disk byte a database superuser can write reaches the
+workflow's JSON parser unescaped.
 
 Volumes with `recovery.signal` or `standby.signal` are refused outright by
 both `check` and `upgrade` (exit 2): those shapes can't be upgraded in
@@ -401,7 +409,12 @@ Both sides also hold a `flock` on the volume-root
 container shared for its lifetime. A job dispatched against a live database
 refuses instead of corrupting the cluster, and a database deployed while a
 job is mid-flight refuses to boot — in-image backstops for the
-orchestrator's own exclusion.
+orchestrator's own exclusion. Honest scope note: the shared side only exists
+on runtime images built from this change, so a service still running an
+older image is protected during its first upgrade by the orchestrator's
+stop-before-dispatch and the platform's single-mount guarantee alone — the
+lock becomes a real backstop for that service only after it redeploys onto a
+current image.
 
 The job tolerates the platform's ungraceful container stop: it clears a stale
 `postmaster.pid` and, when `pg_control` says the cluster was not shut down
@@ -416,14 +429,28 @@ SSL off and rejects every `sslmode=require` client. `pg_hba.conf` gets the
 same two-layer treatment: the job carries the old cluster's `pg_hba.conf`
 (and `pg_ident.conf`) into the new data directory — it's the user's actual
 config, custom rules included — and `wrapper.sh` re-appends the
-`host all all all <method>` rule whenever the config lacks any host rule,
-because a database without it looks healthy from localhost while refusing
-every remote client. The PITR lifecycle sentinels (`.pitr_configured`,
+`host all all all <method>` rule when (and only when) the file has been
+reset to initdb's recognizable default shape — loopback host rules and
+nothing else. A config the operator narrowed by address, database/user, or
+TLS is an authored policy and is never silently re-widened; a file with no
+host rules at all is a deliberate local-only lockdown and is left alone
+too. The PITR lifecycle sentinels (`.pitr_configured`,
 `.pitr_staging`, `.pgbackrest_restored`) are carried across the swap too,
 and a `completed` upgrade marker is itself treated as proof that recovery
 already promoted — otherwise an upgraded PITR-restored fork (whose
 `WAL_RECOVER_FROM_*` env stays set forever) would re-stage archive recovery
 against the source bucket and never become ready.
+
+`postgresql.conf` and `postgresql.auto.conf` (`ALTER SYSTEM` settings) are
+deliberately **not** carried: either file can hold a GUC the target major
+removed, and one unrecognized parameter there refuses the whole boot. The
+user's tuning must not silently evaporate either, so the job stashes both
+files at the volume root as `.pre-upgrade-<from>-postgresql.conf` /
+`.pre-upgrade-<from>-postgresql.auto.conf` (they outlive the old data dir's
+24 h reclaim) and records `needsConfigReview: true` in the completed marker —
+surfacing "re-apply your `ALTER SYSTEM` settings" is the dashboard's job,
+because the alternative is the user discovering it via a post-upgrade
+`max_connections` regression.
 
 #### Disk reclaim and rollback window
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ recovery entirely **even if `POSTGRES_RECOVERY_TARGET_TIME` is changed
 to a different value** — the cluster has already promoted to a new
 timeline and replaying again would corrupt it. To probe a different
 target, restore from a fresh volume snapshot (or, advanced: remove
-`$PGDATA/.pitr_configured` before the next start).
+`$PGDATA/.pitr_configured` before the next start — and, if the service
+was ever major-upgraded, the volume-root `.railway-major-upgrade.json`
+too, since a completed upgrade marker is also read as "recovery done").
 
 When `POSTGRES_RECOVERY_TARGET_TIME` is set on a brand-new container
 (no `$PGDATA/PG_VERSION`), the wrapper runs `pgbackrest --repo=2 restore
@@ -370,16 +372,36 @@ takes a mode as its argument:
 
 | Mode | Effect |
 |------|--------|
-| `check` | `pg_upgrade --check` against a throwaway target cluster. Volume untouched. Exit 1 = blockers. |
+| `check` | `pg_upgrade --check` against a throwaway target cluster. Exit 1 = blockers. **Not strictly read-only**: a cluster that wasn't shut down cleanly (the platform stops containers with SIGKILL, so that's the normal case) is first quiesced — WAL replayed with the old binaries, then a clean shutdown — exactly what the next boot would have done. Only a cleanly-shut-down volume is checked without writes. |
 | `upgrade` | `--check`, then `pg_upgrade --link`, then the completion marker and directory swap. |
 | `status` | Prints the marker phase + on-disk major as JSON, for resume decisions. |
 | `manifest` | Prints the target major's installable extensions as JSON. |
 
-`.railway-major-upgrade.json` at the volume root is the commit point:
-`upgraded` means pg_upgrade succeeded and recovery must roll **forward**;
-`completed` means the swap is done. `wrapper.sh` refuses to boot while a
-non-completed marker exists, and refuses any image whose major differs from
-the on-disk `PG_VERSION` — so no mismatched boot can touch the data.
+Volumes with `recovery.signal` or `standby.signal` are refused outright by
+both `check` and `upgrade` (exit 2): those shapes can't be upgraded in
+place, and the quiesce would consume a mid-restore volume's recovery intent.
+Finish or promote recovery first.
+
+`.railway-major-upgrade.json` at the volume root is the commit point
+(fsynced through the parent directory, and every write checked before any
+directory is mutated): `upgraded` means pg_upgrade succeeded and recovery
+must roll **forward**; `completed` means the swap is done. Both phases are
+scoped to the marker's own version pair — a `completed` marker from a
+previous upgrade of the same volume is history, not state, so chained
+upgrades (16→17, later 17→18) work; an in-flight marker of a foreign pair
+is refused. If the marker is lost in the one window where roll-back is
+impossible (post-pg_upgrade, the old cluster's `pg_control` is renamed
+away), the job re-infers the roll-forward from the disk shape itself.
+`wrapper.sh` refuses to boot while a non-completed marker exists, and
+refuses any image whose major differs from the on-disk `PG_VERSION` — so no
+mismatched boot can touch the data.
+
+Both sides also hold a `flock` on the volume-root
+`.railway-major-upgrade.lock`: the job exclusively for its run, the runtime
+container shared for its lifetime. A job dispatched against a live database
+refuses instead of corrupting the cluster, and a database deployed while a
+job is mid-flight refuses to boot — in-image backstops for the
+orchestrator's own exclusion.
 
 The job tolerates the platform's ungraceful container stop: it clears a stale
 `postmaster.pid` and, when `pg_control` says the cluster was not shut down
@@ -390,7 +412,42 @@ Because `pg_upgrade` promotes a freshly `initdb`'d data directory, settings that
 live in `postgresql.conf` do not carry over. The certificates survive at the
 volume root, so `wrapper.sh` re-applies the `ssl` settings whenever the config
 has none while certs exist — without that, an upgraded database comes back with
-SSL off and rejects every `sslmode=require` client.
+SSL off and rejects every `sslmode=require` client. `pg_hba.conf` gets the
+same two-layer treatment: the job carries the old cluster's `pg_hba.conf`
+(and `pg_ident.conf`) into the new data directory — it's the user's actual
+config, custom rules included — and `wrapper.sh` re-appends the
+`host all all all <method>` rule whenever the config lacks any host rule,
+because a database without it looks healthy from localhost while refusing
+every remote client. The PITR lifecycle sentinels (`.pitr_configured`,
+`.pitr_staging`, `.pgbackrest_restored`) are carried across the swap too,
+and a `completed` upgrade marker is itself treated as proof that recovery
+already promoted — otherwise an upgraded PITR-restored fork (whose
+`WAL_RECOVER_FROM_*` env stays set forever) would re-stage archive recovery
+against the source bucket and never become ready.
+
+#### Disk reclaim and rollback window
+
+The pre-upgrade cluster is kept at `${PGDATA}.old-<from>` as the rollback
+body. Because `pg_upgrade --link` hardlinks data files, that directory pins
+every pre-upgrade inode — space freed in the upgraded database is not
+returned to the volume while it exists. Once the upgrade is confirmed (the
+upgraded database up and answering past a grace period, default 24 h from
+the marker's `completedAt`; `UPGRADE_OLD_DIR_RETENTION_SECONDS` overrides),
+`wrapper.sh` removes it in the background and stamps `oldDataDirRemovedAt`
+in the marker. Until then it is the instant-rollback path; after that,
+rollback means restoring the pre-upgrade backup.
+
+#### Collation caveat (known follow-up)
+
+`pg_upgrade` preserves index files verbatim, but indexes on collatable
+columns (text/varchar btrees) are only valid for the glibc that built them,
+and the target image's glibc may differ from whatever built the source
+cluster. The marker records `needsReindex: true` on every upgrade — the
+image deliberately does **not** auto-`REINDEX` (rebuilding every text index
+on an arbitrarily large database inside the upgrade window is the wrong
+default). Surfacing that flag and driving the reindex is the dashboard's
+follow-up; `wrapper.sh`'s collation-version refresh only silences the
+version-mismatch warnings, it does not rebuild indexes.
 
 ### Archive re-anchoring
 
@@ -412,18 +469,38 @@ identifier makes the path collision-free and deterministic, so an interrupted
 attempt recomputes the same target. The previous cluster's archive is untouched
 and stays restorable as its own history in the bucket.
 
-Detection is the fingerprint, never the upgrade marker: that marker is deleted
-eventually, and a PITR-restored or otherwise re-identified cluster needs the
-identical response. The job's directory swap promotes a freshly initdb'd data
-directory, so today an upgraded `$PGDATA` usually inherits none of the old
-cluster's pgbackrest files and the path is simply derived fresh; the check is
-what keeps that from being load-bearing for any upgrade route that carries
-`$PGDATA` forward. Nothing here can fail the boot — an incomplete re-anchor is
-logged loudly and retried by the backup watcher, because a database that is up
-with degraded archiving beats one that refuses to start.
+Detection is the fingerprint, never the upgrade marker: the marker is
+removed from consideration eventually, and detection must not depend on it.
+To be precise about scope: a **PITR restore cannot trip this check** —
+`pgbackrest restore` copies the source's data files, so the
+`system_identifier` is preserved and the restored `$PGDATA` carries the
+source's repo-path marker *and* its matching anchor. (Restored forks get
+their own bucket via `WAL_ARCHIVE_*`, which is what keeps them off the
+source's prefix; the anchor plays no part.) The upgrade job's directory
+swap likewise promotes a freshly initdb'd data directory, so today's
+in-place route derives the path fresh rather than exercising the re-anchor.
+The re-anchor is therefore **defense in depth for routes that don't exist
+yet**: any upgrade path that carries `$PGDATA`'s pgbackrest files forward
+across a re-identification (a dump/restore fallback for the legacy
+PGDATA-at-the-volume-root layout, a future restore flavor that rewrites
+identity). Nothing here can fail the boot — an incomplete re-anchor is
+logged loudly and retried by the backup watcher, because a database that is
+up with degraded archiving beats one that refuses to start.
+
+A product consequence of per-cluster paths, accepted deliberately: **the
+PITR window restarts at a major upgrade.** Archiving moves to the new
+cluster's prefix and an immediate full backup re-anchors the window there;
+the old prefix stays in the bucket as a browsable, restorable history of
+the pre-upgrade cluster, but nothing expires it — its retention was driven
+by `pgbackrest expire` runs that now happen on the new prefix only. Adding
+expiry/cleanup for orphaned `cluster-*` prefixes (after a safety window) is
+an open follow-up, tracked for the dashboard/backboard side; the image does
+not delete archive data.
 
 Tests: `./test/e2e-upgrade.sh` (add `FROM_VERSION=14 TO_VERSION=17` to cover a
-pre-16 source, where pg_upgrade's `reg*`/`aclitem` checks fire). The re-anchor
+pre-16 source, where pg_upgrade's `reg*`/`aclitem` checks fire). CI runs the
+harness on 16→17 and 17→18 — the latter pins the initdb data-checksums
+default flip in 18, which needs explicit parity flags. The re-anchor
 tests need a bucket, so they live in the archive harness instead:
 `./test/e2e.sh t_upgrade_archive_reanchors_to_new_cluster_path
 t_reanchor_stale_marker_after_upgrade t_reanchor_backfills_missing_anchor`.

--- a/README.md
+++ b/README.md
@@ -383,6 +383,12 @@ The job tolerates the platform's ungraceful container stop: it clears a stale
 cleanly, replays WAL with the old binaries and shuts down cleanly before
 upgrading (pg_upgrade requires it).
 
+Because `pg_upgrade` promotes a freshly `initdb`'d data directory, settings that
+live in `postgresql.conf` do not carry over. The certificates survive at the
+volume root, so `wrapper.sh` re-applies the `ssl` settings whenever the config
+has none while certs exist — without that, an upgraded database comes back with
+SSL off and rejects every `sslmode=require` client.
+
 ### Archive re-anchoring
 
 `pg_upgrade` initdb's the target, so an upgraded service comes back with a new

--- a/README.md
+++ b/README.md
@@ -368,7 +368,14 @@ docker build -f Dockerfile.upgrade \
 ```
 
 It runs against the database's own volume while the service is stopped, and
-takes a mode as its argument:
+selects its mode from the `UPGRADE_JOB_MODE` env var — never `startCommand`
+or a positional arg, which the dispatcher (railwayapp/mono#34384) can't rely
+on: Railway's two container runtimes disagree on how a deployment's
+`startCommand` composes with the image's own `ENTRYPOINT`. A positional arg
+still works for local/manual runs and the e2e harness, which invoke the
+script directly, but only as a fallback — an env var takes priority, and an
+unrecognized positional arg refuses rather than silently defaulting to
+`upgrade`:
 
 | Mode | Effect |
 |------|--------|
@@ -484,6 +491,16 @@ the marker's `completedAt`; `UPGRADE_OLD_DIR_RETENTION_SECONDS` overrides),
 `wrapper.sh` removes it in the background and stamps `oldDataDirRemovedAt`
 in the marker. Until then it is the instant-rollback path; after that,
 rollback means restoring the pre-upgrade backup.
+
+Manual rollback is not a plain rename: pg_upgrade disables the old cluster
+by renaming its `global/pg_control` to `.old` before linking, specifically
+so it can't be started by accident while its files are shared via hardlinks
+with the new cluster — restoring it means restoring that file too, not just
+moving the directory back to `$PGDATA`. And if the job ever refuses because
+a leftover `${PGDATA}.old-<from>` is already there, don't rename it to
+another `${PGDATA}.old-*` name to get it out of the way — the background
+reclaim above matches that whole glob and would delete it once the grace
+period passes; move it outside the prefix entirely.
 
 #### Collation caveat (known follow-up)
 

--- a/README.md
+++ b/README.md
@@ -341,3 +341,38 @@ is set in the `PGPORT` environment variable. We did this to allow connections
 to the postgres service over the `RAILWAY_TCP_PROXY_PORT`. If you need to
 change this behavior, feel free to build your own image without passing the
 `--port` parameter to the `CMD` command in the Dockerfile.
+
+## Major version upgrades
+
+`Dockerfile.upgrade` builds a one-shot job image carrying two majors' server
+binaries, driven by `upgrade-job.sh`. Built per source→target pair:
+
+```bash
+docker build -f Dockerfile.upgrade \
+  --build-arg FROM_VERSION=16 --build-arg TO_VERSION=17 \
+  -t postgres-upgrade:16-17 .
+```
+
+It runs against the database's own volume while the service is stopped, and
+takes a mode as its argument:
+
+| Mode | Effect |
+|------|--------|
+| `check` | `pg_upgrade --check` against a throwaway target cluster. Volume untouched. Exit 1 = blockers. |
+| `upgrade` | `--check`, then `pg_upgrade --link`, then the completion marker and directory swap. |
+| `status` | Prints the marker phase + on-disk major as JSON, for resume decisions. |
+| `manifest` | Prints the target major's installable extensions as JSON. |
+
+`.railway-major-upgrade.json` at the volume root is the commit point:
+`upgraded` means pg_upgrade succeeded and recovery must roll **forward**;
+`completed` means the swap is done. `wrapper.sh` refuses to boot while a
+non-completed marker exists, and refuses any image whose major differs from
+the on-disk `PG_VERSION` — so no mismatched boot can touch the data.
+
+The job tolerates the platform's ungraceful container stop: it clears a stale
+`postmaster.pid` and, when `pg_control` says the cluster was not shut down
+cleanly, replays WAL with the old binaries and shuts down cleanly before
+upgrading (pg_upgrade requires it).
+
+Tests: `./test/e2e-upgrade.sh` (add `FROM_VERSION=14 TO_VERSION=17` to cover a
+pre-16 source, where pg_upgrade's `reg*`/`aclitem` checks fire).

--- a/README.md
+++ b/README.md
@@ -409,12 +409,7 @@ Both sides also hold a `flock` on the volume-root
 container shared for its lifetime. A job dispatched against a live database
 refuses instead of corrupting the cluster, and a database deployed while a
 job is mid-flight refuses to boot — in-image backstops for the
-orchestrator's own exclusion. Honest scope note: the shared side only exists
-on runtime images built from this change, so a service still running an
-older image is protected during its first upgrade by the orchestrator's
-stop-before-dispatch and the platform's single-mount guarantee alone — the
-lock becomes a real backstop for that service only after it redeploys onto a
-current image.
+orchestrator's own exclusion.
 
 The job tolerates the platform's ungraceful container stop: it clears a stale
 `postmaster.pid` and, when `pg_control` says the cluster was not shut down

--- a/README.md
+++ b/README.md
@@ -397,10 +397,18 @@ must roll **forward**; `completed` means the swap is done. Both phases are
 scoped to the marker's own version pair — a `completed` marker from a
 previous upgrade of the same volume is history, not state, so chained
 upgrades (16→17, later 17→18) work; an in-flight marker of a foreign pair
-is refused. If the marker is lost in the one window where roll-back is
-impossible (post-pg_upgrade, the old cluster's `pg_control` is renamed
-away), the job re-infers the roll-forward from the disk shape itself.
-`wrapper.sh` refuses to boot while a non-completed marker exists, and
+is refused. pg_upgrade disables the old cluster (renames its `pg_control`
+to `pg_control.old`) **before** it links the first user relation file —
+verified empirically, and pg_upgrade's own output prescribes the rename-back
+as the recovery — so that rename alone never drives a roll-forward. If the
+marker is lost, the job rolls forward only when its own completion sentinel
+(written inside the target dir the moment pg_upgrade exits 0) is present;
+`pg_control.old` without the sentinel is a crash mid-link, and the job rolls
+back instead — it reverses the rename (safe while the target cluster has
+never been started) and redoes the upgrade from scratch. The same rename-back
+runs when pg_upgrade itself fails after disabling the old cluster, so that
+failure leaves a bootable FROM-major volume rather than forcing a backup
+restore. `wrapper.sh` refuses to boot while a non-completed marker exists, and
 refuses any image whose major differs from the on-disk `PG_VERSION` — so no
 mismatched boot can touch the data.
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,15 @@ persisted in `$PGDATA/.pgbackrest_repo_path` so the archive-push
 wrapper, the backup watcher, and `pgbackrest stanza-create` all
 converge on the same value.
 
+Alongside it, `$PGDATA/.pgbackrest_repo_anchor` records the
+`system_identifier` and `PG_VERSION` the path was derived from. The
+marker wins verbatim on every boot, so this fingerprint is the only
+thing that can tell "same cluster, same path" apart from "a different
+cluster inherited this path" — see the archive re-anchoring paragraph
+under [Major version upgrades](#major-version-upgrades). A volume
+predating the file adopts its live identity on first boot and keeps
+the path it already archives to.
+
 Why per-cluster: a wipe-and-reuse-bucket cycle (operator drops the
 data volume, redeploys the service against the same `WAL_ARCHIVE_BUCKET`)
 produces a brand-new `system_identifier` from `initdb`. Without
@@ -374,5 +383,38 @@ The job tolerates the platform's ungraceful container stop: it clears a stale
 cleanly, replays WAL with the old binaries and shuts down cleanly before
 upgrading (pg_upgrade requires it).
 
+### Archive re-anchoring
+
+`pg_upgrade` initdb's the target, so an upgraded service comes back with a new
+`system_identifier` and a new `PG_VERSION` — a different cluster as far as
+pgBackRest is concerned. Archiving has to follow it to
+`${WAL_ARCHIVE_PATH}/cluster-<new_sysid>`: the previous prefix records the old
+system id in its `archive.info`, so every `archive-push` against it fails and
+`stanza-create` refuses the mismatch outright.
+
+On every boot `wrapper.sh` compares `.pgbackrest_repo_anchor` against the
+cluster on disk. On a mismatch in either component, and only when
+`WAL_ARCHIVE_BUCKET` is set, it moves archiving before Postgres starts: flip the
+repo-path marker to the new cluster's prefix, drop the old path's async spool
+statuses (a stale `.ok` would make pgBackRest skip an upload the new path never
+received), reset the backup-watcher state so a full lands immediately at the new
+prefix, and `stanza-create` there. No epoch suffix is needed — a fresh system
+identifier makes the path collision-free and deterministic, so an interrupted
+attempt recomputes the same target. The previous cluster's archive is untouched
+and stays restorable as its own history in the bucket.
+
+Detection is the fingerprint, never the upgrade marker: that marker is deleted
+eventually, and a PITR-restored or otherwise re-identified cluster needs the
+identical response. The job's directory swap promotes a freshly initdb'd data
+directory, so today an upgraded `$PGDATA` usually inherits none of the old
+cluster's pgbackrest files and the path is simply derived fresh; the check is
+what keeps that from being load-bearing for any upgrade route that carries
+`$PGDATA` forward. Nothing here can fail the boot — an incomplete re-anchor is
+logged loudly and retried by the backup watcher, because a database that is up
+with degraded archiving beats one that refuses to start.
+
 Tests: `./test/e2e-upgrade.sh` (add `FROM_VERSION=14 TO_VERSION=17` to cover a
-pre-16 source, where pg_upgrade's `reg*`/`aclitem` checks fire).
+pre-16 source, where pg_upgrade's `reg*`/`aclitem` checks fire). The re-anchor
+tests need a bucket, so they live in the archive harness instead:
+`./test/e2e.sh t_upgrade_archive_reanchors_to_new_cluster_path
+t_reanchor_stale_marker_after_upgrade t_reanchor_backfills_missing_anchor`.

--- a/README.md
+++ b/README.md
@@ -354,7 +354,10 @@ change this behavior, feel free to build your own image without passing the
 ## Major version upgrades
 
 `Dockerfile.upgrade` builds a one-shot job image carrying two majors' server
-binaries, driven by `upgrade-job.sh`. Built per source→target pair:
+binaries, driven by `upgrade-job.sh`. CI publishes one image per supported
+(source → newer target) pair as
+`ghcr.io/railwayapp-templates/postgres-ssl/upgrade:<from>-<to>`, which is what
+the dashboard's upgrade workflow dispatches. Locally:
 
 ```bash
 docker build -f Dockerfile.upgrade \

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -157,7 +157,7 @@ log() { echo "pgbackrest-watcher: $*"; }
 #                                       proof is "current catalog_max > this")
 #   last_force_recovery_at=<epoch>   — last time we pkill'd the async daemon
 #   force_attempts=<int>             — pkill cycles this gap-recovery cycle
-#   wal_regression_orig_path=<path>  — pre-migration repo1-path, set on the
+#   archive_migration_orig_path=<path> — pre-migration repo1-path, set on the
 #                                       first WAL_REGRESSION self-heal and
 #                                       never cleared. Successive migrations
 #                                       compose suffix off this (orig-<e2>),
@@ -166,15 +166,26 @@ log() { echo "pgbackrest-watcher: $*"; }
 #                                       rollbacks gets flat sibling prefixes
 #                                       (cluster-X, cluster-X-e1, cluster-X-e2)
 #                                       rather than a deepening chain.
-#   wal_regression_pending_new_path=<path>
-#                                     — in-flight migration target. Written
-#                                       before apply_active_path; cleared on
-#                                       success. On retry after a transient
+#   archive_migration_pending_new_path=<path>
+#                                     — in-flight migration target, and the
+#                                       interlock that blocks backups until the
+#                                       migration finalizes. Written before
+#                                       apply_active_path; cleared on success.
+#                                       On retry after a transient
 #                                       apply_active_path failure, reuse this
 #                                       instead of computing a fresh epoch —
 #                                       otherwise every retry would create a
 #                                       new cluster-X-<epoch> sibling and
 #                                       spam orphaned prefixes.
+#                                       Also set by wrapper.sh when a boot-time
+#                                       re-anchor moves archiving onto a
+#                                       re-identified cluster's own path, so the
+#                                       same finalization + gating applies to
+#                                       both producers.
+#                                       Both fields were named wal_regression_*
+#                                       before the re-anchor path shared them;
+#                                       migrate_legacy_state_field_names renames
+#                                       them in place on startup.
 #   probe_fail_since=<epoch>         — epoch when pgbackrest info first failed
 #                                       in the current consecutive-failure run
 #                                       (0 = probes are succeeding). Reset to 0
@@ -206,6 +217,39 @@ write_state_field() {
   fi
   echo "${field}=${value}" >> "$tmp"
   mv "$tmp" "$STATE_FILE"
+}
+
+# One-shot rename of the pre-generalization field names, run once at startup so
+# every reader below can assume the new names exist and nothing needs a
+# read-with-fallback (a fallback would deadlock the "cleared" state: writing the
+# new key empty while a legacy key still held a path would keep resolving to
+# the stale path forever).
+#
+# Renamed rather than dual-read because the migration machinery is no longer
+# WAL_REGRESSION-specific — wrapper.sh's boot-time re-anchor sets the same
+# pending field. A state file written by the previous image version is
+# converted on the first poll after the upgrade; one that has already been
+# converted (or never had the legacy fields) is untouched.
+migrate_legacy_state_field_names() {
+  [ ! -f "$STATE_FILE" ] && return 0
+  local legacy new value
+  for legacy in wal_regression_orig_path wal_regression_pending_new_path; do
+    grep -qE "^${legacy}=" "$STATE_FILE" 2>/dev/null || continue
+    new="archive_migration_${legacy#wal_regression_}"
+    value=$(read_state "$legacy")
+    # Keep whichever value the new name already carries: only the legacy
+    # writer could have set the legacy key, so a populated new key means this
+    # rename already ran and the legacy line is a leftover.
+    if [ -z "$(read_state "$new")" ] && [ -n "$value" ]; then
+      write_state_field "$new" "$value" || return 1
+    fi
+    local tmp
+    tmp=$(mktemp "$STATE_FILE.XXXX") || return 1
+    grep -vE "^${legacy}=" "$STATE_FILE" > "$tmp" 2>/dev/null || true
+    mv "$tmp" "$STATE_FILE" || { rm -f "$tmp"; return 1; }
+    log "state: renamed ${legacy} → ${new}"
+  done
+  return 0
 }
 
 # Stats from pg_stat_archiver. Sets globals so callers can branch on them
@@ -682,15 +726,21 @@ write_state_field_required() {
   return 0
 }
 
-# Finalizes a marker-flipped WAL_REGRESSION migration by forcing pgBackRest's
+# Finalizes a marker-flipped archive-path migration by forcing pgBackRest's
 # async daemon to re-read repo1-path and clearing stale async status files from
-# the old path. Only clear wal_regression_pending_new_path after this succeeds;
-# a crash before cleanup leaves the pending field in place so the next watcher
-# iteration retries this finalization instead of trusting stale .ok/.error files.
-finalize_wal_regression_migration() {
+# the old path. Only clear archive_migration_pending_new_path after this
+# succeeds; a crash before cleanup leaves the pending field in place so the next
+# watcher iteration retries this finalization instead of trusting stale
+# .ok/.error files.
+#
+# Shared by both producers of a migration: the WAL_REGRESSION self-heal below,
+# and wrapper.sh's boot-time re-anchor onto a re-identified cluster's path
+# (which sets the same pending field and normally finalizes its own migration —
+# this runs when that boot-time attempt did not get that far).
+finalize_archive_path_migration() {
   local path="$1"
 
-  log "wal-regression: kicking async daemon to pick up new repo1-path"
+  log "archive-migration: kicking async daemon to pick up new repo1-path"
   kick_async_daemon
   # Wait up to 2s for the daemon to actually exit before cleaning spool
   # files. pkill(1) is non-blocking — in the window between signal delivery
@@ -702,7 +752,7 @@ finalize_wal_regression_migration() {
     sleep 0.2
   done
   if pgrep -f 'archive-push:async' >/dev/null 2>&1; then
-    log "wal-regression: async daemon did not exit after TERM; forcing kill before cleaning spool"
+    log "archive-migration: async daemon did not exit after TERM; forcing kill before cleaning spool"
     pkill -9 -f 'archive-push:async' 2>/dev/null || true
     local _kill_deadline=$(($(date +%s) + 2))
     while pgrep -f 'archive-push:async' >/dev/null 2>&1 \
@@ -710,7 +760,7 @@ finalize_wal_regression_migration() {
       sleep 0.2
     done
     if pgrep -f 'archive-push:async' >/dev/null 2>&1; then
-      log "wal-regression: async daemon still alive after SIGKILL; will retry finalization"
+      log "archive-migration: async daemon still alive after SIGKILL; will retry finalization"
       return 1
     fi
   fi
@@ -721,37 +771,37 @@ finalize_wal_regression_migration() {
   # without uploading the segment to the NEW path. The spool is a coordination
   # cache, never durable data — async re-uploads from pg_wal on next call.
   if ! rm -f "$SPOOL_ERR_DIR"/*.error "$SPOOL_ERR_DIR"/*.ok 2>/dev/null; then
-    log "wal-regression: failed to clean async status files; will retry finalization"
+    log "archive-migration: failed to clean async status files; will retry finalization"
     return 1
   fi
 
-  # Clear the generic gap-recovery sentinel; wal_regression_pending_new_path
-  # remains the recovery-specific backup gate until finalization fully succeeds.
+  # Clear the generic gap-recovery sentinel; archive_migration_pending_new_path
+  # remains the migration-specific backup gate until finalization fully succeeds.
   rm -f "$GAP_MARKER"
 
-  if ! write_state_field wal_regression_pending_new_path ""; then
-    log "wal-regression: failed to clear pending migration marker; will retry finalization"
+  if ! write_state_field archive_migration_pending_new_path ""; then
+    log "archive-migration: failed to clear pending migration marker; will retry finalization"
     return 1
   fi
 
-  log "wal-regression: migration finalized at ${path}; async status cache cleared"
+  log "archive-migration: migration finalized at ${path}; async status cache cleared"
 }
 
-# If a prior iteration flipped the marker and cleaned stale spool statuses but
-# crashed (or hit a transient state-file write failure) before clearing
-# wal_regression_pending_new_path, no .error may remain to call
+# If a prior iteration (or wrapper.sh's boot-time re-anchor) flipped the marker
+# but crashed — or hit a transient state-file write failure — before clearing
+# archive_migration_pending_new_path, no .error may remain to call
 # migrate_to_new_archive_path again. Retry finalization directly whenever the
 # active marker already equals the pending target; suppress other gap work for
 # this iteration so failures keep retrying cleanly on the next poll.
-finalize_pending_wal_regression_migration_if_needed() {
+finalize_pending_archive_path_migration_if_needed() {
   local pending
-  pending=$(read_state wal_regression_pending_new_path)
+  pending=$(read_state archive_migration_pending_new_path)
   [ -z "$pending" ] && return 1
   [ "${PGBACKREST_REPO1_PATH:-}" != "$pending" ] && return 1
 
-  GAP_STATE_DIAG="wal-regression-finalizing"
-  log "wal-regression: finalizing pending archive-path migration at ${pending}"
-  finalize_wal_regression_migration "$pending" || true
+  GAP_STATE_DIAG="archive-migration-finalizing"
+  log "archive-migration: finalizing pending archive-path migration at ${pending}"
+  finalize_archive_path_migration "$pending" || true
   return 0
 }
 
@@ -777,7 +827,7 @@ finalize_pending_wal_regression_migration_if_needed() {
 # to 0 and re-pick the same `-2` suffix as a prior migration, colliding with
 # the still-broken contents at that path. Epoch-suffixed paths are unique
 # across rollbacks for as long as wall-clock advances. The computed epoch is
-# persisted in wal_regression_pending_new_path before the state reset and
+# persisted in archive_migration_pending_new_path before the state reset and
 # reused on retry, so a transiently-failing apply_active_path doesn't spawn
 # a new sibling prefix per poll.
 #
@@ -804,10 +854,10 @@ migrate_to_new_archive_path() {
   # cluster-SYSID-<epoch1>, cluster-SYSID-<epoch2>, … rather than chaining
   # suffixes (cluster-SYSID-<epoch1>-<epoch2>).
   local orig_path
-  orig_path=$(read_state wal_regression_orig_path)
+  orig_path=$(read_state archive_migration_orig_path)
   if [ -z "$orig_path" ]; then
     orig_path="$PGBACKREST_REPO1_PATH"
-    write_state_field_required wal_regression_orig_path "$orig_path" || return 1
+    write_state_field_required archive_migration_orig_path "$orig_path" || return 1
   fi
 
   # Reuse the pending new_path from a prior failed attempt if present —
@@ -816,10 +866,10 @@ migrate_to_new_archive_path() {
   # accumulate orphaned cluster-X-<epochN> siblings until the underlying
   # condition cleared.
   local new_path
-  new_path=$(read_state wal_regression_pending_new_path)
+  new_path=$(read_state archive_migration_pending_new_path)
   if [ -z "$new_path" ]; then
     new_path="${orig_path}-$(date +%s)"
-    write_state_field_required wal_regression_pending_new_path "$new_path" || return 1
+    write_state_field_required archive_migration_pending_new_path "$new_path" || return 1
   fi
 
   # Previous iteration may have flipped the marker and crashed before clearing
@@ -828,7 +878,7 @@ migrate_to_new_archive_path() {
   # the new path.
   if [ "$PGBACKREST_REPO1_PATH" = "$new_path" ]; then
     log "wal-regression: finalizing pending archive-path migration at ${new_path}"
-    finalize_wal_regression_migration "$new_path"
+    finalize_archive_path_migration "$new_path"
     return $?
   fi
 
@@ -858,7 +908,7 @@ migrate_to_new_archive_path() {
     return 1
   fi
 
-  if ! finalize_wal_regression_migration "$new_path"; then
+  if ! finalize_archive_path_migration "$new_path"; then
     return 1
   fi
 
@@ -876,11 +926,11 @@ migrate_to_new_archive_path() {
 # in recovery just advances the timers / inspects current catalog max.
 #
 # Returns 0 always — migration-specific backup gating is handled by
-# wal_regression_pending_new_path in decide_action.
+# archive_migration_pending_new_path in decide_action.
 gap_recovery_step() {
   local now; now=$(date +%s)
 
-  if finalize_pending_wal_regression_migration_if_needed; then
+  if finalize_pending_archive_path_migration_if_needed; then
     return 0
   fi
 
@@ -1138,14 +1188,16 @@ decide_action() {
   LAST_FULL_FAILED_DIAG="$last_full_failed"
   GAP_MARKER_DIAG=$([ -f "$GAP_MARKER" ] && echo "present" || echo "absent")
 
-  # WAL_REGRESSION migration is the only recovery path that must block
-  # backups: until the async daemon is stopped and stale old-path spool
-  # statuses are cleaned, a stale .ok can falsely satisfy archive-push on
-  # the new path. Generic WAL gaps are not gated here — if a full/diff can
-  # succeed while gap-recovery is running, that is useful signal.
-  local wal_regression_pending
-  wal_regression_pending=$(read_state wal_regression_pending_new_path)
-  if [ -n "$wal_regression_pending" ]; then
+  # An in-flight archive-path migration is the only condition that must block
+  # backups outright: until the async daemon is stopped and stale old-path spool
+  # statuses are cleaned, a stale .ok can falsely satisfy archive-push on the
+  # new path. Set by the WAL_REGRESSION self-heal and by wrapper.sh's boot-time
+  # re-anchor. Generic WAL gaps are not gated here — if a full/diff can succeed
+  # while gap-recovery is running, that is useful signal.
+  local migration_pending
+  migration_pending=$(read_state archive_migration_pending_new_path)
+  if [ -n "$migration_pending" ]; then
+    MIGRATION_PENDING_DIAG="$migration_pending"
     return 0
   fi
 
@@ -1317,7 +1369,7 @@ watcher_iteration() {
   if [ -z "$DECIDED_ACTION" ]; then
     # Surface why decide_action stayed silent so post-mortems on "watcher
     # ran for N minutes and never took a backup" don't require guessing.
-    log "iteration: no action (last_full=${LAST_FULL_DIAG:-?}, archived=${ARCHIVED_COUNT:-?}, failed=${FAILED_COUNT:-?}, gap_marker=${GAP_MARKER_DIAG:-?}, gap_state=${GAP_STATE_DIAG:-?}, last_full_failed=${LAST_FULL_FAILED_DIAG:-?}, lag=${LAST_OBSERVED_LAG_SEGMENTS:-?})"
+    log "iteration: no action (last_full=${LAST_FULL_DIAG:-?}, archived=${ARCHIVED_COUNT:-?}, failed=${FAILED_COUNT:-?}, gap_marker=${GAP_MARKER_DIAG:-?}, gap_state=${GAP_STATE_DIAG:-?}, last_full_failed=${LAST_FULL_FAILED_DIAG:-?}, lag=${LAST_OBSERVED_LAG_SEGMENTS:-?}, migration_pending=${MIGRATION_PENDING_DIAG:-none})"
     return 0
   fi
 
@@ -1345,6 +1397,14 @@ sync_repo_path_from_marker() {
 }
 
 sync_repo_path_from_marker
+
+# Convert a state file written by the pre-generalization field names before any
+# reader touches it. Non-fatal: a failure here leaves the legacy names in
+# place, which reads as "no migration pending" — the same state a fresh volume
+# starts in, and one the WAL_REGRESSION probe re-detects from the .error files
+# that caused it.
+migrate_legacy_state_field_names \
+  || log "state: could not rename legacy wal_regression_* fields; continuing"
 
 log "starting (poll=${POLL_INTERVAL_SECONDS}s, initial_poll=${INITIAL_POLL_SECONDS}s, full=${FULL_INTERVAL_SECONDS}s, diff=${DIFF_INTERVAL_SECONDS}s, gap_backoff=${GAP_RECOVERY_BACKOFF_SECONDS}s, lag_threshold=${WAL_LAG_GAP_THRESHOLD_SEGMENTS} segments, repo1-path=${PGBACKREST_REPO1_PATH:-unset})"
 

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -793,11 +793,38 @@ finalize_archive_path_migration() {
 # migrate_to_new_archive_path again. Retry finalization directly whenever the
 # active marker already equals the pending target; suppress other gap work for
 # this iteration so failures keep retrying cleanly on the next poll.
+#
+# When the active path does NOT equal the pending target, the migration is
+# half-APPLIED: the gate was set but the marker never flipped — the shape
+# wrapper.sh's boot-time re-anchor leaves when its marker write fails after
+# the gate write succeeded. Nothing else retries that in-container (the boot
+# path only re-runs on the next deploy), so without this branch the gate
+# would block every backup until a redeploy. Complete the flip here: re-run
+# the state resets (idempotent — the gate writer already cleared them for a
+# wrapper-produced pending, and re-clearing closes the crash window where a
+# watcher-produced pending landed before its own resets), then
+# apply_active_path + finalize, the same steps the producer would have run.
 finalize_pending_archive_path_migration_if_needed() {
   local pending
   pending=$(read_state archive_migration_pending_new_path)
   [ -z "$pending" ] && return 1
-  [ "${PGBACKREST_REPO1_PATH:-}" != "$pending" ] && return 1
+
+  if [ "${PGBACKREST_REPO1_PATH:-}" != "$pending" ]; then
+    GAP_STATE_DIAG="archive-migration-completing"
+    log "archive-migration: completing half-applied migration to ${pending} (active path is still ${PGBACKREST_REPO1_PATH:-unset})"
+    refresh_archiver_stats || true
+    write_state_field_required last_full_failed_count "${FAILED_COUNT:-0}" || return 0
+    write_state_field_required last_full_at "" || return 0
+    write_state_field_required last_diff_at "" || return 0
+    write_state_field_required last_lag_detected_at 0 || return 0
+    write_state_field_required catalog_max_at_detection "" || return 0
+    write_state_field_required last_force_recovery_at 0 || return 0
+    write_state_field_required force_attempts 0 || return 0
+    if ! apply_active_path "$pending"; then
+      log "archive-migration: could not flip the repo-path marker to ${pending}; will retry"
+      return 0
+    fi
+  fi
 
   GAP_STATE_DIAG="archive-migration-finalizing"
   log "archive-migration: finalizing pending archive-path migration at ${pending}"

--- a/pgbackrest-init.sh
+++ b/pgbackrest-init.sh
@@ -93,5 +93,15 @@ if [ ! -f "$PGDATA/.pgbackrest_repo_path" ] && [ -f "$PGDATA/global/pg_control" 
     echo "$cluster_path" > "$PGDATA/.pgbackrest_repo_path"
     chmod 0640 "$PGDATA/.pgbackrest_repo_path"
     echo "pgbackrest: per-cluster repo path = ${cluster_path}"
+    # Fingerprint the cluster that path was derived from. wrapper.sh compares
+    # it against the live cluster on every boot and re-anchors archiving to a
+    # fresh sub-path when they diverge (a pg_upgrade, or any other route to a
+    # new system_identifier) — see PGBACKREST_REPO_ANCHOR_FILE there. Seeding
+    # it here rather than letting wrapper.sh backfill it next boot means the
+    # first boot after initdb already carries a derived fingerprint instead of
+    # an adopted one.
+    printf 'sysid=%s\npg_version=%s\n' "$sysid" "$(cat "$PGDATA/PG_VERSION")" \
+      > "$PGDATA/.pgbackrest_repo_anchor"
+    chmod 0640 "$PGDATA/.pgbackrest_repo_anchor"
   fi
 fi

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -354,7 +354,7 @@ t_check_pass() {
   seed_from_cluster "$vol" || return 1
   run_job "$vol" check
   assert_eq "$JOB_RC" 0 "check mode exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
-  assert_contains "$JOB_OUT" '"ok": true' "machine-readable result" || return 1
+  assert_contains "$JOB_OUT" '"ok":true' "machine-readable result" || return 1
   assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "data major untouched by check" || return 1
   run_pg checkpass-pg "$vol" "$FROM_IMAGE" || return 1
   wait_for_pg checkpass-pg || { fail_dump checkpass checkpass-pg; return 1; }
@@ -473,6 +473,12 @@ t_upgrade_happy_path() {
   assert_eq "$JOB_RC" 0 "upgrade exit code" || { echo "$JOB_OUT" | tail -30; return 1; }
   assert_eq "$(marker_field "$vol" phase)" "completed" "marker phase" || return 1
   assert_eq "$(marker_field "$vol" needsReindex)" "true" "collation-reindex flag recorded" || return 1
+  assert_eq "$(marker_field "$vol" needsConfigReview)" "true" "config-review flag recorded" || return 1
+  # postgresql{,.auto}.conf are not carried; their reference copies must land
+  # at the volume root, where they outlive the old dir's 24h reclaim.
+  in_volume "$vol" "test -f /var/lib/postgresql/data/.pre-upgrade-${FROM_VERSION}-postgresql.conf \
+    && test -f /var/lib/postgresql/data/.pre-upgrade-${FROM_VERSION}-postgresql.auto.conf" \
+    || { echo "  pre-upgrade config stash missing at the volume root"; return 1; }
   assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "on-disk major is now TO" || return 1
   # The rollback body must survive the upgrade itself (reclaim is a separate,
   # grace-gated path — see t_old_datadir_reclaimed).
@@ -494,7 +500,7 @@ t_upgrade_idempotent() {
   local vol="upg-e2e-happy"
   run_job "$vol" upgrade
   assert_eq "$JOB_RC" 0 "idempotent re-run exit code" || { echo "$JOB_OUT" | tail -10; return 1; }
-  assert_contains "$JOB_OUT" '"alreadyDone": true' "no-op signaled" || return 1
+  assert_contains "$JOB_OUT" '"alreadyDone":true' "no-op signaled" || return 1
 }
 
 # status mode reports the terminal state for the workflow's resume decision.
@@ -502,8 +508,8 @@ t_status_mode() {
   local vol="upg-e2e-happy"
   run_job "$vol" status
   assert_eq "$JOB_RC" 0 "status exit code" || return 1
-  assert_contains "$JOB_OUT" '"phase": "completed"' "status phase" || return 1
-  assert_contains "$JOB_OUT" "\"dataMajor\": \"$TO_VERSION\"" "status data major" || return 1
+  assert_contains "$JOB_OUT" '"phase":"completed"' "status phase" || return 1
+  assert_contains "$JOB_OUT" "\"dataMajor\":\"$TO_VERSION\"" "status data major" || return 1
 }
 
 # manifest mode lists the TO major's installable extensions (preflight feed).
@@ -572,7 +578,10 @@ t_old_image_on_upgraded_data() {
   expect_boot_refusal "$vol" "$FROM_IMAGE" "data directory holds major version $TO_VERSION" || return 1
 }
 
-# A non-completed marker blocks EVERY runtime boot — both majors.
+# A non-completed marker blocks EVERY runtime boot — both majors. An
+# UNREADABLE marker must refuse too: a file we cannot parse still means an
+# upgrade touched this volume, and "nothing in flight" is the one
+# interpretation that can lose data (same contract as postgres-ha's guards).
 t_boot_refused_mid_upgrade() {
   local vol="upg-e2e-midmarker"
   seed_from_cluster "$vol" || return 1
@@ -580,6 +589,11 @@ t_boot_refused_mid_upgrade() {
     -c "echo '{\"phase\": \"upgraded\", \"from\": \"$FROM_VERSION\", \"to\": \"$TO_VERSION\"}' > $MARKER_PATH"
   expect_boot_refusal "$vol" "$FROM_IMAGE" "upgrade is in progress" || return 1
   expect_boot_refusal "$vol" "$TO_IMAGE" "upgrade is in progress" || return 1
+
+  docker run --rm -v "$vol:/var/lib/postgresql/data" --entrypoint /bin/sh "$JOB_IMAGE" \
+    -c "echo '{not json' > $MARKER_PATH"
+  expect_boot_refusal "$vol" "$FROM_IMAGE" "marker phase: unreadable" || return 1
+  in_volume "$vol" "rm -f $MARKER_PATH"
 }
 
 # Crash between the two directory renames: marker=upgraded, old dir moved
@@ -637,9 +651,19 @@ t_remote_auth_survives_upgrade() {
     "e2e-custom-hba-rule" "custom pg_hba rule carried across the upgrade" || return 1
   stop_pg hba-after
 
-  # Wrapper self-heal layer: lose the host rules entirely (any path that
-  # regenerates pg_hba.conf), boot, and remote auth must come back.
-  in_volume "$vol" "grep -vE '^[[:space:]]*host' $PGDATA_IN_VOLUME/pg_hba.conf > /tmp/hba && cat /tmp/hba > $PGDATA_IN_VOLUME/pg_hba.conf" || return 1
+  # Wrapper self-heal layer: reset pg_hba to initdb's default shape — local
+  # lines plus the loopback host rules and nothing else, which is what any
+  # path that regenerates the file actually produces. The heal is keyed on
+  # exactly that shape (see t_narrowed_hba_not_rewidened for the negative),
+  # so remote auth must come back on the next boot.
+  in_volume "$vol" "printf '%s\n' \
+    'local all all trust' \
+    'host all all 127.0.0.1/32 trust' \
+    'host all all ::1/128 trust' \
+    'local replication all trust' \
+    'host replication all 127.0.0.1/32 trust' \
+    'host replication all ::1/128 trust' \
+    > $PGDATA_IN_VOLUME/pg_hba.conf" || return 1
   run_pg hba-healed "$vol" "$TO_IMAGE" --network "$E2E_NET" || return 1
   wait_for_pg hba-healed || { fail_dump hba-healed hba-healed; return 1; }
   assert_contains "$(docker logs hba-healed 2>&1)" "re-appending" "wrapper reported the pg_hba heal" || return 1
@@ -741,15 +765,51 @@ t_second_upgrade_reaches_next_major() {
 
 # An in-flight (phase=upgraded) marker belonging to a DIFFERENT version pair
 # must not drive this job's directory swap — its upgrade dirs belong to the
-# other job. Refuse loudly, volume untouched.
+# other job. Refuse loudly, volume untouched. The planted marker uses NUMERIC
+# majors on purpose: more than one producer writes this file (postgres-ha's
+# workflow tolerates numeric majors for the same reason), and jq's -r read
+# must normalize them rather than misread the pair.
 t_foreign_pair_upgraded_marker_refused() {
   local vol="upg-e2e-foreignpair"
   seed_from_cluster "$vol" || return 1
-  in_volume "$vol" "echo '{\"phase\": \"upgraded\", \"from\": \"13\", \"to\": \"14\"}' > $MARKER_PATH" || return 1
+  in_volume "$vol" "echo '{\"phase\": \"upgraded\", \"from\": 13, \"to\": 14}' > $MARKER_PATH" || return 1
   run_job "$vol" upgrade
   assert_eq "$JOB_RC" 2 "foreign-pair upgraded marker refused" || { echo "$JOB_OUT" | tail -10; return 1; }
   assert_contains "$JOB_OUT" "refuses to finish another pair's swap" "refusal names the mismatch" || return 1
+  assert_contains "$JOB_OUT" "13 -> 14" "numeric marker majors normalized in the message" || return 1
   assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "volume untouched" || return 1
+
+  # check mode must also name the in-flight marker instead of preflighting
+  # over another job's half-done state.
+  run_job "$vol" check
+  assert_eq "$JOB_RC" 2 "check refused on a foreign in-flight marker" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_contains "$JOB_OUT" "already in progress" "check names the in-flight marker" || return 1
+  in_volume "$vol" "rm -f $MARKER_PATH"
+}
+
+# A marker phase this job does not recognize (the HA workflow's "reseed" on a
+# replica volume, or a future writer's state) is someone else's in-flight
+# state: both modes must refuse rather than overwrite it at the commit point.
+t_unknown_marker_phase_refused() {
+  local vol="upg-e2e-unknownphase"
+  seed_from_cluster "$vol" || return 1
+  in_volume "$vol" "echo '{\"phase\": \"reseed\", \"from\": \"$FROM_VERSION\", \"to\": \"$TO_VERSION\"}' > $MARKER_PATH" || return 1
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 2 "unknown phase refused by upgrade" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_contains "$JOB_OUT" "not this job's to resolve" "refusal names the foreign phase" || return 1
+  run_job "$vol" check
+  assert_eq "$JOB_RC" 2 "unknown phase refused by check" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "volume untouched" || return 1
+
+  # An UNREADABLE marker is someone's in-flight state we cannot even name:
+  # both modes must refuse rather than proceed over (and overwrite) it.
+  in_volume "$vol" "echo '{not json' > $MARKER_PATH" || return 1
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 2 "unreadable marker refused by upgrade" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_contains "$JOB_OUT" "cannot be read" "refusal names the unreadable marker" || return 1
+  run_job "$vol" check
+  assert_eq "$JOB_RC" 2 "unreadable marker refused by check" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "volume still untouched" || return 1
   in_volume "$vol" "rm -f $MARKER_PATH"
 }
 
@@ -946,6 +1006,150 @@ t_upgrade_survives_root_owned_volume_root() {
   stop_pg rootvol-pg
 }
 
+# The official entrypoint initdb's with --username="$POSTGRES_USER", so a
+# custom-user cluster has NO 'postgres' role at all — the job must connect
+# (and initdb the target) as the cluster's actual install user, and the
+# wrapper's post-upgrade analyze must too. A hardcoded -U postgres made the
+# whole feature DOA for this cohort, with a libpq error buried in pg_upgrade
+# output as the only signal.
+t_custom_superuser_upgrades() {
+  local vol="upg-e2e-customuser"
+  fresh_volume "$vol" || return 1
+  remove_container custom-pg || return 1
+  docker run -d --name custom-pg --label postgres-upgrade-e2e=1 \
+    -e "POSTGRES_PASSWORD=test" -e "POSTGRES_USER=myuser" -e "PGDATA=$PGDATA_IN_VOLUME" \
+    -v "$vol:/var/lib/postgresql/data" "$FROM_IMAGE" >/dev/null || return 1
+  wait_for_pg custom-pg || { fail_dump customuser custom-pg; return 1; }
+  docker exec custom-pg psql -U myuser -tAc \
+    "CREATE TABLE cu_canary(id int); INSERT INTO cu_canary SELECT generate_series(1, 100)" >/dev/null \
+    || { echo "  could not seed as the custom superuser"; fail_dump customuser custom-pg; return 1; }
+  stop_pg custom-pg
+
+  # Both modes must work with the service's own env (which is how production
+  # dispatch delivers POSTGRES_USER to the job).
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" -e "POSTGRES_USER=myuser" \
+    -v "$vol:/var/lib/postgresql/data" "$JOB_IMAGE" check 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 0 "check passes on a custom-superuser cluster" || { echo "$JOB_OUT" | tail -20; return 1; }
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" -e "POSTGRES_USER=myuser" \
+    -v "$vol:/var/lib/postgresql/data" "$JOB_IMAGE" upgrade 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 0 "upgrade succeeds on a custom-superuser cluster" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "data major is TO" || return 1
+
+  remove_container custom2-pg || return 1
+  docker run -d --name custom2-pg --label postgres-upgrade-e2e=1 \
+    -e "POSTGRES_PASSWORD=test" -e "POSTGRES_USER=myuser" -e "PGDATA=$PGDATA_IN_VOLUME" \
+    -v "$vol:/var/lib/postgresql/data" "$TO_IMAGE" >/dev/null || return 1
+  wait_for_pg custom2-pg || { fail_dump customuser2 custom2-pg; return 1; }
+  assert_eq "$(docker exec custom2-pg psql -U myuser -tAc 'SELECT count(*) FROM cu_canary' 2>&1)" "100" \
+    "data survived under the custom superuser" || return 1
+  # The wrapper's staged analyze must also authenticate as the custom user
+  # (a hardcoded -U postgres would fail here on every boot forever).
+  local deadline=$(($(date +%s) + 120))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    [ "$(marker_field "$vol" needsAnalyze)" = "false" ] && break
+    sleep 5
+  done
+  assert_eq "$(marker_field "$vol" needsAnalyze)" "false" "staged analyze completed as the custom superuser" \
+    || { fail_dump customuser2 custom2-pg; stop_pg custom2-pg; return 1; }
+  stop_pg custom2-pg
+}
+
+# The pg_hba heal must NEVER re-widen an authored policy: a config narrowed
+# by address keeps only its own rules — appending `host all all all` under it
+# would re-admit exactly the clients the narrowing excluded (pg_hba is
+# first-match-wins, so the catch-all wins for everything the narrow rules
+# don't match).
+t_narrowed_hba_not_rewidened() {
+  local vol="upg-e2e-narrowhba"
+  seed_from_cluster "$vol" || return 1
+  in_volume "$vol" "printf '%s\n' \
+    'local all all trust' \
+    'host all all 127.0.0.1/32 trust' \
+    'host all all ::1/128 trust' \
+    'host all all 192.0.2.0/24 scram-sha-256' \
+    > $PGDATA_IN_VOLUME/pg_hba.conf" || return 1
+  run_pg narrow-pg "$vol" "$FROM_IMAGE" || return 1
+  wait_for_pg narrow-pg || { fail_dump narrowhba narrow-pg; return 1; }
+  assert_not_contains "$(docker logs narrow-pg 2>&1)" "re-appending" "heal must not fire on an authored policy" || return 1
+  assert_not_contains "$(docker exec narrow-pg cat "$PGDATA_IN_VOLUME/pg_hba.conf" 2>&1)" "host all all all" \
+    "no wide-open rule appended under the narrowed policy" || return 1
+  stop_pg narrow-pg
+}
+
+# check initdb's its throwaway cluster into /tmp, so without an explicit
+# probe it would never notice that the REAL upgrade's sibling directory can't
+# be created on this volume — the exact green-preflight/red-upgrade class the
+# root-owned-volume-root bug shipped through. A read-only volume is the
+# cheapest reproducible "slot not creatable" shape.
+t_check_probes_sibling_slot() {
+  local vol="upg-e2e-roprobe"
+  seed_from_cluster "$vol" || return 1
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" \
+    -v "$vol:/var/lib/postgresql/data:ro" \
+    "$JOB_IMAGE" check 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 2 "check refuses when the sibling slot cannot be created" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_contains "$JOB_OUT" "cannot create the upgrade directory" "probe names the failure" || return 1
+
+  # And on a writable volume the probe passes and leaves nothing behind.
+  run_job "$vol" check
+  assert_eq "$JOB_RC" 0 "check passes on the writable volume" || { echo "$JOB_OUT" | tail -20; return 1; }
+  in_volume "$vol" "test ! -e ${PGDATA_IN_VOLUME}.upgrade-${TO_VERSION}.preflight" \
+    || { echo "  probe directory left behind"; return 1; }
+}
+
+# "Already done" needs the marker AND the data directory to agree: a
+# completed same-pair marker sitting over FROM-major data (a partial manual
+# restore put the old cluster back without touching the volume-root marker)
+# must re-run the upgrade, not no-op to success — the workflow would flip the
+# image tag onto FROM data and the service would boot-refuse after a
+# "successful" job.
+t_same_pair_completed_marker_reruns() {
+  local vol="upg-e2e-samepair"
+  seed_from_cluster "$vol" || return 1
+  in_volume "$vol" "echo '{\"phase\": \"completed\", \"from\": \"$FROM_VERSION\", \"to\": \"$TO_VERSION\"}' > $MARKER_PATH" || return 1
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "same-pair marker over FROM data re-runs the upgrade" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_not_contains "$JOB_OUT" '"alreadyDone"' "did not no-op on the stale marker" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "data actually upgraded" || return 1
+}
+
+# marker=upgraded (same pair) but the new data dir is gone: the swap must
+# refuse BEFORE the first rename. Moving $PGDATA aside on the strength of the
+# marker alone would convert a still-bootable degenerate state into "no data
+# dir at all".
+t_upgraded_marker_missing_new_dir_refused() {
+  local vol="upg-e2e-lostnewdir"
+  seed_from_cluster "$vol" || return 1
+  in_volume "$vol" "echo '{\"phase\": \"upgraded\", \"from\": \"$FROM_VERSION\", \"to\": \"$TO_VERSION\"}' > $MARKER_PATH" || return 1
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 3 "refused to swap without a valid new data dir" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_contains "$JOB_OUT" "cannot finish the swap" "refusal names the missing target" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "PGDATA left in place" || return 1
+  in_volume "$vol" "test ! -e ${PGDATA_IN_VOLUME}.old-${FROM_VERSION}" \
+    || { echo "  old-keep dir appeared — the swap began despite the refusal"; return 1; }
+  in_volume "$vol" "rm -f $MARKER_PATH"
+}
+
+# A service variable can set PG_MAJOR to anything; the mismatch guard must
+# trust the image's installed server tree instead (adopted from postgres-ha's
+# image_major()) — a stray PG_MAJOR must not refuse a perfectly matched boot.
+t_pg_major_env_override_ignored() {
+  local vol="upg-e2e-pgmajorenv"
+  seed_from_cluster "$vol" || return 1
+  run_pg envmajor-pg "$vol" "$FROM_IMAGE" -e "PG_MAJOR=$TO_VERSION" || return 1
+  wait_for_pg envmajor-pg || { fail_dump envmajor envmajor-pg; return 1; }
+  assert_contains "$(docker logs envmajor-pg 2>&1)" "trusting the filesystem" \
+    "the env/filesystem disagreement is logged" || return 1
+  assert_eq "$(psql_in envmajor-pg 'SELECT 1')" "1" "database booted despite the stray PG_MAJOR" || return 1
+  stop_pg envmajor-pg
+}
+
 # ----- runner -----------------------------------------------------------------
 ALL_TESTS=(
   t_vanilla_boot
@@ -976,6 +1180,13 @@ ALL_TESTS=(
   t_old_datadir_reclaimed
   t_trailing_slash_pgdata
   t_upgrade_survives_root_owned_volume_root
+  t_custom_superuser_upgrades
+  t_narrowed_hba_not_rewidened
+  t_check_probes_sibling_slot
+  t_same_pair_completed_marker_reruns
+  t_upgraded_marker_missing_new_dir_refused
+  t_unknown_marker_phase_refused
+  t_pg_major_env_override_ignored
 )
 
 TESTS=("${@:-}")

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -1276,6 +1276,32 @@ t_pg_major_env_override_ignored() {
   stop_pg envmajor-pg
 }
 
+# Both the postgres-ha and standalone postgres templates default
+# PGHOST=${{ RAILWAY_PRIVATE_DOMAIN }} — a service variable the job inherits
+# along with everything else (that's how it gets PGDATA). pg_upgrade reads
+# libpq env vars directly and refuses outright on a non-local PGHOST/PGPORT
+# ("libpq environment variable PGHOST has a non-local server value"),
+# blocking --check before anything is touched — found against real Railway
+# infrastructure, where it fails on effectively every template deployment.
+t_railway_private_domain_pghost_ignored() {
+  local vol="upg-e2e-pghost"
+  seed_from_cluster "$vol" || return 1
+
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" -e "PGHOST=postgres.railway.internal" -e "PGPORT=5432" \
+    -v "$vol:/var/lib/postgresql/data" "$JOB_IMAGE" check 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 0 "check succeeds despite an inherited private-domain PGHOST" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_contains "$JOB_OUT" '"ok":true' "check result reports ok" || return 1
+
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" -e "PGHOST=postgres.railway.internal" -e "PGPORT=5432" \
+    -v "$vol:/var/lib/postgresql/data" "$JOB_IMAGE" upgrade 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 0 "upgrade succeeds despite an inherited private-domain PGHOST" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "data major is TO" || return 1
+}
+
 # ----- runner -----------------------------------------------------------------
 ALL_TESTS=(
   t_vanilla_boot
@@ -1317,6 +1343,7 @@ ALL_TESTS=(
   t_stale_old_keep_dir_refused
   t_unknown_marker_phase_refused
   t_pg_major_env_override_ignored
+  t_railway_private_domain_pghost_ignored
 )
 
 TESTS=("${@:-}")

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -629,6 +629,29 @@ t_pg_control_disabled_without_marker_refused() {
   expect_boot_refusal "$vol" "$FROM_IMAGE" "interrupted major version upgrade" || return 1
 }
 
+# Belt-and-suspenders guard for a crash between finish_swap's two renames:
+# $PGDATA itself is gone at that point (renamed to .old-<from>), so the
+# pg_control.old guard above (which looks under $PGDATA) has nothing to
+# check — this is the shape only the sibling-directory check catches.
+# Reconstructs the disk exactly as a crash there would leave it: no
+# $PGDATA, the old (disabled) cluster at .old-<from>, the finished new
+# cluster at .upgrade-<to>, no marker.
+t_upgrade_siblings_without_pgdata_refused() {
+  local vol="upg-e2e-siblingsnodata"
+  seed_from_cluster "$vol" || return 1
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "initial upgrade" || { echo "$JOB_OUT" | tail -20; return 1; }
+  in_volume "$vol" "
+    set -e
+    cd /var/lib/postgresql/data
+    mv pgdata pgdata.upgrade-${TO_VERSION}
+    rm -f $MARKER_PATH
+  " || return 1
+  expect_boot_refusal "$vol" "$TO_IMAGE" "upgrade-job sibling directories exist" || return 1
+  in_volume "$vol" "test -d ${PGDATA_IN_VOLUME}.upgrade-${TO_VERSION}" \
+    || { echo "  sibling directory got touched despite the refusal"; return 1; }
+}
+
 # Crash between the two directory renames: marker=upgraded, old dir moved
 # aside, no $PGDATA. Re-running the job completes the swap deterministically.
 t_resume_after_crash_between_swaps() {
@@ -996,6 +1019,16 @@ t_marker_lost_after_pg_upgrade_resumes() {
     rm -f $MARKER_PATH
   " || return 1
 
+  # This resume now writes a phase=upgraded marker before calling
+  # finish_swap (matching the other two entries into it), closing a window
+  # where a crash between finish_swap's two renames during THIS specific
+  # path left no marker at all — a black-box success-path assertion can't
+  # distinguish that fix being present from absent (finish_swap's own final
+  # write lands "completed" either way), so this is verified by code
+  # reading, not by this test. t_upgrade_siblings_without_pgdata_refused is
+  # the actual regression backstop: it proves wrapper.sh now refuses to
+  # boot on the disk shape that ordering gap could have produced, whatever
+  # its root cause.
   run_job "$vol" upgrade
   assert_eq "$JOB_RC" 0 "marker-less resume exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
   assert_contains "$JOB_OUT" "disk shape shows a finished pg_upgrade" "roll-forward inferred from disk" || return 1
@@ -1498,6 +1531,7 @@ ALL_TESTS=(
   t_mismatch_boot_failstop
   t_boot_refused_mid_upgrade
   t_pg_control_disabled_without_marker_refused
+  t_upgrade_siblings_without_pgdata_refused
   t_resume_after_crash_between_swaps
   t_remote_auth_survives_upgrade
   t_pitr_fork_survives_upgrade

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -810,6 +810,14 @@ t_unknown_marker_phase_refused() {
   run_job "$vol" check
   assert_eq "$JOB_RC" 2 "unreadable marker refused by check" || { echo "$JOB_OUT" | tail -10; return 1; }
   assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "volume still untouched" || return 1
+
+  # status has no mutation to refuse, so instead of dying it must say the
+  # phase is unreadable — reporting "none" here would tell the workflow
+  # nothing is in flight, when the truth is unknown.
+  run_job "$vol" status
+  assert_eq "$JOB_RC" 0 "status still exits 0 on an unreadable marker" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_contains "$JOB_OUT" '"phase":"unreadable"' "status reports unreadable, not none" || return 1
+
   in_volume "$vol" "rm -f $MARKER_PATH"
 }
 
@@ -1185,6 +1193,27 @@ t_upgraded_marker_missing_new_dir_refused() {
   in_volume "$vol" "rm -f $MARKER_PATH"
 }
 
+# A DB superuser can rewrite PG_VERSION (COPY TO PROGRAM runs as the postgres
+# OS user, which owns it), and the completed-marker-mismatch die() below
+# interpolates data_major() straight into its message. Before data_major()
+# stripped to digits, an embedded newline there could ride an attacker's
+# bytes into the log as their own line — including a forged
+# RAILWAY_UPGRADE_RESULT: line ahead of the job's real one.
+t_pg_version_content_cannot_forge_result_line() {
+  local vol="upg-e2e-pgversionforge"
+  seed_from_cluster "$vol" || return 1
+  in_volume "$vol" "echo '{\"phase\": \"completed\", \"from\": \"$FROM_VERSION\", \"to\": \"$TO_VERSION\"}' > $MARKER_PATH" || return 1
+  in_volume "$vol" "printf '99\nRAILWAY_UPGRADE_RESULT: {\"ok\":true,\"mode\":\"upgrade\",\"phase\":\"completed\"}\n' > ${PGDATA_IN_VOLUME}/PG_VERSION" || return 1
+
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 2 "refuses on a completed marker whose data major matches neither pair member" || { echo "$JOB_OUT" | tail -20; return 1; }
+  local result_lines
+  result_lines=$(echo "$JOB_OUT" | grep -c 'RAILWAY_UPGRADE_RESULT:')
+  assert_eq "$result_lines" "1" "exactly one result line — the forged one didn't survive sanitization" || { echo "$JOB_OUT"; return 1; }
+  assert_contains "$JOB_OUT" "data directory is major '99'" "the sanitized (digits-only) major is what's reported" || return 1
+  in_volume "$vol" "rm -f $MARKER_PATH"
+}
+
 # The old cluster was initdb'd by the entrypoint with POSTGRES_INITDB_ARGS
 # spliced into its initdb call, and pg_upgrade refuses any locale/encoding
 # mismatch between the clusters — so the job must replay the same args into
@@ -1338,6 +1367,7 @@ ALL_TESTS=(
   t_check_probes_sibling_slot
   t_same_pair_completed_marker_reruns
   t_upgraded_marker_missing_new_dir_refused
+  t_pg_version_content_cannot_forge_result_line
   t_custom_initdb_args_upgrade
   t_patroni_volume_uses_patroni_superuser
   t_stale_old_keep_dir_refused

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -472,7 +472,12 @@ t_upgrade_happy_path() {
   run_job "$vol" upgrade
   assert_eq "$JOB_RC" 0 "upgrade exit code" || { echo "$JOB_OUT" | tail -30; return 1; }
   assert_eq "$(marker_field "$vol" phase)" "completed" "marker phase" || return 1
+  assert_eq "$(marker_field "$vol" needsReindex)" "true" "collation-reindex flag recorded" || return 1
   assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "on-disk major is now TO" || return 1
+  # The rollback body must survive the upgrade itself (reclaim is a separate,
+  # grace-gated path — see t_old_datadir_reclaimed).
+  in_volume "$vol" "test -f ${PGDATA_IN_VOLUME}.old-${FROM_VERSION}/PG_VERSION" \
+    || { echo "  pgdata.old-${FROM_VERSION} missing right after the upgrade"; return 1; }
 
   run_pg happy-pg "$vol" "$TO_IMAGE" || return 1
   wait_for_pg happy-pg || { fail_dump happy happy-pg; return 1; }

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -461,7 +461,7 @@ t_refuses_concurrent_job() {
   local rc="$JOB_RC" out="$JOB_OUT"
   docker rm -f lockholder >/dev/null 2>&1
   assert_eq "$rc" 2 "second job refused" || { echo "$out" | tail -10; return 1; }
-  assert_contains "$out" "another upgrade job is already running" "lock message" || return 1
+  assert_contains "$out" "holds the upgrade lock" "lock message" || return 1
 }
 
 # The whole point: upgrade succeeds, marker completes, the TO image boots,
@@ -748,6 +748,167 @@ t_foreign_pair_upgraded_marker_refused() {
   in_volume "$vol" "rm -f $MARKER_PATH"
 }
 
+# The in-image job-vs-runtime backstop: with the database container RUNNING
+# on the volume (its wrapper holds the shared flock for the container's
+# lifetime — through docker-entrypoint's exec of postgres, which is exactly
+# what this proves), both job modes must refuse, and the database must be
+# unharmed. Without this, a job racing a live runtime bricks the volume
+# while reporting ok:true.
+t_job_refused_while_runtime_live() {
+  local vol="upg-e2e-joblock"
+  fresh_volume "$vol" || return 1
+  run_pg lockrt-pg "$vol" "$FROM_IMAGE" || return 1
+  wait_for_pg lockrt-pg || { fail_dump lockrt lockrt-pg; return 1; }
+  psql_must lockrt-pg "CREATE TABLE lock_canary (id int); INSERT INTO lock_canary VALUES (1)" || return 1
+
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 2 "upgrade refused while runtime is live" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_contains "$JOB_OUT" "holds the upgrade lock" "refusal names the lock" || return 1
+  run_job "$vol" check
+  assert_eq "$JOB_RC" 2 "check refused while runtime is live" || { echo "$JOB_OUT" | tail -10; return 1; }
+
+  # The database kept running through both refusals.
+  assert_eq "$(psql_in lockrt-pg 'SELECT count(*) FROM lock_canary')" "1" "database unharmed" || return 1
+  stop_pg lockrt-pg
+
+  # And with the runtime stopped, the same job succeeds — the lock is released
+  # with the container, not leaked.
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "upgrade succeeds once the runtime is stopped" || { echo "$JOB_OUT" | tail -20; return 1; }
+}
+
+# The runtime-vs-job direction of the same lock: a database deployed while
+# an upgrade job holds the exclusive flock must refuse to boot.
+t_runtime_refused_while_job_locked() {
+  local vol="upg-e2e-rtlock"
+  seed_from_cluster "$vol" || return 1
+  docker run -d --name rt-lockholder --label postgres-upgrade-e2e=1 \
+    -v "$vol:/var/lib/postgresql/data" --entrypoint /bin/sh "$JOB_IMAGE" \
+    -c "exec 9>/var/lib/postgresql/data/.railway-major-upgrade.lock; flock 9; sleep 60" >/dev/null
+  sleep 2
+  local rc=0
+  expect_boot_refusal "$vol" "$FROM_IMAGE" "upgrade job is currently running" || rc=1
+  docker rm -f rt-lockholder >/dev/null 2>&1
+  return "$rc"
+}
+
+# recovery.signal / standby.signal volumes are refused by BOTH modes, and the
+# signal file is not consumed: check's quiesce would otherwise eat a
+# mid-restore volume's recovery intent (replaying to "whatever WAL is local"
+# instead of the configured target), and a standby that PASSES check would
+# still fail the real run.
+t_recovery_shapes_refused() {
+  local vol="upg-e2e-recshape"
+  seed_from_cluster "$vol" || return 1
+  local sig
+  for sig in recovery.signal standby.signal; do
+    in_volume "$vol" "touch $PGDATA_IN_VOLUME/$sig && chown postgres:postgres $PGDATA_IN_VOLUME/$sig" || return 1
+    run_job "$vol" check
+    assert_eq "$JOB_RC" 2 "check refuses a $sig volume" || { echo "$JOB_OUT" | tail -10; return 1; }
+    assert_contains "$JOB_OUT" "$sig" "refusal names $sig" || return 1
+    run_job "$vol" upgrade
+    assert_eq "$JOB_RC" 2 "upgrade refuses a $sig volume" || { echo "$JOB_OUT" | tail -10; return 1; }
+    in_volume "$vol" "test -f $PGDATA_IN_VOLUME/$sig" \
+      || { echo "  $sig was consumed by the refused job"; return 1; }
+    in_volume "$vol" "rm -f $PGDATA_IN_VOLUME/$sig" || return 1
+  done
+
+  # The volume is still upgradeable once the signals are gone.
+  run_job "$vol" check
+  assert_eq "$JOB_RC" 0 "check passes after the signals are removed" || { echo "$JOB_OUT" | tail -10; return 1; }
+}
+
+# The marker-lost window: pg_upgrade finished (old cluster's pg_control
+# renamed to pg_control.old — it can never start again) but the marker is
+# gone. The disk shape alone must drive the roll-forward; without it the
+# volume is bricked in both directions. Reconstructed from a completed
+# upgrade: put the dirs back to "post-pg_upgrade, pre-swap" and delete the
+# marker.
+t_marker_lost_after_pg_upgrade_resumes() {
+  local vol="upg-e2e-lostmarker"
+  seed_from_cluster "$vol" || return 1
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "initial upgrade" || { echo "$JOB_OUT" | tail -20; return 1; }
+  # The premise: pg_upgrade --link really does rename pg_control away.
+  in_volume "$vol" "test -f ${PGDATA_IN_VOLUME}.old-${FROM_VERSION}/global/pg_control.old" \
+    || { echo "  premise broken: pg_upgrade left no pg_control.old"; return 1; }
+  in_volume "$vol" "
+    set -e
+    cd /var/lib/postgresql/data
+    mv pgdata pgdata.upgrade-${TO_VERSION}
+    mv pgdata.old-${FROM_VERSION} pgdata
+    rm -f $MARKER_PATH
+  " || return 1
+
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "marker-less resume exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
+  assert_contains "$JOB_OUT" "disk shape shows a finished pg_upgrade" "roll-forward inferred from disk" || return 1
+  assert_eq "$(marker_field "$vol" phase)" "completed" "marker rebuilt as completed" || return 1
+  run_pg lostmarker-pg "$vol" "$TO_IMAGE" || return 1
+  wait_for_pg lostmarker-pg || { fail_dump lostmarker lostmarker-pg; return 1; }
+  assert_eq "$(psql_in lostmarker-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "data intact after marker-less resume" || return 1
+  stop_pg lostmarker-pg
+}
+
+# pgdata.old-<from> is the rollback body and pins every pre-upgrade inode
+# (--link hardlinks); it must survive normal boots and be reclaimed in the
+# background once the upgraded database has been up past the grace period,
+# stamping oldDataDirRemovedAt in the marker.
+t_old_datadir_reclaimed() {
+  local vol="upg-e2e-reclaim"
+  seed_from_cluster "$vol" || return 1
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "upgrade exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
+
+  # A normal boot (default 24h grace) must NOT reclaim.
+  run_pg reclaim-hold "$vol" "$TO_IMAGE" || return 1
+  wait_for_pg reclaim-hold || { fail_dump reclaim-hold reclaim-hold; return 1; }
+  sleep 5
+  local held_rc=0
+  docker exec reclaim-hold test -d "${PGDATA_IN_VOLUME}.old-${FROM_VERSION}" || held_rc=1
+  stop_pg reclaim-hold
+  [ "$held_rc" = "0" ] || { echo "  old data dir reclaimed before the grace period"; return 1; }
+
+  # With the grace collapsed, the same boot reclaims and stamps the marker.
+  run_pg reclaim-pg "$vol" "$TO_IMAGE" -e "UPGRADE_OLD_DIR_RETENTION_SECONDS=1" || return 1
+  wait_for_pg reclaim-pg || { fail_dump reclaim reclaim-pg; return 1; }
+  local deadline=$(($(date +%s) + 90))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if [ -n "$(marker_field "$vol" oldDataDirRemovedAt)" ]; then
+      break
+    fi
+    sleep 3
+  done
+  assert_contains "$(docker logs reclaim-pg 2>&1)" "pre-upgrade data dir reclaimed" "reclaim reported" || { fail_dump reclaim reclaim-pg; stop_pg reclaim-pg; return 1; }
+  stop_pg reclaim-pg
+  in_volume "$vol" "test ! -e ${PGDATA_IN_VOLUME}.old-${FROM_VERSION}" \
+    || { echo "  old data dir still present after reclaim"; return 1; }
+  [ -n "$(marker_field "$vol" oldDataDirRemovedAt)" ] \
+    || { echo "  marker has no oldDataDirRemovedAt after reclaim"; return 1; }
+}
+
+# A trailing slash on PGDATA must not change any derived path: it used to
+# put the new cluster INSIDE the data dir and wedge the volume at
+# phase=upgraded permanently.
+t_trailing_slash_pgdata() {
+  local vol="upg-e2e-slash"
+  seed_from_cluster "$vol" || return 1
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=${PGDATA_IN_VOLUME}/" \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$JOB_IMAGE" upgrade 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 0 "upgrade with trailing-slash PGDATA" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_eq "$(marker_field "$vol" phase)" "completed" "marker completed" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "data major is TO" || return 1
+
+  # The runtime normalizes too.
+  run_pg slash-pg "$vol" "$TO_IMAGE" -e "PGDATA=${PGDATA_IN_VOLUME}/" || return 1
+  wait_for_pg slash-pg || { fail_dump slash slash-pg; return 1; }
+  assert_eq "$(psql_in slash-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "data intact with trailing-slash PGDATA" || return 1
+  stop_pg slash-pg
+}
+
 # ----- runner -----------------------------------------------------------------
 ALL_TESTS=(
   t_vanilla_boot
@@ -771,6 +932,12 @@ ALL_TESTS=(
   t_pitr_fork_survives_upgrade
   t_second_upgrade_reaches_next_major
   t_foreign_pair_upgraded_marker_refused
+  t_job_refused_while_runtime_live
+  t_runtime_refused_while_job_locked
+  t_recovery_shapes_refused
+  t_marker_lost_after_pg_upgrade_resumes
+  t_old_datadir_reclaimed
+  t_trailing_slash_pgdata
 )
 
 TESTS=("${@:-}")

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -189,11 +189,6 @@ run_pg() {
   fi
 }
 
-# Waits for the REAL server, not the temporary one docker-entrypoint runs
-# during initdb to execute the init scripts. pg_isready answers on that temp
-# server's socket too, so a seed issued on its say-so can land mid-init and be
-# rolled away with it. The "ready to accept connections" line is only logged by
-# the final server, so gate on that as well.
 # Waits for the FINAL server, never the temporary one docker-entrypoint runs
 # during initdb to execute the init scripts. That temp server logs its own
 # "ready to accept connections" and then shuts down, so both pg_isready on the
@@ -327,6 +322,11 @@ volume_data_major() {
 }
 
 cleanup_all() {
+  # CI sets this so its failure-diagnostics step can still `docker logs` the
+  # containers — this trap otherwise removes them before that step runs,
+  # making the collection loop dead code. The runner VM is discarded either
+  # way, so nothing leaks.
+  [ "${E2E_KEEP_CONTAINERS:-0}" = "1" ] && return 0
   docker ps -aq --filter label=postgres-upgrade-e2e=1 | xargs -r docker rm -f >/dev/null 2>&1
   docker volume ls -q | grep '^upg-e2e-' | xargs -r docker volume rm >/dev/null 2>&1
   docker network rm "$E2E_NET" >/dev/null 2>&1
@@ -1185,6 +1185,83 @@ t_upgraded_marker_missing_new_dir_refused() {
   in_volume "$vol" "rm -f $MARKER_PATH"
 }
 
+# The old cluster was initdb'd by the entrypoint with POSTGRES_INITDB_ARGS
+# spliced into its initdb call, and pg_upgrade refuses any locale/encoding
+# mismatch between the clusters — so the job must replay the same args into
+# the target initdb, or a custom-locale service preflights and upgrades into
+# a refusal forever. --locale=C is always available and differs from the
+# image default (en_US.utf8), which makes it the regression discriminator.
+t_custom_initdb_args_upgrade() {
+  local vol="upg-e2e-initdbargs"
+  fresh_volume "$vol" || return 1
+  run_pg initargs-pg "$vol" "$FROM_IMAGE" -e "POSTGRES_INITDB_ARGS=--locale=C" || return 1
+  wait_for_pg initargs-pg || { fail_dump initargs initargs-pg; return 1; }
+  psql_must initargs-pg "CREATE TABLE ia_canary(id int); INSERT INTO ia_canary SELECT generate_series(1,100)" || return 1
+  assert_eq "$(psql_in initargs-pg "SELECT datcollate FROM pg_database WHERE datname='template0'")" "C" "seed cluster really is locale=C" || return 1
+  stop_pg initargs-pg
+
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" -e "POSTGRES_INITDB_ARGS=--locale=C" \
+    -v "$vol:/var/lib/postgresql/data" "$JOB_IMAGE" upgrade 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 0 "upgrade with custom initdb args" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "data major is TO" || return 1
+
+  run_pg initargs2-pg "$vol" "$TO_IMAGE" -e "POSTGRES_INITDB_ARGS=--locale=C" || return 1
+  wait_for_pg initargs2-pg || { fail_dump initargs2 initargs2-pg; return 1; }
+  assert_eq "$(psql_in initargs2-pg 'SELECT count(*) FROM ia_canary')" "100" "data survived" || return 1
+  assert_eq "$(psql_in initargs2-pg "SELECT datcollate FROM pg_database WHERE datname='template0'")" "C" "locale carried into the new cluster" || return 1
+  stop_pg initargs2-pg
+}
+
+# postgres-ha's env contract INVERTS postgres-ssl's: POSTGRES_USER there is
+# the APP user Patroni creates, and the install user is
+# PATRONI_SUPERUSER_USERNAME (default postgres). The job inherits the
+# service's variables, so on an HA volume it must not trust POSTGRES_USER —
+# the discriminator is the volume itself (a Patroni data dir always carries
+# patroni.dynamic.json). Simulated: a postgres-install-user cluster with the
+# patroni file planted, dispatched with the app-user env a real HA service
+# would deliver — without the discriminator the job initdb's the target as
+# 'appuser' and pg_upgrade fails the install-user match.
+t_patroni_volume_uses_patroni_superuser() {
+  local vol="upg-e2e-patroniuser"
+  seed_from_cluster "$vol" || return 1
+  in_volume "$vol" "echo '{}' > $PGDATA_IN_VOLUME/patroni.dynamic.json \
+    && chown postgres:postgres $PGDATA_IN_VOLUME/patroni.dynamic.json" || return 1
+
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" -e "POSTGRES_USER=appuser" \
+    -v "$vol:/var/lib/postgresql/data" "$JOB_IMAGE" upgrade 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 0 "upgrade succeeds on a patroni-shaped volume with app-user env" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_contains "$JOB_OUT" "patroni cluster detected" "the discriminator is logged" || return 1
+  assert_eq "$(marker_field "$vol" phase)" "completed" "marker completed" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "data major is TO" || return 1
+}
+
+# A pre-existing pgdata.old-<from> next to FROM-major data is a manual-
+# intervention artifact (a partial restore COPIED the rollback body back and
+# left the original). finish_swap's `mv` onto that existing directory would
+# NEST pgdata inside it instead of renaming — both modes must refuse upfront
+# with the volume untouched, and succeed once the leftover is cleared.
+t_stale_old_keep_dir_refused() {
+  local vol="upg-e2e-staleold"
+  seed_from_cluster "$vol" || return 1
+  in_volume "$vol" "mkdir -p ${PGDATA_IN_VOLUME}.old-${FROM_VERSION} \
+    && touch ${PGDATA_IN_VOLUME}.old-${FROM_VERSION}/PG_VERSION" || return 1
+
+  run_job "$vol" check
+  assert_eq "$JOB_RC" 2 "check refuses on a stale rollback body" || { echo "$JOB_OUT" | tail -10; return 1; }
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 2 "upgrade refuses on a stale rollback body" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_contains "$JOB_OUT" "already exists" "refusal names the leftover dir" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "PGDATA untouched" || return 1
+
+  in_volume "$vol" "rm -rf ${PGDATA_IN_VOLUME}.old-${FROM_VERSION}" || return 1
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "succeeds once the leftover is removed" || { echo "$JOB_OUT" | tail -20; return 1; }
+}
+
 # A service variable can set PG_MAJOR to anything; the mismatch guard must
 # trust the image's installed server tree instead (adopted from postgres-ha's
 # image_major()) — a stray PG_MAJOR must not refuse a perfectly matched boot.
@@ -1235,6 +1312,9 @@ ALL_TESTS=(
   t_check_probes_sibling_slot
   t_same_pair_completed_marker_reruns
   t_upgraded_marker_missing_new_dir_refused
+  t_custom_initdb_args_upgrade
+  t_patroni_volume_uses_patroni_superuser
+  t_stale_old_keep_dir_refused
   t_unknown_marker_phase_refused
   t_pg_major_env_override_ignored
 )

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -819,6 +819,77 @@ t_second_upgrade_reaches_next_major() {
   stop_pg chain-pg
 }
 
+# Regression for the reclaim fix: chaining two upgrades before the first's
+# background reclaim ever runs (no runtime boot in between — exactly what the
+# sibling test above does) leaves TWO .old-<major> siblings on the volume at
+# once. wrapper.sh used to gate a single `rm -rf .old-*` off the LATEST
+# marker's completedAt alone, so an orphaned older generation was held
+# hostage to the newer upgrade's own clock instead of being reclaimed on its
+# own schedule (and, with a shorter retention override on the later upgrade,
+# could be swept before its OWN retention had actually elapsed). Each
+# sibling's mtime is set once — by the mv that created it — and is an
+# independent per-generation clock: back-date the first generation past its
+# own default 24h retention while leaving the second one fresh, and confirm
+# only the first is reclaimed.
+t_chained_upgrade_reclaims_by_own_age() {
+  if [ ! -f "$REPO_ROOT/Dockerfile.${CHAIN_VERSION}" ]; then
+    note "skipped: no Dockerfile.${CHAIN_VERSION} to chain onto"
+    return 0
+  fi
+  ensure_chain_images || return 1
+  local vol="upg-e2e-chainreclaim"
+  seed_from_cluster "$vol" || return 1
+
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "first upgrade exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
+
+  # No runtime boot here on purpose: the first upgrade's own reclaim fork
+  # never gets a chance to run, so its rollback body survives untouched into
+  # the second upgrade.
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$CHAIN_JOB_IMAGE" upgrade 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 0 "second upgrade exit code" || { echo "$JOB_OUT" | tail -30; return 1; }
+  in_volume "$vol" "test -d ${PGDATA_IN_VOLUME}.old-${FROM_VERSION} && test -d ${PGDATA_IN_VOLUME}.old-${TO_VERSION}" \
+    || { echo "  premise broken: expected both .old-${FROM_VERSION} and .old-${TO_VERSION} to exist after chaining"; return 1; }
+
+  # Back-date the FIRST generation past the default 24h retention; leave the
+  # second one at its real (just-created) mtime.
+  in_volume "$vol" "touch -d '@$(( $(date +%s) - 90000 ))' ${PGDATA_IN_VOLUME}.old-${FROM_VERSION}" || return 1
+
+  remove_container chainreclaim-pg
+  docker run -d --name chainreclaim-pg --label postgres-upgrade-e2e=1 \
+    -e "POSTGRES_PASSWORD=test" -e "PGDATA=$PGDATA_IN_VOLUME" \
+    -v "$vol:/var/lib/postgresql/data" "$CHAIN_IMAGE" >/dev/null || return 1
+  wait_for_pg chainreclaim-pg || { fail_dump chainreclaim chainreclaim-pg; return 1; }
+
+  local deadline=$(($(date +%s) + 120)) reclaimed=0
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if docker logs chainreclaim-pg 2>&1 | grep -qF "reclaiming the pre-upgrade data dir (${PGDATA_IN_VOLUME}.old-${FROM_VERSION})"; then
+      reclaimed=1; break
+    fi
+    sleep 3
+  done
+  if [ "$reclaimed" != "1" ]; then
+    echo "  the back-dated .old-${FROM_VERSION} was never reclaimed"
+    fail_dump chainreclaim chainreclaim-pg
+    stop_pg chainreclaim-pg
+    return 1
+  fi
+
+  in_volume "$vol" "test ! -e ${PGDATA_IN_VOLUME}.old-${FROM_VERSION}" \
+    || { echo "  back-dated .old-${FROM_VERSION} still present"; stop_pg chainreclaim-pg; return 1; }
+  # The fresh (just-created) second generation must NOT have been swept along
+  # with it — its own 24h default retention has not elapsed.
+  in_volume "$vol" "test -d ${PGDATA_IN_VOLUME}.old-${TO_VERSION}" \
+    || { echo "  fresh .old-${TO_VERSION} was reclaimed early — generations are not independent"; stop_pg chainreclaim-pg; return 1; }
+  assert_eq "$(psql_in chainreclaim-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "data intact after partial reclaim" \
+    || { stop_pg chainreclaim-pg; return 1; }
+  stop_pg chainreclaim-pg
+}
+
 # checksum_flag derives the target's --data-checksums / --no-data-checksums
 # from the OLD cluster's own pg_controldata, specifically so a user's stale
 # POSTGRES_INITDB_ARGS can't mismatch the pairing. That only protects
@@ -1366,7 +1437,11 @@ t_custom_initdb_args_upgrade() {
 t_patroni_volume_uses_patroni_superuser() {
   local vol="upg-e2e-patroniuser"
   seed_from_cluster "$vol" || return 1
-  in_volume "$vol" "echo '{}' > $PGDATA_IN_VOLUME/patroni.dynamic.json \
+  # A real dynamic.json always carries a top-level .postgresql key — the
+  # discriminator checks for it (see t_stray_patroni_file_not_trusted for the
+  # negative case), so the planted fixture has to be Patroni-shaped, not just
+  # correctly named.
+  in_volume "$vol" "echo '{\"postgresql\": {}}' > $PGDATA_IN_VOLUME/patroni.dynamic.json \
     && chown postgres:postgres $PGDATA_IN_VOLUME/patroni.dynamic.json" || return 1
 
   JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
@@ -1376,6 +1451,25 @@ t_patroni_volume_uses_patroni_superuser() {
   assert_eq "$JOB_RC" 0 "upgrade succeeds on a patroni-shaped volume with app-user env" || { echo "$JOB_OUT" | tail -30; return 1; }
   assert_contains "$JOB_OUT" "patroni cluster detected" "the discriminator is logged" || return 1
   assert_eq "$(marker_field "$vol" phase)" "completed" "marker completed" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "data major is TO" || return 1
+}
+
+# A stray/empty file that merely happens to be NAMED patroni.dynamic.json (a
+# manual copy, a leftover from mixing template types) must not be trusted as
+# proof of a Patroni-managed cluster — that would pick
+# PATRONI_SUPERUSER_USERNAME over the volume's real install user on an
+# ordinary postgres-ssl service. The discriminator requires the file's own
+# .postgresql key, which this fixture deliberately omits.
+t_stray_patroni_file_not_trusted() {
+  local vol="upg-e2e-straypatroni"
+  seed_from_cluster "$vol" || return 1
+  in_volume "$vol" "echo '{}' > $PGDATA_IN_VOLUME/patroni.dynamic.json \
+    && chown postgres:postgres $PGDATA_IN_VOLUME/patroni.dynamic.json" || return 1
+
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "upgrade succeeds despite the stray file" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_not_contains "$JOB_OUT" "patroni cluster detected" "discriminator did not fire on a non-Patroni-shaped file" || return 1
+  assert_contains "$JOB_OUT" "doesn't look like a Patroni state file" "the mismatch is logged" || return 1
   assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "data major is TO" || return 1
 }
 
@@ -1461,6 +1555,26 @@ t_unrecognized_positional_arg_refused() {
   assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "volume untouched — did not silently upgrade" || return 1
 }
 
+# The image's own CMD is the safety net for a bare `docker run` with NO mode
+# specified at all — no UPGRADE_JOB_MODE, no positional arg — exactly the
+# ad-hoc manual/incident-response invocation the mode-dispatch guards above
+# exist for (an unrecognized positional arg refuses, but "no argument
+# whatsoever" isn't unrecognized, it silently inherits whatever CMD defaults
+# to). That default must be inert — read-only, no lock taken, no directory
+# touched — never the single most destructive mode there is.
+t_bare_invocation_defaults_to_read_only_mode() {
+  local vol="upg-e2e-barecmd"
+  seed_from_cluster "$vol" || return 1
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$JOB_IMAGE" 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 0 "bare invocation (image default CMD) exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
+  assert_contains "$JOB_OUT" '"mode":"status"' "image default is the read-only status mode, not upgrade" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "a bare invocation must not touch the data" || return 1
+}
+
 # The production dispatch path selects the mode via UPGRADE_JOB_MODE alone,
 # with NO positional arg — Railway never sends one (see the doc comment on
 # the MODE block in upgrade-job.sh). Every other test in this suite drives
@@ -1536,6 +1650,7 @@ ALL_TESTS=(
   t_remote_auth_survives_upgrade
   t_pitr_fork_survives_upgrade
   t_second_upgrade_reaches_next_major
+  t_chained_upgrade_reclaims_by_own_age
   t_custom_initdb_args_checksums_flag_wins
   t_foreign_pair_upgraded_marker_refused
   t_job_refused_while_runtime_live
@@ -1554,11 +1669,13 @@ ALL_TESTS=(
   t_pg_version_content_cannot_forge_result_line
   t_custom_initdb_args_upgrade
   t_patroni_volume_uses_patroni_superuser
+  t_stray_patroni_file_not_trusted
   t_stale_old_keep_dir_refused
   t_unknown_marker_phase_refused
   t_pg_major_env_override_ignored
   t_railway_private_domain_pghost_ignored
   t_unrecognized_positional_arg_refused
+  t_bare_invocation_defaults_to_read_only_mode
   t_upgrade_job_mode_env_var_selects_mode
   t_railway_env_without_mode_var_refused
 )

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -394,19 +394,36 @@ t_check_blocker() {
   stop_pg blocker2-pg
 }
 
-# reg*/aclitem columns block ONLY from a pre-16 source. Runs on the pairs
-# where that gating says it must fire, and asserts pg_upgrade agrees — this is
-# the ground truth the dashboard preflight's version gating mirrors.
+# reg*/aclitem columns never block from a >=16 source (verified for 16→17);
+# whether they block from any GIVEN pre-16 source is not a clean rule —
+# empirically, 15→16 fires both, but 14→15 fires neither (pg_upgrade's own
+# checks evidently depend on what changed across that specific pair's span,
+# not on the source major alone). This runs on whichever pre-16 pair the
+# suite is invoked with and asserts pg_upgrade agrees with what THAT pair
+# is known to do — it is not a general statement about every pre-16 source.
+# This is the same real-world gating the dashboard preflight's version
+# check mirrors.
+#
+# Seeded and checked SEPARATELY, not both columns in one cluster: pg_upgrade
+# runs its consistency checks in a fixed sequence and stops at the first
+# fatal one, so with both columns present the reg* check (which comes first)
+# preempts aclitem's — its message never prints, not because the gating
+# didn't fire, but because that check never ran.
 t_check_blocker_pre16_types() {
   if [ "$FROM_VERSION" -ge 16 ]; then
-    note "skipped: reg*/aclitem checks only fire from a pre-16 source"
+    note "skipped: only verified to fire on a pre-16 source (16→17 confirmed clean)"
     return 0
   fi
   local vol="upg-e2e-pre16types"
-  seed_from_cluster "$vol" "CREATE TABLE t_aclitem (c aclitem); CREATE TABLE t_regproc (c regproc)" || return 1
+  seed_from_cluster "$vol" "CREATE TABLE t_regproc (c regproc)" || return 1
   run_job "$vol" check
-  assert_eq "$JOB_RC" 1 "check exit code with pre-16 type blockers" || { echo "$JOB_OUT" | tail -20; return 1; }
+  assert_eq "$JOB_RC" 1 "check exit code with a reg* blocker" || { echo "$JOB_OUT" | tail -20; return 1; }
   assert_contains "$JOB_OUT" "reg* data types" "reg* blocker named" || return 1
+
+  local vol2="upg-e2e-pre16types-aclitem"
+  seed_from_cluster "$vol2" "CREATE TABLE t_aclitem (c aclitem)" || return 1
+  run_job "$vol2" check
+  assert_eq "$JOB_RC" 1 "check exit code with an aclitem blocker" || { echo "$JOB_OUT" | tail -20; return 1; }
   assert_contains "$JOB_OUT" "aclitem" "aclitem blocker named" || return 1
 }
 
@@ -599,6 +616,19 @@ t_boot_refused_mid_upgrade() {
   in_volume "$vol" "rm -f $MARKER_PATH"
 }
 
+# The upgrade job only writes its first marker on pg_upgrade's own success —
+# a crash DURING --link leaves no marker at all. pg_control.old present with
+# pg_control absent (pg_upgrade renames it before linking the first relation
+# file) is that exact shape, and PG_VERSION is untouched by the rename, so it
+# still matches the FROM image — the version-mismatch guard would not catch
+# this either without a dedicated check.
+t_pg_control_disabled_without_marker_refused() {
+  local vol="upg-e2e-pgcontrolold"
+  seed_from_cluster "$vol" || return 1
+  in_volume "$vol" "mv $PGDATA_IN_VOLUME/global/pg_control $PGDATA_IN_VOLUME/global/pg_control.old" || return 1
+  expect_boot_refusal "$vol" "$FROM_IMAGE" "interrupted major version upgrade" || return 1
+}
+
 # Crash between the two directory renames: marker=upgraded, old dir moved
 # aside, no $PGDATA. Re-running the job completes the swap deterministically.
 t_resume_after_crash_between_swaps() {
@@ -764,6 +794,51 @@ t_second_upgrade_reaches_next_major() {
   assert_eq "$(psql_in chain-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "data intact after two upgrades" || return 1
   assert_contains "$(psql_in chain-pg 'SHOW server_version')" "$CHAIN_VERSION." "server is TO+1" || return 1
   stop_pg chain-pg
+}
+
+# checksum_flag derives the target's --data-checksums / --no-data-checksums
+# from the OLD cluster's own pg_controldata, specifically so a user's stale
+# POSTGRES_INITDB_ARGS can't mismatch the pairing. That only protects
+# anything when the derived flag is non-empty AND initdb is last-wins on a
+# repeated toggle — which needs a target where --no-data-checksums actually
+# exists (18+, where the default flipped to ON), so this rides the chain
+# pair (17→18 by default) rather than the suite's main FROM→TO. Without the
+# derived flag coming after the user's in the initdb invocation, this would
+# refuse at --check with "old cluster does not use data checksums but the
+# new one does" instead of upgrading.
+t_custom_initdb_args_checksums_flag_wins() {
+  if [ ! -f "$REPO_ROOT/Dockerfile.${CHAIN_VERSION}" ]; then
+    note "skipped: no Dockerfile.${CHAIN_VERSION} to chain onto"
+    return 0
+  fi
+  if [ "$CHAIN_VERSION" -lt 18 ]; then
+    # --no-data-checksums doesn't exist before 18 (added alongside the
+    # default flip), so checksum_flag() derives nothing for a checksums-off
+    # old cluster below that target — there is no override for this test to
+    # prove wins, and the user's --data-checksums would legitimately take
+    # effect and mismatch. Needs a real 18+ target; this suite's own
+    # FROM/TO env vars decide which pair the chain lands on.
+    note "skipped: chain target $CHAIN_VERSION predates --no-data-checksums (needs 18+)"
+    return 0
+  fi
+  ensure_chain_images || return 1
+  local vol="upg-e2e-checksumflag"
+  seed_from_cluster "$vol" || return 1
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "first upgrade (to the checksums-off default) exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
+
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" -e "POSTGRES_INITDB_ARGS=--data-checksums" \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$CHAIN_JOB_IMAGE" upgrade 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 0 "chain upgrade succeeds despite a contradicting POSTGRES_INITDB_ARGS" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_eq "$(volume_data_major "$vol")" "$CHAIN_VERSION" "data major after chain upgrade" || return 1
+
+  local checksum_version
+  checksum_version=$(docker run --rm -v "$vol:/var/lib/postgresql/data" --entrypoint /bin/sh "$CHAIN_JOB_IMAGE" \
+    -c "/usr/lib/postgresql/${CHAIN_VERSION}/bin/pg_controldata $PGDATA_IN_VOLUME 2>/dev/null | awk -F: '/Data page checksum version/ {gsub(/ /,\"\",\$2); print \$2}'")
+  assert_eq "$checksum_version" "0" "derived checksum_flag won — target matches the OLD cluster, not the user's stale flag" || return 1
 }
 
 # An in-flight (phase=upgraded) marker belonging to a DIFFERENT version pair
@@ -1384,6 +1459,26 @@ t_upgrade_job_mode_env_var_selects_mode() {
   assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "status is read-only — data untouched" || return 1
 }
 
+# The image's own CMD ["upgrade"] means every real container start supplies
+# a RECOGNIZED positional arg regardless of runtime — an unrecognized-arg
+# refusal (see t_unrecognized_positional_arg_refused) does nothing to catch
+# a lost UPGRADE_JOB_MODE in production, because "upgrade" isn't unrecognized,
+# it's the single most destructive mode there is. Simulates that exact shape:
+# RAILWAY_ENVIRONMENT set (a real deployment), UPGRADE_JOB_MODE missing, and
+# the positional arg the CMD would supply.
+t_railway_env_without_mode_var_refused() {
+  local vol="upg-e2e-railwaynomode"
+  seed_from_cluster "$vol" || return 1
+
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" -e "RAILWAY_ENVIRONMENT=production" \
+    -v "$vol:/var/lib/postgresql/data" "$JOB_IMAGE" upgrade 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 2 "refuses on Railway without UPGRADE_JOB_MODE, despite a recognized positional arg" || { echo "$JOB_OUT" | tail -20; return 1; }
+  assert_contains "$JOB_OUT" "UPGRADE_JOB_MODE is not set" "refusal names the missing env var" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "volume untouched — did not silently upgrade" || return 1
+}
+
 # ----- runner -----------------------------------------------------------------
 ALL_TESTS=(
   t_vanilla_boot
@@ -1402,10 +1497,12 @@ ALL_TESTS=(
   t_old_image_on_upgraded_data
   t_mismatch_boot_failstop
   t_boot_refused_mid_upgrade
+  t_pg_control_disabled_without_marker_refused
   t_resume_after_crash_between_swaps
   t_remote_auth_survives_upgrade
   t_pitr_fork_survives_upgrade
   t_second_upgrade_reaches_next_major
+  t_custom_initdb_args_checksums_flag_wins
   t_foreign_pair_upgraded_marker_refused
   t_job_refused_while_runtime_live
   t_runtime_refused_while_job_locked
@@ -1429,6 +1526,7 @@ ALL_TESTS=(
   t_railway_private_domain_pghost_ignored
   t_unrecognized_positional_arg_refused
   t_upgrade_job_mode_env_var_selects_mode
+  t_railway_env_without_mode_var_refused
 )
 
 TESTS=("${@:-}")

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -914,6 +914,38 @@ t_trailing_slash_pgdata() {
   stop_pg slash-pg
 }
 
+# A real Railway volume's ROOT is root:root drwxr-xr-x — only PGDATA itself
+# is chowned to postgres (verified against a real deployment). A fresh docker
+# volume does NOT reproduce this: on first mount, docker copies the image's
+# own directory entry for the mount path onto the empty volume, and the
+# official postgres image's own /var/lib/postgresql/data is postgres-owned
+# and world-writable — so every other test in this file runs against a volume
+# root the real platform never produces. `init_new_cluster` used to `mkdir`
+# the sibling `.upgrade-<major>` directory AS postgres (`as_postgres mkdir`),
+# which needs write access to the PARENT — the volume root. That parent is
+# writable by postgres in every local test and by nobody but root in
+# production, so the job passed here and failed exit 3 on every real upgrade.
+# Force the real shape before running the job, so this stays caught.
+t_upgrade_survives_root_owned_volume_root() {
+  local vol="upg-e2e-rootvol"
+  seed_from_cluster "$vol" || return 1
+  in_volume "$vol" "chown root:root /var/lib/postgresql/data && chmod 0755 /var/lib/postgresql/data" \
+    || { echo "  could not force the volume root to root:root"; return 1; }
+  assert_eq "$(in_volume "$vol" 'stat -c "%U:%G %a" /var/lib/postgresql/data')" "root:root 755" \
+    "volume root forced to the production shape" || return 1
+
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "upgrade exit code against a root-owned volume root" \
+    || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_eq "$(marker_field "$vol" phase)" "completed" "marker phase" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "on-disk major is now TO" || return 1
+
+  run_pg rootvol-pg "$vol" "$TO_IMAGE" || return 1
+  wait_for_pg rootvol-pg || { fail_dump rootvol rootvol-pg; return 1; }
+  assert_eq "$(psql_in rootvol-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "rows survived" || return 1
+  stop_pg rootvol-pg
+}
+
 # ----- runner -----------------------------------------------------------------
 ALL_TESTS=(
   t_vanilla_boot
@@ -943,6 +975,7 @@ ALL_TESTS=(
   t_marker_lost_after_pg_upgrade_resumes
   t_old_datadir_reclaimed
   t_trailing_slash_pgdata
+  t_upgrade_survives_root_owned_volume_root
 )
 
 TESTS=("${@:-}")

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -539,8 +539,11 @@ t_ssl_survives_upgrade() {
   run_pg ssl-after "$vol" "$TO_IMAGE" || return 1
   wait_for_pg ssl-after || { fail_dump ssl-after ssl-after; return 1; }
   assert_eq "$(psql_in ssl-after 'SHOW ssl')" "on" "ssl still on after upgrade" || return 1
-  # And a TLS connection actually completes, not just the setting being present.
-  assert_contains "$(docker exec ssl-after psql 'sslmode=require host=localhost user=postgres dbname=postgres' -tAc 'SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()' 2>&1)" "t" "sslmode=require connection is encrypted" || return 1
+  # And a TLS connection actually completes, not just the setting being
+  # present. assert_eq, not assert_contains: pg_stat_ssl.ssl is boolean ('t'
+  # or 'f'), and with stderr captured too, a contains-"t" check would pass on
+  # almost any connection error message as well as the real answer.
+  assert_eq "$(docker exec ssl-after psql 'sslmode=require host=localhost user=postgres dbname=postgres' -tAc 'SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()' 2>&1)" "t" "sslmode=require connection is encrypted" || return 1
   stop_pg ssl-after
 }
 
@@ -1318,17 +1321,67 @@ t_railway_private_domain_pghost_ignored() {
 
   JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
     -e "PGDATA=$PGDATA_IN_VOLUME" -e "PGHOST=postgres.railway.internal" -e "PGPORT=5432" \
+    -e "PGHOSTADDR=10.0.0.5" \
     -v "$vol:/var/lib/postgresql/data" "$JOB_IMAGE" check 2>&1)
   JOB_RC=$?
-  assert_eq "$JOB_RC" 0 "check succeeds despite an inherited private-domain PGHOST" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_eq "$JOB_RC" 0 "check succeeds despite inherited private-domain PGHOST/PGHOSTADDR" || { echo "$JOB_OUT" | tail -30; return 1; }
   assert_contains "$JOB_OUT" '"ok":true' "check result reports ok" || return 1
 
   JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
     -e "PGDATA=$PGDATA_IN_VOLUME" -e "PGHOST=postgres.railway.internal" -e "PGPORT=5432" \
+    -e "PGHOSTADDR=10.0.0.5" \
     -v "$vol:/var/lib/postgresql/data" "$JOB_IMAGE" upgrade 2>&1)
   JOB_RC=$?
-  assert_eq "$JOB_RC" 0 "upgrade succeeds despite an inherited private-domain PGHOST" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_eq "$JOB_RC" 0 "upgrade succeeds despite inherited private-domain PGHOST/PGHOSTADDR" || { echo "$JOB_OUT" | tail -30; return 1; }
   assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "data major is TO" || return 1
+}
+
+# The positional-arg fallback is reachable only from manual/incident-response
+# invocation (production always sets UPGRADE_JOB_MODE), which is exactly
+# where a typo happens. An unrecognized arg must refuse loudly — silently
+# falling through to the "upgrade" default would turn a typo'd read-only
+# check into the destructive path.
+t_unrecognized_positional_arg_refused() {
+  local vol="upg-e2e-badarg"
+  seed_from_cluster "$vol" || return 1
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" \
+    -v "$vol:/var/lib/postgresql/data" "$JOB_IMAGE" cehck 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 2 "unrecognized positional arg refused, not silently upgraded" || { echo "$JOB_OUT" | tail -20; return 1; }
+  assert_contains "$JOB_OUT" "no recognized mode" "refusal names the problem" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "volume untouched — did not silently upgrade" || return 1
+}
+
+# The production dispatch path selects the mode via UPGRADE_JOB_MODE alone,
+# with NO positional arg — Railway never sends one (see the doc comment on
+# the MODE block in upgrade-job.sh). Every other test in this suite drives
+# the mode through a positional arg via run_job, so without this one the
+# actual production mechanism has zero coverage here: a rename or a broken
+# read of UPGRADE_JOB_MODE would go unnoticed by the whole suite while
+# breaking every real dispatch.
+t_upgrade_job_mode_env_var_selects_mode() {
+  local vol="upg-e2e-modeenv"
+  seed_from_cluster "$vol" || return 1
+
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" -e "UPGRADE_JOB_MODE=check" \
+    -v "$vol:/var/lib/postgresql/data" "$JOB_IMAGE" 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 0 "UPGRADE_JOB_MODE=check with no positional arg runs check" || { echo "$JOB_OUT" | tail -20; return 1; }
+  assert_contains "$JOB_OUT" '"mode":"check"' "result reports check mode" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "check is read-only — data untouched" || return 1
+
+  # Defense in depth: Railway never sends a positional arg alongside the env
+  # var, but nothing about the dispatch contract should rely on that — the
+  # env var must win over a conflicting one anyway.
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" -e "UPGRADE_JOB_MODE=status" \
+    -v "$vol:/var/lib/postgresql/data" "$JOB_IMAGE" upgrade 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 0 "UPGRADE_JOB_MODE wins over a conflicting positional arg" || { echo "$JOB_OUT" | tail -20; return 1; }
+  assert_contains "$JOB_OUT" '"mode":"status"' "env var mode used, not the positional upgrade" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "status is read-only — data untouched" || return 1
 }
 
 # ----- runner -----------------------------------------------------------------
@@ -1374,6 +1427,8 @@ ALL_TESTS=(
   t_unknown_marker_phase_refused
   t_pg_major_env_override_ignored
   t_railway_private_domain_pghost_ignored
+  t_unrecognized_positional_arg_refused
+  t_upgrade_job_mode_env_var_selects_mode
 )
 
 TESTS=("${@:-}")

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -1,0 +1,502 @@
+#!/usr/bin/env bash
+# test/e2e-upgrade.sh — end-to-end test harness for the in-place major
+# upgrade job (Dockerfile.upgrade + upgrade-job.sh) and the runtime
+# wrapper's major-version guards.
+#
+# Builds the runtime images for FROM and TO majors (default 16 -> 17,
+# override with FROM_VERSION/TO_VERSION) plus the dual-binary job image,
+# then walks every assertion in sequence. Each assertion is a `t_*`
+# function; failure dumps the relevant container logs. Final exit code is
+# the count of failed tests.
+#
+# Run: ./test/e2e-upgrade.sh
+# Or:  FROM_VERSION=15 TO_VERSION=17 ./test/e2e-upgrade.sh
+# Or:  ./test/e2e-upgrade.sh t_upgrade_happy_path t_upgrade_idempotent
+#
+# Designed for a single-host docker daemon. Volumes are scoped per test.
+
+set -uo pipefail
+
+FROM_VERSION="${FROM_VERSION:-16}"
+TO_VERSION="${TO_VERSION:-17}"
+FROM_IMAGE="postgres-ssl-e2e:${FROM_VERSION}"
+TO_IMAGE="postgres-ssl-e2e:${TO_VERSION}"
+JOB_IMAGE="postgres-upgrade-e2e:${FROM_VERSION}-${TO_VERSION}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PGDATA_IN_VOLUME="/var/lib/postgresql/data/pgdata"
+MARKER_PATH="/var/lib/postgresql/data/.railway-major-upgrade.json"
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+# ----- color / log helpers ---------------------------------------------------
+if [ -t 1 ]; then
+  R=$'\033[31m'; G=$'\033[32m'; Y=$'\033[33m'; B=$'\033[36m'; N=$'\033[0m'
+else
+  R=""; G=""; Y=""; B=""; N=""
+fi
+log()  { echo "${B}==>${N} $*"; }
+ok()   { echo "${G}PASS${N} $*"; PASS=$((PASS+1)); }
+ko()   { echo "${R}FAIL${N} $*"; FAIL=$((FAIL+1)); FAILED_TESTS+=("$1"); }
+note() { echo "  ${Y}note:${N} $*"; }
+
+fail_dump() {
+  local label="$1"; shift
+  echo "${R}--- failure detail (${label}) ---${N}" >&2
+  for c in "$@"; do
+    if docker ps -a --format '{{.Names}}' | grep -q "^${c}$"; then
+      echo "${R}--- docker logs ${c} (last 60) ---${N}" >&2
+      docker logs --tail 60 "$c" 2>&1 | sed 's/^/    /' >&2
+    fi
+  done
+}
+
+# ----- assertion helpers -----------------------------------------------------
+assert_eq() {
+  local actual="$1" expected="$2" msg="$3"
+  if [ "$actual" = "$expected" ]; then return 0; fi
+  echo "  expected: $expected"
+  echo "  actual:   $actual"
+  echo "  msg:      $msg"
+  return 1
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="$3"
+  if echo "$haystack" | grep -qF -- "$needle"; then return 0; fi
+  echo "  expected to contain: $needle"
+  echo "  actual (tail):       $(echo "$haystack" | tail -5)"
+  echo "  msg:                 $msg"
+  return 1
+}
+
+# ----- environment management ------------------------------------------------
+# Always build. The scripts under test (wrapper.sh, upgrade-job.sh) are
+# COPY'd into these images, so an existence check would silently test a stale
+# copy of the very code being changed. Docker's layer cache makes the repeat
+# build cheap — only the COPY layers re-run.
+ensure_images() {
+  for pair in "$FROM_VERSION:$FROM_IMAGE" "$TO_VERSION:$TO_IMAGE"; do
+    local ver="${pair%%:*}" img="${pair#*:}"
+    log "building runtime image $img"
+    docker build -q -f "$REPO_ROOT/Dockerfile.${ver}" -t "$img" "$REPO_ROOT" >/dev/null || exit 1
+  done
+  log "building job image $JOB_IMAGE"
+  docker build -q -f "$REPO_ROOT/Dockerfile.upgrade" \
+    --build-arg "FROM_VERSION=$FROM_VERSION" --build-arg "TO_VERSION=$TO_VERSION" \
+    -t "$JOB_IMAGE" "$REPO_ROOT" >/dev/null || exit 1
+}
+
+fresh_volume() {
+  local vol="$1"
+  docker volume rm "$vol" >/dev/null 2>&1 || true
+  docker volume create "$vol" >/dev/null
+}
+
+# Start a runtime postgres container on a volume. Extra docker args pass
+# through after name+vol+image.
+run_pg() {
+  local name="$1" vol="$2" image="$3"; shift 3
+  docker run -d --name "$name" --label postgres-upgrade-e2e=1 \
+    -e "POSTGRES_PASSWORD=test" \
+    -e "PGDATA=$PGDATA_IN_VOLUME" \
+    "$@" \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$image" >/dev/null
+}
+
+wait_for_pg() {
+  local container="$1" deadline=$(($(date +%s) + 90))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if docker exec "$container" pg_isready -q -U postgres 2>/dev/null; then return 0; fi
+    if [ "$(docker inspect -f '{{.State.Status}}' "$container" 2>/dev/null)" = "exited" ]; then
+      return 1
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+psql_in() {
+  local container="$1" sql="$2"
+  docker exec "$container" psql -U postgres -tAc "$sql" 2>&1
+}
+
+# Clean stop: shut postgres down through pg_ctl so pg_control records
+# "shut down". `docker stop` alone is NOT clean on this image — bash as PID 1
+# never forwards SIGTERM, so postgres is SIGKILLed after the grace period and
+# leaves an unclean cluster plus a stale postmaster.pid (see kill_pg, which
+# exercises that path deliberately).
+stop_pg() {
+  local name="$1"
+  docker exec "$name" gosu postgres pg_ctl -D "$PGDATA_IN_VOLUME" -w -t 60 -m fast stop >/dev/null 2>&1
+  docker stop -t 30 "$name" >/dev/null 2>&1
+  docker rm -f "$name" >/dev/null 2>&1
+}
+
+# Ungraceful stop: what the platform actually does when a deployment is
+# stopped (and what any crash looks like) — unreplayed WAL, cluster state
+# "in production", stale postmaster.pid.
+kill_pg() {
+  local name="$1"
+  docker kill -s KILL "$name" >/dev/null 2>&1
+  docker rm -f "$name" >/dev/null 2>&1
+}
+
+# Run the upgrade job in a given mode on a volume; captures combined output.
+# Sets JOB_OUT and JOB_RC.
+run_job() {
+  local vol="$1" mode="${2:-upgrade}"
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$JOB_IMAGE" "$mode" 2>&1)
+  JOB_RC=$?
+}
+
+# Boot a runtime image on a volume and expect the wrapper to REFUSE (exit
+# nonzero) with a message containing $3. Sets BOOT_OUT.
+expect_boot_refusal() {
+  local vol="$1" image="$2" needle="$3"
+  local name="refusal-$RANDOM"
+  docker run -d --name "$name" --label postgres-upgrade-e2e=1 \
+    -e "POSTGRES_PASSWORD=test" -e "PGDATA=$PGDATA_IN_VOLUME" \
+    -v "$vol:/var/lib/postgresql/data" "$image" >/dev/null
+  local deadline=$(($(date +%s) + 30)) status="running"
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    status="$(docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null)"
+    [ "$status" = "exited" ] && break
+    sleep 1
+  done
+  BOOT_OUT=$(docker logs "$name" 2>&1)
+  local exit_code
+  exit_code=$(docker inspect -f '{{.State.ExitCode}}' "$name" 2>/dev/null)
+  docker rm -f "$name" >/dev/null 2>&1
+  if [ "$status" != "exited" ] || [ "$exit_code" = "0" ]; then
+    echo "  expected the container to exit nonzero (status=$status exit=$exit_code)"
+    return 1
+  fi
+  assert_contains "$BOOT_OUT" "$needle" "refusal message"
+}
+
+# Seed a FROM-major cluster with recognizable data, then stop it cleanly.
+# Leaves the volume ready for the job. $2 optional extra SQL.
+seed_from_cluster() {
+  local vol="$1" extra_sql="${2:-}"
+  fresh_volume "$vol"
+  run_pg seed-pg "$vol" "$FROM_IMAGE"
+  wait_for_pg seed-pg || { fail_dump seed seed-pg; return 1; }
+  psql_in seed-pg "CREATE TABLE upgrade_canary (id serial PRIMARY KEY, body text)" >/dev/null
+  psql_in seed-pg "INSERT INTO upgrade_canary (body) SELECT 'row-' || g FROM generate_series(1, 1000) g" >/dev/null
+  psql_in seed-pg "CREATE INDEX upgrade_canary_body_idx ON upgrade_canary (body)" >/dev/null
+  psql_in seed-pg "CREATE EXTENSION IF NOT EXISTS vector" >/dev/null
+  psql_in seed-pg "CREATE TABLE embeddings (id int, v vector(3)); INSERT INTO embeddings VALUES (1, '[1,2,3]')" >/dev/null
+  if [ -n "$extra_sql" ]; then
+    psql_in seed-pg "$extra_sql" >/dev/null
+  fi
+  stop_pg seed-pg
+}
+
+# Reads one marker field. Uses a plain `.field` and maps jq's "null" to the
+# empty string rather than `// empty`, because jq's `//` treats a literal
+# `false` as absent — a boolean field read that way comes back empty.
+marker_field() {
+  local vol="$1" field="$2"
+  docker run --rm -v "$vol:/var/lib/postgresql/data" --entrypoint /bin/sh "$JOB_IMAGE" \
+    -c "jq -r '.$field' $MARKER_PATH 2>/dev/null" | sed 's/^null$//'
+}
+
+volume_data_major() {
+  local vol="$1"
+  docker run --rm -v "$vol:/var/lib/postgresql/data" --entrypoint /bin/sh "$JOB_IMAGE" \
+    -c "cat $PGDATA_IN_VOLUME/PG_VERSION 2>/dev/null"
+}
+
+cleanup_all() {
+  docker ps -aq --filter label=postgres-upgrade-e2e=1 | xargs -r docker rm -f >/dev/null 2>&1
+  docker volume ls -q | grep '^upg-e2e-' | xargs -r docker volume rm >/dev/null 2>&1
+}
+trap cleanup_all EXIT
+
+# ----- tests -------------------------------------------------------------------
+
+# Regression: the new wrapper guards must not disturb a vanilla fresh init +
+# boot + restart on the FROM major.
+t_vanilla_boot() {
+  local vol="upg-e2e-vanilla"
+  fresh_volume "$vol"
+  run_pg vanilla-pg "$vol" "$FROM_IMAGE"
+  wait_for_pg vanilla-pg || { fail_dump vanilla vanilla-pg; return 1; }
+  psql_in vanilla-pg "SELECT 1" | grep -q 1 || return 1
+  docker restart vanilla-pg >/dev/null
+  wait_for_pg vanilla-pg || { fail_dump vanilla-restart vanilla-pg; return 1; }
+  stop_pg vanilla-pg
+}
+
+# check mode on a healthy cluster: exit 0, volume untouched, FROM still boots.
+t_check_pass() {
+  local vol="upg-e2e-checkpass"
+  seed_from_cluster "$vol" || return 1
+  run_job "$vol" check
+  assert_eq "$JOB_RC" 0 "check mode exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
+  assert_contains "$JOB_OUT" '"ok": true' "machine-readable result" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "data major untouched by check" || return 1
+  run_pg checkpass-pg "$vol" "$FROM_IMAGE"
+  wait_for_pg checkpass-pg || { fail_dump checkpass checkpass-pg; return 1; }
+  assert_eq "$(psql_in checkpass-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "data intact after check" || return 1
+  stop_pg checkpass-pg
+}
+
+# A prepared transaction is a version-independent pg_upgrade blocker: check
+# exits 1, names it, and the FROM cluster still boots untouched.
+#
+# Deliberately NOT using reg*/aclitem columns here: pg_upgrade gates those
+# checks on the SOURCE major (both fire from 14/15, neither fires from 16+),
+# so they make a poor assertion for a harness parameterized over version
+# pairs — and that gating is exactly what the dashboard preflight has to
+# mirror.
+t_check_blocker() {
+  local vol="upg-e2e-blocker"
+  fresh_volume "$vol"
+  run_pg blocker-pg "$vol" "$FROM_IMAGE"
+  wait_for_pg blocker-pg || { fail_dump blocker blocker-pg; return 1; }
+  psql_in blocker-pg "ALTER SYSTEM SET max_prepared_transactions = 10" >/dev/null
+  docker restart blocker-pg >/dev/null
+  wait_for_pg blocker-pg || { fail_dump blocker-restart blocker-pg; return 1; }
+  psql_in blocker-pg "BEGIN; CREATE TABLE prep_canary (x int); PREPARE TRANSACTION 'e2e_blocker_tx'" >/dev/null
+  assert_eq "$(psql_in blocker-pg 'SELECT count(*) FROM pg_prepared_xacts')" "1" "prepared transaction staged" || return 1
+  stop_pg blocker-pg
+
+  run_job "$vol" check
+  assert_eq "$JOB_RC" 1 "check mode exit code with blocker" || { echo "$JOB_OUT" | tail -20; return 1; }
+  assert_contains "$JOB_OUT" "prepared transaction" "blocker named in output" || return 1
+
+  # Untouched: the old cluster still boots and the blocker is still there.
+  run_pg blocker2-pg "$vol" "$FROM_IMAGE"
+  wait_for_pg blocker2-pg || { fail_dump blocker2 blocker2-pg; return 1; }
+  assert_eq "$(psql_in blocker2-pg 'SELECT count(*) FROM pg_prepared_xacts')" "1" "cluster untouched by a failed check" || return 1
+  psql_in blocker2-pg "ROLLBACK PREPARED 'e2e_blocker_tx'" >/dev/null
+  stop_pg blocker2-pg
+}
+
+# reg*/aclitem columns block ONLY from a pre-16 source. Runs on the pairs
+# where that gating says it must fire, and asserts pg_upgrade agrees — this is
+# the ground truth the dashboard preflight's version gating mirrors.
+t_check_blocker_pre16_types() {
+  if [ "$FROM_VERSION" -ge 16 ]; then
+    note "skipped: reg*/aclitem checks only fire from a pre-16 source"
+    return 0
+  fi
+  local vol="upg-e2e-pre16types"
+  seed_from_cluster "$vol" "CREATE TABLE t_aclitem (c aclitem); CREATE TABLE t_regproc (c regproc)" || return 1
+  run_job "$vol" check
+  assert_eq "$JOB_RC" 1 "check exit code with pre-16 type blockers" || { echo "$JOB_OUT" | tail -20; return 1; }
+  assert_contains "$JOB_OUT" "reg* data types" "reg* blocker named" || return 1
+  assert_contains "$JOB_OUT" "aclitem" "aclitem blocker named" || return 1
+}
+
+# Wrong source major: a FROM->TO job pointed at a TO-major volume refuses.
+t_refuses_wrong_major() {
+  local vol="upg-e2e-wrongmajor"
+  fresh_volume "$vol"
+  run_pg wrong-pg "$vol" "$TO_IMAGE"
+  wait_for_pg wrong-pg || { fail_dump wrongmajor wrong-pg; return 1; }
+  stop_pg wrong-pg
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 2 "job refuses wrong source major" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_contains "$JOB_OUT" "this job upgrades $FROM_VERSION" "message names the majors" || return 1
+}
+
+# The platform stops deployments by killing the container, so the job must
+# handle an unclean cluster: replay WAL with the old binaries, shut down
+# cleanly, then upgrade. Without this, pg_upgrade refuses and every real
+# upgrade fails. Committed rows written right before the kill must survive.
+t_recovers_unclean_shutdown() {
+  local vol="upg-e2e-unclean"
+  fresh_volume "$vol"
+  run_pg unclean-pg "$vol" "$FROM_IMAGE"
+  wait_for_pg unclean-pg || { fail_dump unclean unclean-pg; return 1; }
+  psql_in unclean-pg "CREATE TABLE unclean_canary (id int)" >/dev/null
+  psql_in unclean-pg "INSERT INTO unclean_canary SELECT generate_series(1, 500)" >/dev/null
+  psql_in unclean-pg "CHECKPOINT" >/dev/null
+  psql_in unclean-pg "INSERT INTO unclean_canary SELECT generate_series(501, 700)" >/dev/null
+  kill_pg unclean-pg
+
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "upgrade after unclean shutdown" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_contains "$JOB_OUT" "replaying WAL" "recovery path was taken" || return 1
+  assert_eq "$(marker_field "$vol" phase)" "completed" "marker completed" || return 1
+
+  run_pg unclean2-pg "$vol" "$TO_IMAGE"
+  wait_for_pg unclean2-pg || { fail_dump unclean2 unclean2-pg; return 1; }
+  assert_eq "$(psql_in unclean2-pg 'SELECT count(*) FROM unclean_canary')" "700" "post-checkpoint rows replayed and upgraded" || return 1
+  stop_pg unclean2-pg
+}
+
+# A second concurrent job on the same volume is refused (activity-retry race).
+t_refuses_concurrent_job() {
+  local vol="upg-e2e-concurrent"
+  seed_from_cluster "$vol" || return 1
+  # Hold the lock from a sleeper container, then try a real job.
+  docker run -d --name lockholder --label postgres-upgrade-e2e=1 \
+    -v "$vol:/var/lib/postgresql/data" --entrypoint /bin/sh "$JOB_IMAGE" \
+    -c "exec 9>/var/lib/postgresql/data/.railway-major-upgrade.lock; flock 9; sleep 60" >/dev/null
+  sleep 2
+  run_job "$vol" upgrade
+  local rc="$JOB_RC" out="$JOB_OUT"
+  docker rm -f lockholder >/dev/null 2>&1
+  assert_eq "$rc" 2 "second job refused" || { echo "$out" | tail -10; return 1; }
+  assert_contains "$out" "another upgrade job is already running" "lock message" || return 1
+}
+
+# The whole point: upgrade succeeds, marker completes, the TO image boots,
+# and every seeded object (rows, index, pgvector data) survived.
+t_upgrade_happy_path() {
+  local vol="upg-e2e-happy"
+  seed_from_cluster "$vol" || return 1
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "upgrade exit code" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_eq "$(marker_field "$vol" phase)" "completed" "marker phase" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "on-disk major is now TO" || return 1
+
+  run_pg happy-pg "$vol" "$TO_IMAGE"
+  wait_for_pg happy-pg || { fail_dump happy happy-pg; return 1; }
+  assert_eq "$(psql_in happy-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "rows survived" || return 1
+  assert_contains "$(psql_in happy-pg "SELECT body FROM upgrade_canary WHERE body = 'row-500'")" "row-500" "index-reachable row" || return 1
+  assert_eq "$(psql_in happy-pg 'SELECT count(*) FROM embeddings')" "1" "pgvector rows survived" || return 1
+  assert_contains "$(psql_in happy-pg "SELECT v <-> '[1,2,3]' FROM embeddings LIMIT 1")" "0" "pgvector operator works on TO major" || return 1
+  assert_contains "$(psql_in happy-pg 'SHOW server_version')" "$TO_VERSION." "server is TO major" || return 1
+  stop_pg happy-pg
+}
+
+# Re-running a completed upgrade is a no-op success (activity retries).
+t_upgrade_idempotent() {
+  local vol="upg-e2e-happy"
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "idempotent re-run exit code" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_contains "$JOB_OUT" '"alreadyDone": true' "no-op signaled" || return 1
+}
+
+# status mode reports the terminal state for the workflow's resume decision.
+t_status_mode() {
+  local vol="upg-e2e-happy"
+  run_job "$vol" status
+  assert_eq "$JOB_RC" 0 "status exit code" || return 1
+  assert_contains "$JOB_OUT" '"phase": "completed"' "status phase" || return 1
+  assert_contains "$JOB_OUT" "\"dataMajor\": \"$TO_VERSION\"" "status data major" || return 1
+}
+
+# manifest mode lists the TO major's installable extensions (preflight feed).
+t_manifest_mode() {
+  local vol="upg-e2e-happy"
+  run_job "$vol" manifest
+  assert_eq "$JOB_RC" 0 "manifest exit code" || return 1
+  assert_contains "$JOB_OUT" '"vector"' "pgvector present in manifest" || return 1
+  assert_contains "$JOB_OUT" '"pg_stat_statements"' "contrib extension present" || return 1
+}
+
+# After the upgraded database boots, the staged statistics rebuild runs and
+# flips needsAnalyze off.
+t_analyze_staged() {
+  local vol="upg-e2e-happy"
+  run_pg analyze-pg "$vol" "$TO_IMAGE"
+  wait_for_pg analyze-pg || { fail_dump analyze analyze-pg; return 1; }
+  local deadline=$(($(date +%s) + 120))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if [ "$(marker_field "$vol" needsAnalyze)" = "false" ]; then
+      stop_pg analyze-pg
+      return 0
+    fi
+    sleep 5
+  done
+  fail_dump analyze analyze-pg
+  stop_pg analyze-pg
+  echo "  needsAnalyze never flipped to false"
+  return 1
+}
+
+# No marker, TO image on FROM data: the wrapper refuses with an explicit
+# message BEFORE postgres touches anything.
+t_mismatch_boot_failstop() {
+  local vol="upg-e2e-mismatch"
+  seed_from_cluster "$vol" || return 1
+  expect_boot_refusal "$vol" "$TO_IMAGE" "does not upgrade the data files" || return 1
+}
+
+# After a completed upgrade, booting the OLD image is also refused loudly.
+t_old_image_on_upgraded_data() {
+  local vol="upg-e2e-happy"
+  expect_boot_refusal "$vol" "$FROM_IMAGE" "data directory holds major version $TO_VERSION" || return 1
+}
+
+# A non-completed marker blocks EVERY runtime boot — both majors.
+t_boot_refused_mid_upgrade() {
+  local vol="upg-e2e-midmarker"
+  seed_from_cluster "$vol" || return 1
+  docker run --rm -v "$vol:/var/lib/postgresql/data" --entrypoint /bin/sh "$JOB_IMAGE" \
+    -c "echo '{\"phase\": \"upgraded\", \"from\": \"$FROM_VERSION\", \"to\": \"$TO_VERSION\"}' > $MARKER_PATH"
+  expect_boot_refusal "$vol" "$FROM_IMAGE" "upgrade is in progress" || return 1
+  expect_boot_refusal "$vol" "$TO_IMAGE" "upgrade is in progress" || return 1
+}
+
+# Crash between the two directory renames: marker=upgraded, old dir moved
+# aside, no $PGDATA. Re-running the job completes the swap deterministically.
+t_resume_after_crash_between_swaps() {
+  local vol="upg-e2e-crashswap"
+  seed_from_cluster "$vol" || return 1
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "initial upgrade" || return 1
+  # Reconstruct the crash window: pgdata back to "old moved aside, new not
+  # yet promoted", marker back to phase=upgraded.
+  docker run --rm -v "$vol:/var/lib/postgresql/data" --entrypoint /bin/sh "$JOB_IMAGE" -c "
+    set -e
+    cd /var/lib/postgresql/data
+    mv pgdata pgdata.upgrade-${TO_VERSION}
+    echo '{\"phase\": \"upgraded\", \"from\": \"$FROM_VERSION\", \"to\": \"$TO_VERSION\"}' > $MARKER_PATH
+  "
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "resume exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
+  assert_eq "$(marker_field "$vol" phase)" "completed" "marker completed after resume" || return 1
+  run_pg resume-pg "$vol" "$TO_IMAGE"
+  wait_for_pg resume-pg || { fail_dump resume resume-pg; return 1; }
+  assert_eq "$(psql_in resume-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "data intact after resume" || return 1
+  stop_pg resume-pg
+}
+
+# ----- runner -----------------------------------------------------------------
+ALL_TESTS=(
+  t_vanilla_boot
+  t_check_pass
+  t_check_blocker
+  t_check_blocker_pre16_types
+  t_refuses_wrong_major
+  t_recovers_unclean_shutdown
+  t_refuses_concurrent_job
+  t_upgrade_happy_path
+  t_upgrade_idempotent
+  t_status_mode
+  t_manifest_mode
+  t_analyze_staged
+  t_old_image_on_upgraded_data
+  t_mismatch_boot_failstop
+  t_boot_refused_mid_upgrade
+  t_resume_after_crash_between_swaps
+)
+
+TESTS=("${@:-}")
+if [ -z "${TESTS[0]}" ]; then TESTS=("${ALL_TESTS[@]}"); fi
+
+ensure_images
+for t in "${TESTS[@]}"; do
+  log "running $t"
+  if "$t"; then ok "$t"; else ko "$t"; fi
+done
+
+echo
+log "results: ${G}${PASS} passed${N}, ${R}${FAIL} failed${N}"
+if [ "$FAIL" -gt 0 ]; then
+  for t in "${FAILED_TESTS[@]}"; do echo "  ${R}✗${N} $t"; done
+fi
+exit "$FAIL"

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -23,9 +23,18 @@ FROM_IMAGE="postgres-ssl-e2e:${FROM_VERSION}"
 TO_IMAGE="postgres-ssl-e2e:${TO_VERSION}"
 JOB_IMAGE="postgres-upgrade-e2e:${FROM_VERSION}-${TO_VERSION}"
 
+# The chained-upgrade test (FROM -> TO -> TO+1 on one volume) needs a third
+# major; it self-skips when no Dockerfile exists for it.
+CHAIN_VERSION="$((TO_VERSION + 1))"
+CHAIN_IMAGE="postgres-ssl-e2e:${CHAIN_VERSION}"
+CHAIN_JOB_IMAGE="postgres-upgrade-e2e:${TO_VERSION}-${CHAIN_VERSION}"
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PGDATA_IN_VOLUME="/var/lib/postgresql/data/pgdata"
 MARKER_PATH="/var/lib/postgresql/data/.railway-major-upgrade.json"
+# Docker network for the remote-client tests: the default bridge has no name
+# resolution, a user-defined one does.
+E2E_NET="upg-e2e-net"
 
 PASS=0
 FAIL=0
@@ -72,6 +81,14 @@ assert_contains() {
   return 1
 }
 
+assert_not_contains() {
+  local haystack="$1" needle="$2" msg="$3"
+  if ! echo "$haystack" | grep -qF -- "$needle"; then return 0; fi
+  echo "  expected NOT to contain: $needle"
+  echo "  msg:                     $msg"
+  return 1
+}
+
 # ----- environment management ------------------------------------------------
 # Always build. The scripts under test (wrapper.sh, upgrade-job.sh) are
 # COPY'd into these images, so an existence check would silently test a stale
@@ -87,6 +104,36 @@ ensure_images() {
   docker build -q -f "$REPO_ROOT/Dockerfile.upgrade" \
     --build-arg "FROM_VERSION=$FROM_VERSION" --build-arg "TO_VERSION=$TO_VERSION" \
     -t "$JOB_IMAGE" "$REPO_ROOT" >/dev/null || exit 1
+  docker network inspect "$E2E_NET" >/dev/null 2>&1 || docker network create "$E2E_NET" >/dev/null
+}
+
+# Built lazily by the chained-upgrade test only — a TO -> TO+1 job image is
+# a full apt-install build, not worth paying when the test self-skips.
+ensure_chain_images() {
+  [ -f "$REPO_ROOT/Dockerfile.${CHAIN_VERSION}" ] || return 1
+  log "building runtime image $CHAIN_IMAGE"
+  docker build -q -f "$REPO_ROOT/Dockerfile.${CHAIN_VERSION}" -t "$CHAIN_IMAGE" "$REPO_ROOT" >/dev/null || return 1
+  log "building job image $CHAIN_JOB_IMAGE"
+  docker build -q -f "$REPO_ROOT/Dockerfile.upgrade" \
+    --build-arg "FROM_VERSION=$TO_VERSION" --build-arg "TO_VERSION=$CHAIN_VERSION" \
+    -t "$CHAIN_JOB_IMAGE" "$REPO_ROOT" >/dev/null || return 1
+}
+
+# Run a shell snippet against a (stopped) volume, via the job image.
+in_volume() {
+  local vol="$1" snippet="$2"
+  docker run --rm --label postgres-upgrade-e2e=1 \
+    -v "$vol:/var/lib/postgresql/data" --entrypoint /bin/sh "$JOB_IMAGE" -c "$snippet"
+}
+
+# psql from a SECOND container over the docker network — a remote client, so
+# it exercises pg_hba's `host all all all` rule rather than the loopback
+# lines that make localhost-only tests blind to remote-auth regressions.
+remote_psql() {
+  local host="$1" sql="$2"
+  docker run --rm --network "$E2E_NET" --label postgres-upgrade-e2e=1 \
+    -e PGPASSWORD=test --entrypoint psql "$FROM_IMAGE" \
+    -h "$host" -U postgres -d postgres -tAc "$sql" 2>&1
 }
 
 # Removing a container is asynchronous enough that the next `docker volume rm`
@@ -282,6 +329,7 @@ volume_data_major() {
 cleanup_all() {
   docker ps -aq --filter label=postgres-upgrade-e2e=1 | xargs -r docker rm -f >/dev/null 2>&1
   docker volume ls -q | grep '^upg-e2e-' | xargs -r docker volume rm >/dev/null 2>&1
+  docker network rm "$E2E_NET" >/dev/null 2>&1
 }
 trap cleanup_all EXIT
 
@@ -553,6 +601,153 @@ t_resume_after_crash_between_swaps() {
   stop_pg resume-pg
 }
 
+# pg_hba.conf: initdb writes only local/loopback lines; the `host all all all`
+# rule that admits remote clients is appended by the official entrypoint at
+# init time and must survive the upgrade (the job carries the old pg_hba
+# across the swap) — a localhost-only check can't see this regression, so
+# assert from a SECOND container over the docker network. Custom user rules
+# must survive too. Then strip the host rules to simulate any other path that
+# regenerates pg_hba, and assert the wrapper self-heals it from config state.
+t_remote_auth_survives_upgrade() {
+  local vol="upg-e2e-remotehba"
+  seed_from_cluster "$vol" || return 1
+
+  run_pg hba-before "$vol" "$FROM_IMAGE" --network "$E2E_NET" || return 1
+  wait_for_pg hba-before || { fail_dump hba-before hba-before; return 1; }
+  assert_eq "$(remote_psql hba-before 'SELECT 1')" "1" "remote client connects before upgrade" || return 1
+  # A recognizable user-added rule, to prove the carry preserves custom lines
+  # rather than resetting to a default file.
+  docker exec hba-before bash -c \
+    "echo 'host all all 192.0.2.0/24 trust # e2e-custom-hba-rule' >> $PGDATA_IN_VOLUME/pg_hba.conf" || return 1
+  stop_pg hba-before
+
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "upgrade exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
+
+  run_pg hba-after "$vol" "$TO_IMAGE" --network "$E2E_NET" || return 1
+  wait_for_pg hba-after || { fail_dump hba-after hba-after; return 1; }
+  assert_eq "$(remote_psql hba-after 'SELECT count(*) FROM upgrade_canary')" "1000" \
+    "remote client connects and reads data after upgrade" || return 1
+  assert_contains "$(docker exec hba-after cat "$PGDATA_IN_VOLUME/pg_hba.conf" 2>&1)" \
+    "e2e-custom-hba-rule" "custom pg_hba rule carried across the upgrade" || return 1
+  stop_pg hba-after
+
+  # Wrapper self-heal layer: lose the host rules entirely (any path that
+  # regenerates pg_hba.conf), boot, and remote auth must come back.
+  in_volume "$vol" "grep -vE '^[[:space:]]*host' $PGDATA_IN_VOLUME/pg_hba.conf > /tmp/hba && cat /tmp/hba > $PGDATA_IN_VOLUME/pg_hba.conf" || return 1
+  run_pg hba-healed "$vol" "$TO_IMAGE" --network "$E2E_NET" || return 1
+  wait_for_pg hba-healed || { fail_dump hba-healed hba-healed; return 1; }
+  assert_contains "$(docker logs hba-healed 2>&1)" "re-appending" "wrapper reported the pg_hba heal" || return 1
+  assert_eq "$(remote_psql hba-healed 'SELECT 1')" "1" "remote client connects after the wrapper heal" || return 1
+  stop_pg hba-healed
+}
+
+# A PITR-restored fork keeps WAL_RECOVER_FROM_* + POSTGRES_RECOVERY_TARGET_TIME
+# set forever; only the sentinels inside $PGDATA (.pitr_configured /
+# .pgbackrest_restored) record that recovery already promoted. If the swap
+# loses them, the first post-upgrade boot re-stages archive recovery against
+# the SOURCE bucket and the database hangs at "the database system is
+# starting up" forever. The job must carry the sentinels across; the wrapper
+# must also treat the completed marker itself as proof (defense in depth).
+t_pitr_fork_survives_upgrade() {
+  local vol="upg-e2e-pitrfork"
+  local recover_env=(
+    -e "WAL_RECOVER_FROM_BUCKET=e2e-nonexistent-bucket"
+    -e "WAL_RECOVER_FROM_ENDPOINT=e2e.invalid"
+    -e "WAL_RECOVER_FROM_REGION=auto"
+    -e "WAL_RECOVER_FROM_KEY=junk"
+    -e "WAL_RECOVER_FROM_SECRET=junk"
+    -e "POSTGRES_RECOVERY_TARGET_TIME=2026-01-01 00:00:00+00"
+  )
+  seed_from_cluster "$vol" || return 1
+  # The restored-fork post-promote shape: both sentinels present.
+  in_volume "$vol" "touch $PGDATA_IN_VOLUME/.pitr_configured $PGDATA_IN_VOLUME/.pgbackrest_restored \
+    && chown postgres:postgres $PGDATA_IN_VOLUME/.pitr_configured $PGDATA_IN_VOLUME/.pgbackrest_restored" || return 1
+
+  # Baseline: the fork shape boots on the FROM major without re-staging.
+  run_pg fork-before "$vol" "$FROM_IMAGE" "${recover_env[@]}" || return 1
+  wait_for_pg fork-before || { fail_dump fork-before fork-before; return 1; }
+  stop_pg fork-before
+
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "upgrade exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
+  in_volume "$vol" "test -f $PGDATA_IN_VOLUME/.pitr_configured && test -f $PGDATA_IN_VOLUME/.pgbackrest_restored" \
+    || { echo "  PITR sentinels did not survive the swap"; return 1; }
+
+  # The regression: with the same fork env, the upgraded database must become
+  # READY (no recovery staged against the unreachable source bucket).
+  run_pg fork-after "$vol" "$TO_IMAGE" "${recover_env[@]}" || return 1
+  wait_for_pg fork-after || { fail_dump fork-after fork-after; return 1; }
+  local logs; logs="$(docker logs fork-after 2>&1)"
+  assert_not_contains "$logs" "PITR replay staged" "no recovery re-staged after upgrade" || return 1
+  in_volume "$vol" "test ! -f $PGDATA_IN_VOLUME/recovery.signal" \
+    || { echo "  recovery.signal appeared on the upgraded fork"; return 1; }
+  assert_eq "$(psql_in fork-after 'SELECT count(*) FROM upgrade_canary')" "1000" "data intact on the upgraded fork" || return 1
+  stop_pg fork-after
+
+  # Defense-in-depth layer: even with the sentinels gone (an older job, a
+  # manual wipe), the completed marker alone must prevent re-staging.
+  in_volume "$vol" "rm -f $PGDATA_IN_VOLUME/.pitr_configured $PGDATA_IN_VOLUME/.pgbackrest_restored" || return 1
+  run_pg fork-marker "$vol" "$TO_IMAGE" "${recover_env[@]}" || return 1
+  wait_for_pg fork-marker || { fail_dump fork-marker fork-marker; return 1; }
+  assert_not_contains "$(docker logs fork-marker 2>&1)" "PITR replay staged" \
+    "completed marker alone prevents re-staging" || return 1
+  stop_pg fork-marker
+}
+
+# Upgrading the same volume twice (FROM -> TO, then TO -> TO+1) must land on
+# TO+1 with the data intact. Regression: a completed marker from the FIRST
+# pair used to read as "already done" for ANY pair — the second job reported
+# success as a silent no-op, the workflow flipped the image tag, and the
+# service boot-refused on a major mismatch after a "successful" upgrade.
+t_second_upgrade_reaches_next_major() {
+  if [ ! -f "$REPO_ROOT/Dockerfile.${CHAIN_VERSION}" ]; then
+    note "skipped: no Dockerfile.${CHAIN_VERSION} to chain onto"
+    return 0
+  fi
+  ensure_chain_images || return 1
+  local vol="upg-e2e-chain"
+  seed_from_cluster "$vol" || return 1
+
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "first upgrade exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
+  assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "data major after first upgrade" || return 1
+
+  JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$CHAIN_JOB_IMAGE" upgrade 2>&1)
+  JOB_RC=$?
+  assert_eq "$JOB_RC" 0 "second upgrade exit code" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_not_contains "$JOB_OUT" '"alreadyDone"' "second upgrade actually ran (no silent no-op)" || return 1
+  assert_eq "$(marker_field "$vol" phase)" "completed" "marker phase after chain" || return 1
+  assert_eq "$(marker_field "$vol" to)" "$CHAIN_VERSION" "marker records the second pair" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$CHAIN_VERSION" "data major after second upgrade" || return 1
+
+  remove_container chain-pg
+  docker run -d --name chain-pg --label postgres-upgrade-e2e=1 \
+    -e "POSTGRES_PASSWORD=test" -e "PGDATA=$PGDATA_IN_VOLUME" \
+    -v "$vol:/var/lib/postgresql/data" "$CHAIN_IMAGE" >/dev/null || return 1
+  wait_for_pg chain-pg || { fail_dump chain chain-pg; return 1; }
+  assert_eq "$(psql_in chain-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "data intact after two upgrades" || return 1
+  assert_contains "$(psql_in chain-pg 'SHOW server_version')" "$CHAIN_VERSION." "server is TO+1" || return 1
+  stop_pg chain-pg
+}
+
+# An in-flight (phase=upgraded) marker belonging to a DIFFERENT version pair
+# must not drive this job's directory swap — its upgrade dirs belong to the
+# other job. Refuse loudly, volume untouched.
+t_foreign_pair_upgraded_marker_refused() {
+  local vol="upg-e2e-foreignpair"
+  seed_from_cluster "$vol" || return 1
+  in_volume "$vol" "echo '{\"phase\": \"upgraded\", \"from\": \"13\", \"to\": \"14\"}' > $MARKER_PATH" || return 1
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 2 "foreign-pair upgraded marker refused" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_contains "$JOB_OUT" "refuses to finish another pair's swap" "refusal names the mismatch" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "volume untouched" || return 1
+  in_volume "$vol" "rm -f $MARKER_PATH"
+}
+
 # ----- runner -----------------------------------------------------------------
 ALL_TESTS=(
   t_vanilla_boot
@@ -572,6 +767,10 @@ ALL_TESTS=(
   t_mismatch_boot_failstop
   t_boot_refused_mid_upgrade
   t_resume_after_crash_between_swaps
+  t_remote_auth_survives_upgrade
+  t_pitr_fork_survives_upgrade
+  t_second_upgrade_reaches_next_major
+  t_foreign_pair_upgraded_marker_refused
 )
 
 TESTS=("${@:-}")

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -884,11 +884,15 @@ t_recovery_shapes_refused() {
 }
 
 # The marker-lost window: pg_upgrade finished (old cluster's pg_control
-# renamed to pg_control.old — it can never start again) but the marker is
-# gone. The disk shape alone must drive the roll-forward; without it the
-# volume is bricked in both directions. Reconstructed from a completed
-# upgrade: put the dirs back to "post-pg_upgrade, pre-swap" and delete the
-# marker.
+# renamed to pg_control.old, the job's completion sentinel written) but the
+# marker is gone. The disk shape alone must drive the roll-forward; without
+# it the volume is bricked in both directions. Reconstructed from a
+# completed upgrade: put the dirs back to "post-pg_upgrade, pre-swap",
+# re-plant the sentinel (finish_swap removes it from the promoted dir; in
+# the real window finish_swap never ran, so it is present), delete the
+# marker. The sentinel is load-bearing: pg_control.old alone means only
+# that linking STARTED — see t_crash_mid_link_rolls_back_and_reruns for
+# the shape where it must NOT roll forward.
 t_marker_lost_after_pg_upgrade_resumes() {
   local vol="upg-e2e-lostmarker"
   seed_from_cluster "$vol" || return 1
@@ -901,6 +905,7 @@ t_marker_lost_after_pg_upgrade_resumes() {
     set -e
     cd /var/lib/postgresql/data
     mv pgdata pgdata.upgrade-${TO_VERSION}
+    touch pgdata.upgrade-${TO_VERSION}/.railway_pg_upgrade_complete
     mv pgdata.old-${FROM_VERSION} pgdata
     rm -f $MARKER_PATH
   " || return 1
@@ -913,6 +918,50 @@ t_marker_lost_after_pg_upgrade_resumes() {
   wait_for_pg lostmarker-pg || { fail_dump lostmarker lostmarker-pg; return 1; }
   assert_eq "$(psql_in lostmarker-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "data intact after marker-less resume" || return 1
   stop_pg lostmarker-pg
+}
+
+# The inverse of the marker-lost window: pg_upgrade renames the old
+# cluster's pg_control BEFORE it links the first user relation file
+# (verified empirically — its own output prescribes the rename-back as the
+# recovery), so "pg_control.old present" is NOT proof pg_upgrade finished.
+# A crash mid-link leaves that rename plus a PARTIALLY-linked target dir;
+# without the completion sentinel the resume must roll BACK — reverse the
+# rename and redo the upgrade from scratch — never promote the partial
+# target (the old inference did exactly that: silent data loss).
+t_crash_mid_link_rolls_back_and_reruns() {
+  local vol="upg-e2e-midlink"
+  seed_from_cluster "$vol" || return 1
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "initial upgrade" || { echo "$JOB_OUT" | tail -20; return 1; }
+  # Reconstruct the mid-link crash: the old cluster back in place still
+  # DISABLED (global/pg_control.old — pg_upgrade renamed it in place and the
+  # swap carried it into pgdata.old-<from>), a partial target dir
+  # (PG_VERSION present, no completion sentinel), no marker. Removing the
+  # promoted dir first only drops hardlink counts; the old files survive.
+  in_volume "$vol" "
+    set -e
+    cd /var/lib/postgresql/data
+    rm -rf pgdata
+    mv pgdata.old-${FROM_VERSION} pgdata
+    mkdir -p pgdata.upgrade-${TO_VERSION}
+    echo ${TO_VERSION} > pgdata.upgrade-${TO_VERSION}/PG_VERSION
+    chown -R postgres:postgres pgdata.upgrade-${TO_VERSION}
+    rm -f $MARKER_PATH
+  " || return 1
+  in_volume "$vol" "test -f ${PGDATA_IN_VOLUME}/global/pg_control.old && test ! -f ${PGDATA_IN_VOLUME}/global/pg_control" \
+    || { echo "  premise broken: reconstructed old cluster is not in the disabled shape"; return 1; }
+
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "mid-link crash resume exit code" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_contains "$JOB_OUT" "rolling back to the old cluster" "roll-back path taken, not roll-forward" || return 1
+  assert_contains "$JOB_OUT" "restored global/pg_control" "the disable was reversed" || return 1
+  assert_eq "$(marker_field "$vol" phase)" "completed" "re-run completed" || return 1
+  assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "data major is TO after the re-run" || return 1
+
+  run_pg midlink-pg "$vol" "$TO_IMAGE" || return 1
+  wait_for_pg midlink-pg || { fail_dump midlink midlink-pg; return 1; }
+  assert_eq "$(psql_in midlink-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "data intact after roll-back + re-run" || return 1
+  stop_pg midlink-pg
 }
 
 # pgdata.old-<from> is the rollback body and pins every pre-upgrade inode
@@ -1177,6 +1226,7 @@ ALL_TESTS=(
   t_runtime_refused_while_job_locked
   t_recovery_shapes_refused
   t_marker_lost_after_pg_upgrade_resumes
+  t_crash_mid_link_rolls_back_and_reruns
   t_old_datadir_reclaimed
   t_trailing_slash_pgdata
   t_upgrade_survives_root_owned_volume_root

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -89,28 +89,77 @@ ensure_images() {
     -t "$JOB_IMAGE" "$REPO_ROOT" >/dev/null || exit 1
 }
 
+# Removing a container is asynchronous enough that the next `docker volume rm`
+# can still see the volume as in-use. Wait for the name to actually disappear
+# before returning, so callers can rely on the volume being free.
+remove_container() {
+  local name="$1" deadline=$(($(date +%s) + 30))
+  docker rm -f "$name" >/dev/null 2>&1
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    docker ps -a --format '{{.Names}}' | grep -qx "$name" || return 0
+    sleep 1
+  done
+  echo "  container $name did not go away"
+  return 1
+}
+
+# A volume that a dying container still holds fails to delete — and with the
+# failure swallowed, the "fresh" volume silently carries the previous test's
+# data (or its still-terminating postgres). Retry until the delete really
+# succeeds, and fail the test rather than proceed on a dirty volume.
 fresh_volume() {
-  local vol="$1"
-  docker volume rm "$vol" >/dev/null 2>&1 || true
-  docker volume create "$vol" >/dev/null
+  local vol="$1" deadline=$(($(date +%s) + 60))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if ! docker volume inspect "$vol" >/dev/null 2>&1; then
+      docker volume create "$vol" >/dev/null
+      return 0
+    fi
+    docker volume rm "$vol" >/dev/null 2>&1
+    sleep 1
+  done
+  echo "  could not free volume $vol (still in use)"
+  return 1
 }
 
 # Start a runtime postgres container on a volume. Extra docker args pass
 # through after name+vol+image.
+#
+# Container names are reused across tests, so a leftover container of the same
+# name must be removed first and the run must FAIL LOUDLY otherwise: a swallowed
+# name conflict leaves the old container (on the old volume) answering, and every
+# later psql in the test silently seeds or asserts against the wrong database.
 run_pg() {
   local name="$1" vol="$2" image="$3"; shift 3
-  docker run -d --name "$name" --label postgres-upgrade-e2e=1 \
+  remove_container "$name" || return 1
+  if ! docker run -d --name "$name" --label postgres-upgrade-e2e=1 \
     -e "POSTGRES_PASSWORD=test" \
     -e "PGDATA=$PGDATA_IN_VOLUME" \
     "$@" \
     -v "$vol:/var/lib/postgresql/data" \
-    "$image" >/dev/null
+    "$image" >/dev/null; then
+    echo "  docker run failed for container $name on volume $vol"
+    return 1
+  fi
 }
 
+# Waits for the REAL server, not the temporary one docker-entrypoint runs
+# during initdb to execute the init scripts. pg_isready answers on that temp
+# server's socket too, so a seed issued on its say-so can land mid-init and be
+# rolled away with it. The "ready to accept connections" line is only logged by
+# the final server, so gate on that as well.
+# Waits for the FINAL server, never the temporary one docker-entrypoint runs
+# during initdb to execute the init scripts. That temp server logs its own
+# "ready to accept connections" and then shuts down, so both pg_isready on the
+# unix socket and a log grep will happily match it — and a seed issued then dies
+# with "the database system is shutting down". The discriminator is TCP: the
+# temp server is started with listen_addresses='' and has no TCP listener, so a
+# TCP-ready answer can only come from the real one.
 wait_for_pg() {
-  local container="$1" deadline=$(($(date +%s) + 90))
+  local container="$1" deadline=$(($(date +%s) + 120))
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    if docker exec "$container" pg_isready -q -U postgres 2>/dev/null; then return 0; fi
+    if docker exec "$container" pg_isready -q -h 127.0.0.1 -p 5432 -U postgres 2>/dev/null; then
+      return 0
+    fi
     if [ "$(docker inspect -f '{{.State.Status}}' "$container" 2>/dev/null)" = "exited" ]; then
       return 1
     fi
@@ -124,6 +173,20 @@ psql_in() {
   docker exec "$container" psql -U postgres -tAc "$sql" 2>&1
 }
 
+# Same, but fails the test when postgres reports an error. Setup steps must
+# never be silently swallowed — a seed that didn't run turns into a confusing
+# "relation does not exist" three assertions later.
+psql_must() {
+  local container="$1" sql="$2" out
+  out="$(psql_in "$container" "$sql")"
+  if echo "$out" | grep -qE "^(ERROR|FATAL|psql: error)"; then
+    echo "  psql failed: $sql"
+    echo "  output: $out"
+    fail_dump "psql:$container" "$container"
+    return 1
+  fi
+}
+
 # Clean stop: shut postgres down through pg_ctl so pg_control records
 # "shut down". `docker stop` alone is NOT clean on this image — bash as PID 1
 # never forwards SIGTERM, so postgres is SIGKILLed after the grace period and
@@ -133,7 +196,7 @@ stop_pg() {
   local name="$1"
   docker exec "$name" gosu postgres pg_ctl -D "$PGDATA_IN_VOLUME" -w -t 60 -m fast stop >/dev/null 2>&1
   docker stop -t 30 "$name" >/dev/null 2>&1
-  docker rm -f "$name" >/dev/null 2>&1
+  remove_container "$name"
 }
 
 # Ungraceful stop: what the platform actually does when a deployment is
@@ -142,7 +205,7 @@ stop_pg() {
 kill_pg() {
   local name="$1"
   docker kill -s KILL "$name" >/dev/null 2>&1
-  docker rm -f "$name" >/dev/null 2>&1
+  remove_container "$name"
 }
 
 # Run the upgrade job in a given mode on a volume; captures combined output.
@@ -173,7 +236,7 @@ expect_boot_refusal() {
   BOOT_OUT=$(docker logs "$name" 2>&1)
   local exit_code
   exit_code=$(docker inspect -f '{{.State.ExitCode}}' "$name" 2>/dev/null)
-  docker rm -f "$name" >/dev/null 2>&1
+  remove_container "$name"
   if [ "$status" != "exited" ] || [ "$exit_code" = "0" ]; then
     echo "  expected the container to exit nonzero (status=$status exit=$exit_code)"
     return 1
@@ -185,17 +248,19 @@ expect_boot_refusal() {
 # Leaves the volume ready for the job. $2 optional extra SQL.
 seed_from_cluster() {
   local vol="$1" extra_sql="${2:-}"
-  fresh_volume "$vol"
-  run_pg seed-pg "$vol" "$FROM_IMAGE"
+  fresh_volume "$vol" || return 1
+  run_pg seed-pg "$vol" "$FROM_IMAGE" || return 1
   wait_for_pg seed-pg || { fail_dump seed seed-pg; return 1; }
-  psql_in seed-pg "CREATE TABLE upgrade_canary (id serial PRIMARY KEY, body text)" >/dev/null
-  psql_in seed-pg "INSERT INTO upgrade_canary (body) SELECT 'row-' || g FROM generate_series(1, 1000) g" >/dev/null
-  psql_in seed-pg "CREATE INDEX upgrade_canary_body_idx ON upgrade_canary (body)" >/dev/null
-  psql_in seed-pg "CREATE EXTENSION IF NOT EXISTS vector" >/dev/null
-  psql_in seed-pg "CREATE TABLE embeddings (id int, v vector(3)); INSERT INTO embeddings VALUES (1, '[1,2,3]')" >/dev/null
+  psql_must seed-pg "CREATE TABLE upgrade_canary (id serial PRIMARY KEY, body text)" || return 1
+  psql_must seed-pg "INSERT INTO upgrade_canary (body) SELECT 'row-' || g FROM generate_series(1, 1000) g" || return 1
+  psql_must seed-pg "CREATE INDEX upgrade_canary_body_idx ON upgrade_canary (body)" || return 1
+  psql_must seed-pg "CREATE EXTENSION IF NOT EXISTS vector" || return 1
+  psql_must seed-pg "CREATE TABLE embeddings (id int, v vector(3)); INSERT INTO embeddings VALUES (1, '[1,2,3]')" || return 1
   if [ -n "$extra_sql" ]; then
-    psql_in seed-pg "$extra_sql" >/dev/null
+    psql_must seed-pg "$extra_sql" || return 1
   fi
+  # Prove the seed is durable before handing the volume to the job.
+  assert_eq "$(psql_in seed-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "seed persisted" || return 1
   stop_pg seed-pg
 }
 
@@ -226,8 +291,8 @@ trap cleanup_all EXIT
 # boot + restart on the FROM major.
 t_vanilla_boot() {
   local vol="upg-e2e-vanilla"
-  fresh_volume "$vol"
-  run_pg vanilla-pg "$vol" "$FROM_IMAGE"
+  fresh_volume "$vol" || return 1
+  run_pg vanilla-pg "$vol" "$FROM_IMAGE" || return 1
   wait_for_pg vanilla-pg || { fail_dump vanilla vanilla-pg; return 1; }
   psql_in vanilla-pg "SELECT 1" | grep -q 1 || return 1
   docker restart vanilla-pg >/dev/null
@@ -243,7 +308,7 @@ t_check_pass() {
   assert_eq "$JOB_RC" 0 "check mode exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
   assert_contains "$JOB_OUT" '"ok": true' "machine-readable result" || return 1
   assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "data major untouched by check" || return 1
-  run_pg checkpass-pg "$vol" "$FROM_IMAGE"
+  run_pg checkpass-pg "$vol" "$FROM_IMAGE" || return 1
   wait_for_pg checkpass-pg || { fail_dump checkpass checkpass-pg; return 1; }
   assert_eq "$(psql_in checkpass-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "data intact after check" || return 1
   stop_pg checkpass-pg
@@ -259,8 +324,8 @@ t_check_pass() {
 # mirror.
 t_check_blocker() {
   local vol="upg-e2e-blocker"
-  fresh_volume "$vol"
-  run_pg blocker-pg "$vol" "$FROM_IMAGE"
+  fresh_volume "$vol" || return 1
+  run_pg blocker-pg "$vol" "$FROM_IMAGE" || return 1
   wait_for_pg blocker-pg || { fail_dump blocker blocker-pg; return 1; }
   psql_in blocker-pg "ALTER SYSTEM SET max_prepared_transactions = 10" >/dev/null
   docker restart blocker-pg >/dev/null
@@ -274,7 +339,7 @@ t_check_blocker() {
   assert_contains "$JOB_OUT" "prepared transaction" "blocker named in output" || return 1
 
   # Untouched: the old cluster still boots and the blocker is still there.
-  run_pg blocker2-pg "$vol" "$FROM_IMAGE"
+  run_pg blocker2-pg "$vol" "$FROM_IMAGE" || return 1
   wait_for_pg blocker2-pg || { fail_dump blocker2 blocker2-pg; return 1; }
   assert_eq "$(psql_in blocker2-pg 'SELECT count(*) FROM pg_prepared_xacts')" "1" "cluster untouched by a failed check" || return 1
   psql_in blocker2-pg "ROLLBACK PREPARED 'e2e_blocker_tx'" >/dev/null
@@ -300,8 +365,8 @@ t_check_blocker_pre16_types() {
 # Wrong source major: a FROM->TO job pointed at a TO-major volume refuses.
 t_refuses_wrong_major() {
   local vol="upg-e2e-wrongmajor"
-  fresh_volume "$vol"
-  run_pg wrong-pg "$vol" "$TO_IMAGE"
+  fresh_volume "$vol" || return 1
+  run_pg wrong-pg "$vol" "$TO_IMAGE" || return 1
   wait_for_pg wrong-pg || { fail_dump wrongmajor wrong-pg; return 1; }
   stop_pg wrong-pg
   run_job "$vol" upgrade
@@ -315,13 +380,13 @@ t_refuses_wrong_major() {
 # upgrade fails. Committed rows written right before the kill must survive.
 t_recovers_unclean_shutdown() {
   local vol="upg-e2e-unclean"
-  fresh_volume "$vol"
-  run_pg unclean-pg "$vol" "$FROM_IMAGE"
+  fresh_volume "$vol" || return 1
+  run_pg unclean-pg "$vol" "$FROM_IMAGE" || return 1
   wait_for_pg unclean-pg || { fail_dump unclean unclean-pg; return 1; }
-  psql_in unclean-pg "CREATE TABLE unclean_canary (id int)" >/dev/null
-  psql_in unclean-pg "INSERT INTO unclean_canary SELECT generate_series(1, 500)" >/dev/null
-  psql_in unclean-pg "CHECKPOINT" >/dev/null
-  psql_in unclean-pg "INSERT INTO unclean_canary SELECT generate_series(501, 700)" >/dev/null
+  psql_must unclean-pg "CREATE TABLE unclean_canary (id int)" || return 1
+  psql_must unclean-pg "INSERT INTO unclean_canary SELECT generate_series(1, 500)" || return 1
+  psql_must unclean-pg "CHECKPOINT" || return 1
+  psql_must unclean-pg "INSERT INTO unclean_canary SELECT generate_series(501, 700)" || return 1
   kill_pg unclean-pg
 
   run_job "$vol" upgrade
@@ -329,7 +394,7 @@ t_recovers_unclean_shutdown() {
   assert_contains "$JOB_OUT" "replaying WAL" "recovery path was taken" || return 1
   assert_eq "$(marker_field "$vol" phase)" "completed" "marker completed" || return 1
 
-  run_pg unclean2-pg "$vol" "$TO_IMAGE"
+  run_pg unclean2-pg "$vol" "$TO_IMAGE" || return 1
   wait_for_pg unclean2-pg || { fail_dump unclean2 unclean2-pg; return 1; }
   assert_eq "$(psql_in unclean2-pg 'SELECT count(*) FROM unclean_canary')" "700" "post-checkpoint rows replayed and upgraded" || return 1
   stop_pg unclean2-pg
@@ -361,7 +426,7 @@ t_upgrade_happy_path() {
   assert_eq "$(marker_field "$vol" phase)" "completed" "marker phase" || return 1
   assert_eq "$(volume_data_major "$vol")" "$TO_VERSION" "on-disk major is now TO" || return 1
 
-  run_pg happy-pg "$vol" "$TO_IMAGE"
+  run_pg happy-pg "$vol" "$TO_IMAGE" || return 1
   wait_for_pg happy-pg || { fail_dump happy happy-pg; return 1; }
   assert_eq "$(psql_in happy-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "rows survived" || return 1
   assert_contains "$(psql_in happy-pg "SELECT body FROM upgrade_canary WHERE body = 'row-500'")" "row-500" "index-reachable row" || return 1
@@ -397,11 +462,34 @@ t_manifest_mode() {
   assert_contains "$JOB_OUT" '"pg_stat_statements"' "contrib extension present" || return 1
 }
 
+# pg_upgrade promotes a freshly initdb'd data directory, so postgresql.conf
+# loses the ssl settings while the certificates survive at the volume root.
+# A database that comes back with SSL off rejects every sslmode=require client,
+# so the wrapper must re-apply the settings from the config's own state.
+t_ssl_survives_upgrade() {
+  local vol="upg-e2e-ssl"
+  seed_from_cluster "$vol" || return 1
+  run_pg ssl-before "$vol" "$FROM_IMAGE" || return 1
+  wait_for_pg ssl-before || { fail_dump ssl-before ssl-before; return 1; }
+  assert_eq "$(psql_in ssl-before 'SHOW ssl')" "on" "ssl on before upgrade" || return 1
+  stop_pg ssl-before
+
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "upgrade exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
+
+  run_pg ssl-after "$vol" "$TO_IMAGE" || return 1
+  wait_for_pg ssl-after || { fail_dump ssl-after ssl-after; return 1; }
+  assert_eq "$(psql_in ssl-after 'SHOW ssl')" "on" "ssl still on after upgrade" || return 1
+  # And a TLS connection actually completes, not just the setting being present.
+  assert_contains "$(docker exec ssl-after psql 'sslmode=require host=localhost user=postgres dbname=postgres' -tAc 'SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()' 2>&1)" "t" "sslmode=require connection is encrypted" || return 1
+  stop_pg ssl-after
+}
+
 # After the upgraded database boots, the staged statistics rebuild runs and
 # flips needsAnalyze off.
 t_analyze_staged() {
   local vol="upg-e2e-happy"
-  run_pg analyze-pg "$vol" "$TO_IMAGE"
+  run_pg analyze-pg "$vol" "$TO_IMAGE" || return 1
   wait_for_pg analyze-pg || { fail_dump analyze analyze-pg; return 1; }
   local deadline=$(($(date +%s) + 120))
   while [ "$(date +%s)" -lt "$deadline" ]; do
@@ -459,7 +547,7 @@ t_resume_after_crash_between_swaps() {
   run_job "$vol" upgrade
   assert_eq "$JOB_RC" 0 "resume exit code" || { echo "$JOB_OUT" | tail -20; return 1; }
   assert_eq "$(marker_field "$vol" phase)" "completed" "marker completed after resume" || return 1
-  run_pg resume-pg "$vol" "$TO_IMAGE"
+  run_pg resume-pg "$vol" "$TO_IMAGE" || return 1
   wait_for_pg resume-pg || { fail_dump resume resume-pg; return 1; }
   assert_eq "$(psql_in resume-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "data intact after resume" || return 1
   stop_pg resume-pg
@@ -478,6 +566,7 @@ ALL_TESTS=(
   t_upgrade_idempotent
   t_status_mode
   t_manifest_mode
+  t_ssl_survives_upgrade
   t_analyze_staged
   t_old_image_on_upgraded_data
   t_mismatch_boot_failstop

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -28,6 +28,18 @@ BUCKET="pgbackrest"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DOCKERFILE="${REPO_ROOT}/Dockerfile.${PG_VERSION}"
 
+# Major-upgrade re-anchor tests: $PG_VERSION is the TARGET major (so they use
+# the suite's own $IMAGE for the upgraded side) and one major below is the
+# source. Those tests use the Railway data layout — PGDATA a subdirectory of
+# the volume — because upgrade-job.sh refuses a PGDATA that IS the volume root
+# (--link needs a sibling directory on the same filesystem). Every other test
+# in this file leaves PGDATA at the image default, which is the volume root.
+UPG_FROM_VERSION="${UPG_FROM_VERSION:-$((PG_VERSION - 1))}"
+UPG_FROM_IMAGE="postgres-ssl-pitr:${UPG_FROM_VERSION}"
+UPG_JOB_IMAGE="postgres-upgrade-e2e:${UPG_FROM_VERSION}-${PG_VERSION}"
+PGDATA_IN_VOLUME="/var/lib/postgresql/data/pgdata"
+UPGRADE_MARKER_IN_VOLUME="/var/lib/postgresql/data/.railway-major-upgrade.json"
+
 PASS=0
 FAIL=0
 FAILED_TESTS=()
@@ -102,6 +114,32 @@ ensure_image() {
   fi
   log "building $IMAGE from $DOCKERFILE"
   docker build -q -f "$DOCKERFILE" -t "$IMAGE" "$REPO_ROOT" >/dev/null
+}
+
+# Rebuild $IMAGE unconditionally. ensure_image above skips the build when the
+# tag already exists, which silently tests a stale copy of wrapper.sh /
+# pgbackrest-init.sh / the watcher — those are COPY'd in, so the tag says
+# nothing about which version of them the image holds. Tests that assert on
+# entrypoint behavior call this instead. Docker's layer cache keeps the repeat
+# cheap: only the COPY layers re-run.
+rebuild_image() {
+  log "rebuilding $IMAGE from $DOCKERFILE"
+  docker build -q -f "$DOCKERFILE" -t "$IMAGE" "$REPO_ROOT" >/dev/null
+}
+
+# Images for the major-upgrade re-anchor tests: the source major's runtime image
+# and the dual-binary job image, plus the rebuild above. Always builds, for the
+# same reason — upgrade-job.sh is COPY'd into the job image.
+ensure_upgrade_images() {
+  rebuild_image || return 1
+  log "building $UPG_FROM_IMAGE (upgrade source major)"
+  docker build -q -f "${REPO_ROOT}/Dockerfile.${UPG_FROM_VERSION}" \
+    -t "$UPG_FROM_IMAGE" "$REPO_ROOT" >/dev/null || return 1
+  log "building $UPG_JOB_IMAGE"
+  docker build -q -f "${REPO_ROOT}/Dockerfile.upgrade" \
+    --build-arg "FROM_VERSION=${UPG_FROM_VERSION}" \
+    --build-arg "TO_VERSION=${PG_VERSION}" \
+    -t "$UPG_JOB_IMAGE" "$REPO_ROOT" >/dev/null || return 1
 }
 
 ensure_network() {
@@ -182,6 +220,12 @@ gosu postgres pgbackrest --stanza=main --pg1-path=/var/lib/postgresql/data \
 
 # Common runner for an archiving service. All test containers carry the
 # postgres-ssl-e2e=1 label so the trap can find and clean them up.
+#
+# Defaults to the suite's own $IMAGE. Prefix a call with
+# `ARCHIVING_PG_IMAGE=<image>` to boot a different major against the same
+# bucket — the major-upgrade re-anchor tests need both sides of a version pair.
+# A prefix assignment on a bash function call is scoped to that call, so the
+# override cannot leak into later ones.
 run_archiving_pg() {
   local name="$1" vol="$2"; shift 2
   docker run -d --name "$name" --label postgres-ssl-e2e=1 --network "$NET" \
@@ -195,7 +239,7 @@ run_archiving_pg() {
     -e "PGBACKREST_REPO1_S3_URI_STYLE=path" \
     "$@" \
     -v "$vol:/var/lib/postgresql/data" \
-    "$IMAGE" >/dev/null
+    "${ARCHIVING_PG_IMAGE:-$IMAGE}" >/dev/null
 }
 
 # Wait for postgres to accept connections. 120 s default — restored
@@ -1199,6 +1243,71 @@ wait_for_watcher_backup() {
   return 1
 }
 
+# Count backups of a type in an EXPLICIT repo path, rather than in whatever the
+# container's marker currently points at (count_backups_of_type). Two things
+# need this: asserting a previous cluster's prefix still holds its backups after
+# archiving moved off it, and probing at all from a container whose PGDATA is
+# not the volume root. This is the same per-call PGBACKREST_REPO1_PATH override
+# mono's usePitrHistories uses to enumerate a bucket's histories.
+count_backups_at_path() {
+  local container="$1" want_type="$2" path="$3"
+  docker exec -u postgres "$container" bash -c "
+    export PGBACKREST_REPO1_S3_BUCKET=\"\$WAL_ARCHIVE_BUCKET\"
+    export PGBACKREST_REPO1_S3_KEY=\"\$WAL_ARCHIVE_KEY\"
+    export PGBACKREST_REPO1_S3_KEY_SECRET=\"\$WAL_ARCHIVE_SECRET\"
+    export PGBACKREST_REPO1_S3_REGION=\"\$WAL_ARCHIVE_REGION\"
+    export PGBACKREST_REPO1_S3_ENDPOINT=\"\$WAL_ARCHIVE_ENDPOINT\"
+    export PGBACKREST_REPO1_PATH=\"$path\"
+    pgbackrest --stanza=main info 2>/dev/null | grep -cE '^[[:space:]]+${want_type} backup: ' || true
+  " 2>/dev/null | tail -1
+}
+
+# Objects under a repo path (a leading-slash path concatenates onto the bucket).
+# Used as the "the previous cluster's prefix was not touched" measurement.
+bucket_objects_under() {
+  mc "mc ls --recursive local/${BUCKET}${1} 2>/dev/null | wc -l" | tail -1 | tr -d ' '
+}
+
+# The cluster's live system_identifier, read from pg_control rather than from
+# the repo-path marker — the assertions have to compare the marker against an
+# independently-derived identity, not against itself.
+cluster_sysid() {
+  local container="$1" pgdata="${2:-/var/lib/postgresql/data}"
+  docker exec "$container" pg_controldata "$pgdata" 2>/dev/null \
+    | awk -F: '/Database system identifier/ { gsub(/[ \t]/,"",$2); print $2 }'
+}
+
+# Shut postgres down through pg_ctl so pg_control records "shut down", then drop
+# the container. `docker rm -f` alone is not clean on this image — bash as PID 1
+# never forwards the signal, so postgres is SIGKILLed and the cluster is left
+# "in production" (upgrade-job.sh recovers from that, but a test asserting the
+# archive path should not also be exercising crash recovery).
+stop_pg_clean() {
+  local name="$1" pgdata="${2:-/var/lib/postgresql/data}"
+  docker exec "$name" gosu postgres pg_ctl -D "$pgdata" -w -t 60 -m fast stop >/dev/null 2>&1 || true
+  docker rm -f "$name" >/dev/null 2>&1 || true
+}
+
+# Run the one-shot upgrade job against a volume. No network: the job never
+# touches S3. Sets JOB_OUT / JOB_RC like test/e2e-upgrade.sh's run_job.
+run_upgrade_job() {
+  local vol="$1" mode="${2:-upgrade}"
+  JOB_OUT=$(docker run --rm --label postgres-ssl-e2e=1 \
+    -e "PGDATA=$PGDATA_IN_VOLUME" \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$UPG_JOB_IMAGE" "$mode" 2>&1)
+  JOB_RC=$?
+}
+
+# Run a shell snippet against a stopped volume (planting or reading state
+# between two containers' lifetimes). Uses the job image because it is the one
+# image guaranteed to exist for both majors in the pair.
+in_stopped_volume() {
+  local vol="$1" snippet="$2"
+  docker run --rm --label postgres-ssl-e2e=1 \
+    -v "$vol:/var/lib/postgresql/data" --entrypoint /bin/sh "$UPG_JOB_IMAGE" -c "$snippet"
+}
+
 t_watcher_initial_full() {
   local name=t-init-full-${PG_VERSION}
   local vol=${name}-vol
@@ -2022,7 +2131,7 @@ EOF
   # migration log by a few seconds on a loaded CI runner.
   local kick_deadline=$(($(date +%s) + 15)) hit_kick=0
   while [ "$(date +%s)" -lt "$kick_deadline" ]; do
-    if docker logs "$name" 2>&1 | grep -q "wal-regression: kicking async daemon"; then
+    if docker logs "$name" 2>&1 | grep -q "archive-migration: kicking async daemon"; then
       hit_kick=1; break
     fi
     sleep 1
@@ -2049,10 +2158,10 @@ EOF
   # State file must record the pre-migration path so successive migrations
   # land at cluster-X-<e2> rather than chaining suffixes (cluster-X-<e1>-<e2>).
   local orig_in_state
-  orig_in_state=$(docker exec "$name" grep -E "^wal_regression_orig_path=" \
+  orig_in_state=$(docker exec "$name" grep -E "^archive_migration_orig_path=" \
     /var/lib/postgresql/data/.pgbackrest_backup_state 2>/dev/null | cut -d= -f2-)
   if [ "$orig_in_state" != "$orig_path" ]; then
-    ko t_watcher_wal_regression_async_spool_probe "wal_regression_orig_path expected '${orig_path}', got '${orig_in_state}'"
+    ko t_watcher_wal_regression_async_spool_probe "archive_migration_orig_path expected '${orig_path}', got '${orig_in_state}'"
     fail_dump t_watcher_wal_regression_async_spool_probe "$name"
     return
   fi
@@ -2061,10 +2170,10 @@ EOF
   # finalize successfully. If this sticks, a later iteration is expected to
   # retry finalization rather than trusting stale old-path .ok/.error files.
   local pending_in_state
-  pending_in_state=$(docker exec "$name" grep -E "^wal_regression_pending_new_path=" \
+  pending_in_state=$(docker exec "$name" grep -E "^archive_migration_pending_new_path=" \
     /var/lib/postgresql/data/.pgbackrest_backup_state 2>/dev/null | cut -d= -f2-)
   if [ -n "$pending_in_state" ]; then
-    ko t_watcher_wal_regression_async_spool_probe "wal_regression_pending_new_path should be clear after finalize, got '${pending_in_state}'"
+    ko t_watcher_wal_regression_async_spool_probe "archive_migration_pending_new_path should be clear after finalize, got '${pending_in_state}'"
     fail_dump t_watcher_wal_regression_async_spool_probe "$name"
     return
   fi
@@ -2476,6 +2585,509 @@ t_volume_wipe_same_bucket_preserves_both() {
 
   ok t_volume_wipe_same_bucket_preserves_both
   note "A=cluster-${sysid_a} (${a_fulls} full), C=cluster-${sysid_c} (${c_fulls} full); both in bucket"
+  docker rm -f "$name" >/dev/null
+  docker volume rm "$vol" >/dev/null
+}
+
+# Bring an archiving cluster on the source major up to "has a full backup at
+# cluster-<sysid>", then shut it down cleanly and upgrade the volume in place.
+# Shared by the two re-anchor tests below; exports SYSID_A / PATH_A /
+# OLD_OBJECTS_BEFORE for their assertions. Returns non-zero after recording its
+# own ko(), so callers just `return`.
+seed_upgraded_volume() {
+  local test_name="$1" name="$2" vol="$3"
+  reset_bucket
+  new_volume "$vol"
+  docker rm -f "$name" >/dev/null 2>&1 || true
+
+  ARCHIVING_PG_IMAGE="$UPG_FROM_IMAGE" run_archiving_pg_fast_watcher "$name" "$vol" \
+    -e "PGDATA=$PGDATA_IN_VOLUME"
+  if ! wait_for_pg "$name"; then
+    ko "$test_name" "source major (${UPG_FROM_VERSION}) did not start"
+    fail_dump "$test_name" "$name"
+    return 1
+  fi
+  # Wait for the stanza before generating WAL: archive-push against a repo with
+  # no stanza fails, and this test has no business exercising that race.
+  for _ in $(seq 1 20); do
+    docker logs "$name" 2>&1 | grep -q "stanza-create completed" && break
+    sleep 1
+  done
+  docker exec "$name" psql -U postgres -c \
+    "CREATE TABLE upgrade_canary(id int); INSERT INTO upgrade_canary SELECT generate_series(1,1000); SELECT pg_switch_wal();" >/dev/null
+  if ! wait_for_watcher_backup "$name" full 90; then
+    ko "$test_name" "no initial full on the source major"
+    fail_dump "$test_name" "$name"
+    return 1
+  fi
+
+  SYSID_A=$(cluster_sysid "$name" "$PGDATA_IN_VOLUME")
+  PATH_A=$(docker exec "$name" cat "$PGDATA_IN_VOLUME/.pgbackrest_repo_path" 2>/dev/null)
+  local anchor_a
+  anchor_a=$(docker exec "$name" cat "$PGDATA_IN_VOLUME/.pgbackrest_repo_anchor" 2>/dev/null | tr '\n' ' ')
+
+  if [ -z "$SYSID_A" ] || [ "$PATH_A" != "/pgbackrest/cluster-${SYSID_A}" ]; then
+    ko "$test_name" "source cluster's marker is not its own per-cluster path: sysid=${SYSID_A}, marker=${PATH_A}"
+    fail_dump "$test_name" "$name"
+    return 1
+  fi
+  # The anchor must be seeded by initdb (pgbackrest-init.sh), not adopted later:
+  # a fresh cluster's fingerprint has to be the derived one.
+  case "$anchor_a" in
+    *"sysid=${SYSID_A}"*"pg_version=${UPG_FROM_VERSION}"*) ;;
+    *)
+      ko "$test_name" "source anchor should name sysid=${SYSID_A} pg_version=${UPG_FROM_VERSION}, got '${anchor_a}'"
+      fail_dump "$test_name" "$name"
+      return 1 ;;
+  esac
+
+  local src_objects
+  src_objects=$(bucket_objects_under "$PATH_A")
+  if [ "${src_objects:-0}" -lt 1 ]; then
+    ko "$test_name" "source cluster archived nothing under ${PATH_A}"
+    fail_dump "$test_name" "$name"
+    return 1
+  fi
+
+  stop_pg_clean "$name" "$PGDATA_IN_VOLUME"
+
+  run_upgrade_job "$vol" upgrade
+  if [ "$JOB_RC" != "0" ]; then
+    ko "$test_name" "upgrade job failed (rc=${JOB_RC})"
+    echo "$JOB_OUT" | tail -20
+    return 1
+  fi
+
+  # Baseline for "the upgraded cluster never wrote to the previous cluster's
+  # prefix" — taken here, with the source stopped and the upgrade done, not
+  # before the shutdown: a clean `pg_ctl stop` switches WAL and archives the
+  # shutdown checkpoint's segment, so a pre-shutdown count is one object short
+  # of the real starting state through no fault of the upgraded cluster. The
+  # upgrade job itself never touches S3.
+  OLD_OBJECTS_BEFORE=$(bucket_objects_under "$PATH_A")
+  return 0
+}
+
+# After the upgraded database boots, wait for a full backup to land and assert
+# the whole end state: WAL and a full under the NEW cluster prefix, the previous
+# cluster's prefix untouched, marker + anchor naming the new identity, data
+# intact. Shared by both re-anchor tests. Returns non-zero after its own ko().
+assert_reanchored_end_state() {
+  local test_name="$1" name="$2" sysid_b="$3"
+  local path_b="/pgbackrest/cluster-${sysid_b}"
+
+  # A successful full is the end-to-end proof that archiving works at the new
+  # path: `pgbackrest backup` brackets pg_backup_start/stop and waits for the
+  # closing WAL segment to be archived before reporting success, so it cannot
+  # succeed while archive-push is failing. Keep switching WAL while we wait —
+  # an idle cluster only produces a segment per archive_timeout.
+  local deadline=$(($(date +%s) + 150)) got_full=0
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if docker logs "$name" 2>&1 | grep -q "pgbackrest-watcher: backup --type=full completed"; then
+      got_full=1; break
+    fi
+    docker exec "$name" psql -U postgres -c "SELECT pg_switch_wal();" >/dev/null 2>&1
+    sleep 3
+  done
+  if [ "$got_full" != "1" ]; then
+    ko "$test_name" "no full backup landed after the upgrade"
+    fail_dump "$test_name" "$name"
+    return 1
+  fi
+
+  local wal_objects
+  wal_objects=$(bucket_objects_under "${path_b}/archive/main")
+  if [ "${wal_objects:-0}" -lt 1 ]; then
+    ko "$test_name" "no WAL under the new cluster prefix ${path_b}/archive/main"
+    fail_dump "$test_name" "$name"
+    return 1
+  fi
+
+  local new_fulls
+  new_fulls=$(count_backups_at_path "$name" full "$path_b")
+  if [ "${new_fulls:-0}" -lt 1 ]; then
+    ko "$test_name" "no full visible at ${path_b}; got ${new_fulls}"
+    fail_dump "$test_name" "$name"
+    return 1
+  fi
+
+  # The previous cluster's history is untouched — same object count as before
+  # the upgrade, and its own full still browsable. This is what keeps the
+  # pre-upgrade PITR window restorable from mono's history picker.
+  local old_objects_after old_fulls
+  old_objects_after=$(bucket_objects_under "$PATH_A")
+  if [ "${old_objects_after:-0}" != "${OLD_OBJECTS_BEFORE:-0}" ]; then
+    ko "$test_name" "previous cluster's prefix ${PATH_A} changed: ${OLD_OBJECTS_BEFORE} objects before, ${old_objects_after} after"
+    fail_dump "$test_name" "$name"
+    return 1
+  fi
+  old_fulls=$(count_backups_at_path "$name" full "$PATH_A")
+  if [ "${old_fulls:-0}" -lt 1 ]; then
+    ko "$test_name" "previous cluster's full no longer visible at ${PATH_A}; got ${old_fulls}"
+    fail_dump "$test_name" "$name"
+    return 1
+  fi
+
+  local canary
+  canary=$(docker exec "$name" psql -U postgres -At -c "SELECT count(*) FROM upgrade_canary" 2>/dev/null)
+  if [ "$canary" != "1000" ]; then
+    ko "$test_name" "upgraded data missing: expected 1000 canary rows, got '${canary}'"
+    fail_dump "$test_name" "$name"
+    return 1
+  fi
+  return 0
+}
+
+# A major upgrade REPLACES the cluster: pg_upgrade initdb's the target and the
+# job swaps it into place, so the service comes back with a new
+# system_identifier and a new PG_VERSION. Archiving has to follow it onto
+# `cluster-<new_sysid>` — the previous cluster's repo records the old system id
+# in its archive.info, so every archive-push against it fails and stanza-create
+# refuses the mismatch outright.
+#
+# This is the natural path (the job's directory swap promotes a freshly initdb'd
+# data dir, so the upgraded PGDATA inherits none of the old cluster's pgbackrest
+# files and the path is derived fresh). t_reanchor_stale_marker_after_upgrade
+# below covers the same upgrade with the old cluster's marker surviving into it.
+t_upgrade_archive_reanchors_to_new_cluster_path() {
+  local name=t-upg-reanchor-${PG_VERSION}
+  local vol=${name}-vol
+  if ! ensure_upgrade_images; then
+    ko "${FUNCNAME[0]}" "could not build the upgrade-pair images"
+    return
+  fi
+  seed_upgraded_volume "${FUNCNAME[0]}" "$name" "$vol" || return
+
+  run_archiving_pg_fast_watcher "$name" "$vol" -e "PGDATA=$PGDATA_IN_VOLUME"
+  if ! wait_for_pg "$name"; then
+    ko "${FUNCNAME[0]}" "upgraded database (${PG_VERSION}) did not start"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+  for _ in $(seq 1 20); do
+    docker logs "$name" 2>&1 | grep -q "stanza-create completed" && break
+    sleep 1
+  done
+
+  local sysid_b path_b anchor_b
+  sysid_b=$(cluster_sysid "$name" "$PGDATA_IN_VOLUME")
+  path_b=$(docker exec "$name" cat "$PGDATA_IN_VOLUME/.pgbackrest_repo_path" 2>/dev/null)
+  anchor_b=$(docker exec "$name" cat "$PGDATA_IN_VOLUME/.pgbackrest_repo_anchor" 2>/dev/null | tr '\n' ' ')
+
+  if [ -z "$sysid_b" ] || [ "$sysid_b" = "$SYSID_A" ]; then
+    ko "${FUNCNAME[0]}" "pg_upgrade should have produced a new system_identifier; got '${sysid_b}' (was '${SYSID_A}')"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+  if [ "$path_b" != "/pgbackrest/cluster-${sysid_b}" ]; then
+    ko "${FUNCNAME[0]}" "marker should be /pgbackrest/cluster-${sysid_b}, got '${path_b}'"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+  case "$anchor_b" in
+    *"sysid=${sysid_b}"*"pg_version=${PG_VERSION}"*) ;;
+    *)
+      ko "${FUNCNAME[0]}" "anchor should name sysid=${sysid_b} pg_version=${PG_VERSION}, got '${anchor_b}'"
+      fail_dump "${FUNCNAME[0]}" "$name"
+      return ;;
+  esac
+
+  assert_reanchored_end_state "${FUNCNAME[0]}" "$name" "$sysid_b" || return
+
+  ok "${FUNCNAME[0]}"
+  note "upgrade ${UPG_FROM_VERSION}→${PG_VERSION} moved archiving ${PATH_A} → ${path_b}; old prefix untouched (${OLD_OBJECTS_BEFORE} objects)"
+  docker rm -f "$name" >/dev/null
+  docker volume rm "$vol" >/dev/null
+}
+
+# The same upgrade, but with the previous cluster's pgbackrest state surviving
+# into the upgraded data directory: a stale repo-path marker, its anchor, a
+# backup state claiming a recent full, and a stale async spool status.
+#
+# Today's job reaches the upgraded state by swapping in a fresh data directory,
+# which drops all of that — so this plants it deliberately. That is not a
+# hypothetical shape: it is what any upgrade route that carries $PGDATA's
+# configuration forward produces, and what the legacy PGDATA-is-the-volume-root
+# layout produces by construction (those files live outside the swapped
+# directory). With the marker winning verbatim, the upgraded cluster would
+# archive into the previous cluster's repo forever.
+#
+# Everything asserted here is boot-time behavior: the flip happens before
+# postgres starts, so no WAL is ever pushed at the stale path.
+t_reanchor_stale_marker_after_upgrade() {
+  local name=t-upg-stalemarker-${PG_VERSION}
+  local vol=${name}-vol
+  if ! ensure_upgrade_images; then
+    ko "${FUNCNAME[0]}" "could not build the upgrade-pair images"
+    return
+  fi
+  seed_upgraded_volume "${FUNCNAME[0]}" "$name" "$vol" || return
+
+  # Plant the previous cluster's state into the upgraded data directory.
+  # last_full_at/last_diff_at are far-future so that a full backup can only
+  # come from the re-anchor resetting this file — not from the periodic
+  # schedule and not from NEEDS_INITIAL_BACKUP on empty state.
+  local stale_ok="000000010000000000000009.ok"
+  if ! in_stopped_volume "$vol" "
+    set -e
+    D=$PGDATA_IN_VOLUME
+    echo '${PATH_A}' > \$D/.pgbackrest_repo_path
+    printf 'sysid=%s\npg_version=%s\n' '${SYSID_A}' '${UPG_FROM_VERSION}' > \$D/.pgbackrest_repo_anchor
+    printf 'last_full_at=%s\nlast_diff_at=%s\n' 9999999999 9999999999 > \$D/.pgbackrest_backup_state
+    mkdir -p \$D/pgbackrest-spool/archive/main/out
+    printf '0\nstale ok from the previous cluster\n' > \$D/pgbackrest-spool/archive/main/out/${stale_ok}
+    chown -R postgres:postgres \$D/.pgbackrest_repo_path \$D/.pgbackrest_repo_anchor \
+      \$D/.pgbackrest_backup_state \$D/pgbackrest-spool
+  " >/dev/null 2>&1; then
+    ko "${FUNCNAME[0]}" "could not plant the previous cluster's pgbackrest state"
+    return
+  fi
+
+  run_archiving_pg_fast_watcher "$name" "$vol" -e "PGDATA=$PGDATA_IN_VOLUME"
+  if ! wait_for_pg "$name"; then
+    ko "${FUNCNAME[0]}" "upgraded database (${PG_VERSION}) did not start"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+
+  local sysid_b path_b anchor_b
+  sysid_b=$(cluster_sysid "$name" "$PGDATA_IN_VOLUME")
+  local expected_path="/pgbackrest/cluster-${sysid_b}"
+
+  # The re-anchor must be reported, and must name both identities — this line is
+  # the only signal an operator gets that a service's archive prefix moved.
+  if ! wait_for_log_line "$name" "cluster re-identified" 30; then
+    ko "${FUNCNAME[0]}" "boot did not detect the re-identified cluster"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+  if ! wait_for_log_line "$name" "re-anchored to ${expected_path}" 30; then
+    ko "${FUNCNAME[0]}" "boot did not report re-anchoring to ${expected_path}"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+
+  path_b=$(docker exec "$name" cat "$PGDATA_IN_VOLUME/.pgbackrest_repo_path" 2>/dev/null)
+  anchor_b=$(docker exec "$name" cat "$PGDATA_IN_VOLUME/.pgbackrest_repo_anchor" 2>/dev/null | tr '\n' ' ')
+  if [ "$path_b" != "$expected_path" ]; then
+    ko "${FUNCNAME[0]}" "marker should have flipped to ${expected_path}, got '${path_b}'"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+  case "$anchor_b" in
+    *"sysid=${sysid_b}"*"pg_version=${PG_VERSION}"*) ;;
+    *)
+      ko "${FUNCNAME[0]}" "anchor should name sysid=${sysid_b} pg_version=${PG_VERSION}, got '${anchor_b}'"
+      fail_dump "${FUNCNAME[0]}" "$name"
+      return ;;
+  esac
+
+  # The rendered conf follows the marker, for `pgbackrest info` callers that
+  # don't go through the PGBACKREST_REPO1_PATH override.
+  local conf_path
+  conf_path=$(docker exec "$name" grep -E "^repo1-path=" /etc/pgbackrest/pgbackrest.conf 2>/dev/null | cut -d= -f2-)
+  if [ "$conf_path" != "$expected_path" ]; then
+    ko "${FUNCNAME[0]}" "pgbackrest.conf repo1-path should be ${expected_path}, got '${conf_path}'"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+
+  # A stale `.ok` is the dangerous leftover: pgBackRest reads it as proof the
+  # segment was already pushed and skips the upload, silently punching a hole in
+  # the new path's WAL coverage.
+  if docker exec "$name" test -e "$PGDATA_IN_VOLUME/pgbackrest-spool/archive/main/out/${stale_ok}"; then
+    ko "${FUNCNAME[0]}" "stale async status ${stale_ok} survived the re-anchor"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+
+  # The migration gate must end up released, or the watcher never backs up again.
+  local pending
+  pending=$(docker exec "$name" grep -E "^archive_migration_pending_new_path=" \
+    "$PGDATA_IN_VOLUME/.pgbackrest_backup_state" 2>/dev/null | cut -d= -f2-)
+  if [ -n "$pending" ]; then
+    ko "${FUNCNAME[0]}" "archive_migration_pending_new_path should be clear after the re-anchor, got '${pending}'"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+
+  assert_reanchored_end_state "${FUNCNAME[0]}" "$name" "$sysid_b" || return
+
+  ok "${FUNCNAME[0]}"
+  note "stale marker at ${PATH_A} re-anchored to ${expected_path} before postgres started; planted state reset, spool cleaned"
+  docker rm -f "$name" >/dev/null
+  docker volume rm "$vol" >/dev/null
+}
+
+# Fleet safety for the rollout itself: a volume that predates the anchor file
+# has a marker and no fingerprint. That must ADOPT the live identity for the
+# path it already archives to, never re-anchor — "no fingerprint" is not
+# evidence of a changed cluster, and treating it as one would move every
+# existing PITR-enabled service to a fresh prefix on its next redeploy,
+# orphaning its whole restore history.
+t_reanchor_backfills_missing_anchor() {
+  local name=t-anchor-backfill-${PG_VERSION}
+  local vol=${name}-vol
+  if ! rebuild_image; then
+    ko "${FUNCNAME[0]}" "could not rebuild $IMAGE"
+    return
+  fi
+  reset_bucket
+  new_volume "$vol"
+  docker rm -f "$name" >/dev/null 2>&1 || true
+
+  run_archiving_pg_fast_watcher "$name" "$vol"
+  if ! wait_for_pg "$name"; then
+    ko "${FUNCNAME[0]}" "no startup"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+  local path_before
+  path_before=$(docker exec "$name" cat /var/lib/postgresql/data/.pgbackrest_repo_path 2>/dev/null)
+  if [ -z "$path_before" ]; then
+    ko "${FUNCNAME[0]}" "no repo-path marker after first boot"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+
+  # Reproduce a pre-anchor volume: marker present, fingerprint absent.
+  docker exec "$name" rm -f /var/lib/postgresql/data/.pgbackrest_repo_anchor
+  docker restart "$name" >/dev/null
+  if ! wait_for_pg "$name"; then
+    ko "${FUNCNAME[0]}" "no startup after removing the anchor"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+
+  if ! wait_for_log_line "$name" "adopted repo-path anchor" 30; then
+    ko "${FUNCNAME[0]}" "boot did not adopt an anchor for the existing marker"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+  if docker logs "$name" 2>&1 | grep -q "cluster re-identified"; then
+    ko "${FUNCNAME[0]}" "a missing anchor was treated as a re-identified cluster"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+
+  local path_after anchor_after sysid
+  path_after=$(docker exec "$name" cat /var/lib/postgresql/data/.pgbackrest_repo_path 2>/dev/null)
+  anchor_after=$(docker exec "$name" cat /var/lib/postgresql/data/.pgbackrest_repo_anchor 2>/dev/null | tr '\n' ' ')
+  sysid=$(cluster_sysid "$name")
+  if [ "$path_after" != "$path_before" ]; then
+    ko "${FUNCNAME[0]}" "archive path moved on a missing anchor: '${path_before}' → '${path_after}'"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+  case "$anchor_after" in
+    *"sysid=${sysid}"*"pg_version=${PG_VERSION}"*) ;;
+    *)
+      ko "${FUNCNAME[0]}" "adopted anchor should name sysid=${sysid} pg_version=${PG_VERSION}, got '${anchor_after}'"
+      fail_dump "${FUNCNAME[0]}" "$name"
+      return ;;
+  esac
+
+  ok "${FUNCNAME[0]}"
+  note "missing anchor adopted (sysid=${sysid}); archive path stayed at ${path_after}"
+  docker rm -f "$name" >/dev/null
+  docker volume rm "$vol" >/dev/null
+}
+
+# The migration machinery's state fields were wal_regression_* before the
+# boot-time re-anchor started sharing them. A volume that redeploys onto the
+# renaming image carries the old names, and the in-flight case is the one that
+# matters: a pending migration recorded under the old name must keep gating
+# backups and still finalize, not silently read as "nothing pending" and let the
+# watcher back up against stale old-path spool statuses.
+#
+# Plants a pending migration equal to the live marker — the shape left by an
+# attempt that flipped the marker and died before cleanup — so the watcher's
+# finalize path has to pick it up through the renamed field.
+t_legacy_wal_regression_state_fields_migrate() {
+  local name=t-legacy-state-${PG_VERSION}
+  local vol=${name}-vol
+  if ! rebuild_image; then
+    ko "${FUNCNAME[0]}" "could not rebuild $IMAGE"
+    return
+  fi
+  reset_bucket
+  new_volume "$vol"
+  docker rm -f "$name" >/dev/null 2>&1 || true
+
+  run_archiving_pg_fast_watcher "$name" "$vol"
+  if ! wait_for_pg "$name"; then
+    ko "${FUNCNAME[0]}" "no startup"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+  for _ in $(seq 1 20); do
+    docker logs "$name" 2>&1 | grep -q "stanza-create completed" && break
+    sleep 1
+  done
+  docker exec "$name" psql -U postgres -c "CREATE TABLE t(id int); SELECT pg_switch_wal();" >/dev/null
+  if ! wait_for_watcher_backup "$name" full 90; then
+    ko "${FUNCNAME[0]}" "no initial full"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+
+  local marker_path legacy_orig
+  marker_path=$(docker exec "$name" cat /var/lib/postgresql/data/.pgbackrest_repo_path 2>/dev/null)
+  legacy_orig="/pgbackrest/cluster-legacy-orig"
+  if ! docker exec -u postgres "$name" sh -c "
+    printf 'wal_regression_orig_path=%s\nwal_regression_pending_new_path=%s\n' \
+      '${legacy_orig}' '${marker_path}' >> /var/lib/postgresql/data/.pgbackrest_backup_state
+  "; then
+    ko "${FUNCNAME[0]}" "could not plant legacy state fields"
+    return
+  fi
+
+  docker restart "$name" >/dev/null
+  if ! wait_for_pg "$name"; then
+    ko "${FUNCNAME[0]}" "no startup after planting legacy state fields"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+
+  if ! wait_for_log_line "$name" "state: renamed wal_regression_pending_new_path" 60; then
+    ko "${FUNCNAME[0]}" "watcher did not rename the legacy pending field"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+
+  # The renamed field must carry its VALUE, and must be the field the finalize
+  # path actually reads — a rename that missed a reader would leave the gate
+  # stuck and the watcher permanently silent.
+  if ! wait_for_log_line "$name" "archive-migration: finalizing pending archive-path migration at ${marker_path}" 60; then
+    ko "${FUNCNAME[0]}" "planted pending migration was not finalized through the renamed field"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+
+  local leftover orig_after pending_after
+  leftover=$(docker exec "$name" grep -cE "^wal_regression_" /var/lib/postgresql/data/.pgbackrest_backup_state 2>/dev/null || true)
+  if [ "${leftover:-0}" != "0" ]; then
+    ko "${FUNCNAME[0]}" "legacy wal_regression_* lines survived the rename (${leftover} left)"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+  orig_after=$(docker exec "$name" grep -E "^archive_migration_orig_path=" \
+    /var/lib/postgresql/data/.pgbackrest_backup_state 2>/dev/null | cut -d= -f2-)
+  if [ "$orig_after" != "$legacy_orig" ]; then
+    ko "${FUNCNAME[0]}" "archive_migration_orig_path should carry '${legacy_orig}', got '${orig_after}'"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+  pending_after=$(docker exec "$name" grep -E "^archive_migration_pending_new_path=" \
+    /var/lib/postgresql/data/.pgbackrest_backup_state 2>/dev/null | cut -d= -f2-)
+  if [ -n "$pending_after" ]; then
+    ko "${FUNCNAME[0]}" "the migration gate should be released after finalize, got '${pending_after}'"
+    fail_dump "${FUNCNAME[0]}" "$name"
+    return
+  fi
+
+  ok "${FUNCNAME[0]}"
+  note "legacy wal_regression_* fields renamed in place; pending migration at ${marker_path} finalized through the new name"
   docker rm -f "$name" >/dev/null
   docker volume rm "$vol" >/dev/null
 }
@@ -3836,6 +4448,11 @@ ALL_TESTS=(
   t_retention_expire_cascades_to_wal
   t_empty_volume_restore_refuses_on_bad_creds
   t_volume_wipe_same_bucket_preserves_both
+  # major-upgrade archive re-anchor (these build their own version-pair images)
+  t_upgrade_archive_reanchors_to_new_cluster_path
+  t_reanchor_stale_marker_after_upgrade
+  t_reanchor_backfills_missing_anchor
+  t_legacy_wal_regression_state_fields_migrate
   t_restore_change_target_after_promote_noop
   t_restore_then_wipe_volume_redoes_restore
   t_restored_service_can_enable_archive_after_promote

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -521,14 +521,23 @@ t_s3_unreachable_pg_stays_up() {
   for i in 1 2 3 4; do
     docker exec "$name" psql -U postgres -c "INSERT INTO t SELECT g FROM generate_series(1,100000) g; SELECT pg_switch_wal();" >/dev/null 2>&1
   done
-  sleep 5
 
   local alive
   alive=$(docker exec "$name" psql -U postgres -At -c "SELECT 1" 2>/dev/null || echo "DEAD")
   assert_eq "$alive" "1" "postgres alive after S3 outage" || { ko t_s3_unreachable_pg_stays_up ""; docker start "$MINIO" >/dev/null; return; }
 
-  local failed_count
-  failed_count=$(docker exec "$name" psql -U postgres -At -c "SELECT failed_count FROM pg_stat_archiver" 2>/dev/null || echo 0)
+  # A fixed sleep here raced the archiver's own retry/backoff on a loaded
+  # runner: docker stop returning is not the same instant pgbackrest's
+  # archive-push actually observes the connection refusal and reports back to
+  # postgres, and that latency is exactly what varies under load. Poll
+  # instead of guessing a sleep long enough for the slowest runner.
+  local failed_count=0
+  local deadline=$(($(date +%s) + 30))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    failed_count=$(docker exec "$name" psql -U postgres -At -c "SELECT failed_count FROM pg_stat_archiver" 2>/dev/null || echo 0)
+    [ "$failed_count" -ge 1 ] && break
+    sleep 1
+  done
   if [ "$failed_count" -lt 1 ]; then
     ko t_s3_unreachable_pg_stays_up "pg_stat_archiver.failed_count should grow under S3 outage; got $failed_count"
     docker start "$MINIO" >/dev/null
@@ -537,10 +546,14 @@ t_s3_unreachable_pg_stays_up() {
 
   log "restarting MinIO; archiver should catch up"
   docker start "$MINIO" >/dev/null
-  sleep 8
 
-  local archived_count
-  archived_count=$(docker exec "$name" psql -U postgres -At -c "SELECT archived_count FROM pg_stat_archiver")
+  local archived_count=0
+  deadline=$(($(date +%s) + 30))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    archived_count=$(docker exec "$name" psql -U postgres -At -c "SELECT archived_count FROM pg_stat_archiver" 2>/dev/null || echo 0)
+    [ "$archived_count" -ge 1 ] && break
+    sleep 1
+  done
   if [ "$archived_count" -lt 1 ]; then
     ko t_s3_unreachable_pg_stays_up "archived_count did not climb after S3 came back; got $archived_count"
     return

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -304,6 +304,7 @@ wait_for_log_line() {
 }
 
 cleanup_test_resources() {
+  [ "${E2E_KEEP_CONTAINERS:-0}" = "1" ] && return 0
   docker rm -f $(docker ps -aq --filter "label=postgres-ssl-e2e=1") 2>/dev/null >/dev/null || true
   for v in $(docker volume ls -q --filter "label=postgres-ssl-e2e=1" 2>/dev/null); do
     docker volume rm "$v" >/dev/null 2>&1 || true
@@ -474,6 +475,61 @@ t_archiving_boot() {
     return
   fi
   ok t_archiving_boot
+  docker rm -f "$name" >/dev/null
+  docker volume rm "$vol" >/dev/null
+}
+
+# A service that sets PGHOSTADDR (an app-side pattern equivalent to the
+# PGHOST=${{ Postgres.RAILWAY_PRIVATE_DOMAIN }} case above) must not break
+# stanza bootstrap: libpq honors PGHOSTADDR even over an explicit -h to the
+# local socket, so pgbackrest's stanza-create subshell would otherwise try
+# to reach itself over the (bogus, non-local) address instead of falling
+# back to the socket. wrapper.sh clears it alongside PGHOST/PGPORT before
+# forking those subshells.
+t_archiving_boot_survives_pghostaddr() {
+  local name=t-arch-pghostaddr-${PG_VERSION}
+  local vol=${name}-vol
+  reset_bucket
+  new_volume "$vol"
+  docker rm -f "$name" >/dev/null 2>&1 || true
+  run_archiving_pg "$name" "$vol" -e "PGHOSTADDR=10.255.255.1"
+  docker container update --label-add postgres-ssl-e2e=1 "$name" >/dev/null 2>&1 || true
+  # wait_for_pg's own readiness probe (docker exec ... pg_isready, no -h)
+  # would ALWAYS fail here regardless of wrapper.sh's own fix, and NOT
+  # because of an -h precedence subtlety: verified empirically that
+  # PGHOSTADDR overrides even an explicit socket-path -h (pg_isready -h
+  # /var/run/postgresql still tries the bogus TCP address and fails) — it
+  # unconditionally forces a TCP connection to that address, full stop.
+  # This is a test-infrastructure limitation, not the product's: `docker
+  # exec` always sees the CONTAINER's declared env (what `docker run -e`
+  # set), never whatever wrapper.sh's already-running process later unset
+  # in its own memory — an unset inside one process can't retroactively
+  # change what a brand-new exec'd process sees, and there is no `-h` value
+  # that out-ranks PGHOSTADDR once it's present in that process's own
+  # environment. So the check itself must clear it for the exec, same as
+  # wrapper.sh clears it for what it forks.
+  local deadline=$(($(date +%s) + 120)) ready=0
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if docker exec -e PGHOSTADDR= "$name" pg_isready -U postgres -q 2>/dev/null; then
+      ready=1
+      break
+    fi
+    sleep 1
+  done
+  [ "$ready" = "1" ] || { ko t_archiving_boot_survives_pghostaddr "postgres did not start"; fail_dump t_archiving_boot_survives_pghostaddr "$name"; return; }
+
+  # A wider deadline than t_archiving_boot's 15s: stanza-create can hit a
+  # transient lock-contention retry (30s backoff, unrelated to PGHOSTADDR —
+  # reproduced with the same shape and timing on a plain manual boot) before
+  # succeeding.
+  local sc_deadline=$(($(date +%s) + 60)) found=0
+  while [ "$(date +%s)" -lt "$sc_deadline" ]; do
+    if docker logs "$name" 2>&1 | grep -q "stanza-create completed"; then found=1; break; fi
+    sleep 1
+  done
+  [ "$found" = "1" ] || { ko t_archiving_boot_survives_pghostaddr "stanza-create did not complete despite PGHOSTADDR"; fail_dump t_archiving_boot_survives_pghostaddr "$name"; return; }
+
+  ok t_archiving_boot_survives_pghostaddr
   docker rm -f "$name" >/dev/null
   docker volume rm "$vol" >/dev/null
 }
@@ -4445,6 +4501,7 @@ ALL_TESTS=(
   t_vanilla_boot
   t_invalid_bucket_skips_archive
   t_archiving_boot
+  t_archiving_boot_survives_pghostaddr
   t_alter_system_survives_restart
   t_s3_unreachable_pg_stays_up
   t_queue_max_5gib_trips

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -2942,8 +2942,16 @@ t_reanchor_backfills_missing_anchor() {
     fail_dump "${FUNCNAME[0]}" "$name"
     return
   fi
-  local path_before
-  path_before=$(docker exec "$name" cat /var/lib/postgresql/data/.pgbackrest_repo_path 2>/dev/null)
+  # Poll rather than single-shot: wait_for_pg's socket probe also answers for
+  # docker-entrypoint's TEMPORARY initdb-time server, so under suite load this
+  # read can land before 99-pgbackrest-init.sh has written the marker. The
+  # marker is guaranteed by END of init; give it a bounded window.
+  local path_before="" _deadline=$(($(date +%s) + 30))
+  while [ "$(date +%s)" -lt "$_deadline" ]; do
+    path_before=$(docker exec "$name" cat /var/lib/postgresql/data/.pgbackrest_repo_path 2>/dev/null)
+    [ -n "$path_before" ] && break
+    sleep 1
+  done
   if [ -z "$path_before" ]; then
     ko "${FUNCNAME[0]}" "no repo-path marker after first boot"
     fail_dump "${FUNCNAME[0]}" "$name"

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -9,7 +9,9 @@
 # Modes (first argument, default "upgrade"):
 #   check    — initdb a throwaway target cluster and run pg_upgrade --check.
 #              Exit 0 = upgradeable, exit 1 = blockers (printed), exit 2 =
-#              precondition failure. NOT strictly read-only: a cluster that
+#              precondition failure, exit 3 = environment failure (the
+#              quiesce below could not start or cleanly stop the old server
+#              — its log is printed). NOT strictly read-only: a cluster that
 #              was not shut down cleanly (the platform stops containers with
 #              SIGKILL, so that is the common case) is first quiesced —
 #              start the old server, replay its WAL, shut down cleanly —
@@ -52,6 +54,15 @@ set -uo pipefail
 FROM_MAJOR="${PG_UPGRADE_FROM:?PG_UPGRADE_FROM not set}"
 TO_MAJOR="${PG_UPGRADE_TO:?PG_UPGRADE_TO not set}"
 
+# The cluster's superuser. The official entrypoint runs
+# `initdb --username="$POSTGRES_USER"`, so a service deployed with a custom
+# POSTGRES_USER has no 'postgres' role at all — pg_upgrade must connect as
+# the cluster's actual install user, and the target cluster must be initdb'd
+# with the SAME name (pg_upgrade requires the install users to match). The
+# job inherits the service's variables in production, so this resolves to
+# the right name there; ad-hoc runs against a custom-user volume need -e.
+PG_SUPERUSER="${POSTGRES_USER:-postgres}"
+
 EXPECTED_VOLUME_MOUNT_PATH="/var/lib/postgresql/data"
 VOLUME_ROOT="$EXPECTED_VOLUME_MOUNT_PATH"
 # The dispatcher must pass the SERVICE's own PGDATA to this container. The
@@ -83,10 +94,16 @@ log() { echo "upgrade-job: $*"; }
 result() {
   echo "RAILWAY_UPGRADE_RESULT: $1"
 }
+# Every result payload is built with jq --arg, never by string interpolation:
+# several interpolated values trace back to bytes a DB superuser can write
+# (PG_VERSION contents, marker fields), and hand-built JSON would let a
+# crafted value close the string and plant duplicate keys — JSON.parse takes
+# the LAST duplicate, so `", "ok": true` inside an error message would flip a
+# failed result to ok:true for the workflow.
 die() {
   local code="$1"; shift
   log "ERROR: $*"
-  result "{\"ok\": false, \"mode\": \"$MODE\", \"error\": \"$*\"}"
+  result "$(jq -nc --arg mode "$MODE" --arg error "$*" '{ok: false, mode: $mode, error: $error}')"
   exit "$code"
 }
 
@@ -95,6 +112,19 @@ die() {
 read_marker_field() {
   [ -f "$MARKER_FILE" ] || { echo ""; return; }
   jq -r ".$1" "$MARKER_FILE" 2>/dev/null | sed 's/^null$//'
+}
+
+# A marker file that exists but cannot be parsed still means an upgrade
+# touched this volume (same contract as postgres-ha's guards and wrapper.sh's
+# boot gate): treating it as "nothing in flight" would let this job proceed
+# over — and overwrite — state whose meaning it cannot know. Refuse and let
+# an operator look. Both stateful modes call this before reading phases;
+# write_marker's atomic tmp+rename means only external damage produces this.
+refuse_unreadable_marker() {
+  [ -f "$MARKER_FILE" ] || return 0
+  if [ -z "$(read_marker_field phase)" ]; then
+    die 2 "the upgrade marker at $MARKER_FILE exists but cannot be read (or has no phase) — refusing to guess; inspect or remove it, then re-run"
+  fi
 }
 
 # The marker is the commit point — it must be durable before we act on it,
@@ -159,8 +189,18 @@ JOB_LOCK_FILE="$VOLUME_ROOT/.railway-major-upgrade.lock"
 # this is the in-image backstop that turns a workflow bug into a refusal
 # instead of a corrupted volume.
 take_job_lock() {
-  command -v flock >/dev/null 2>&1 || return 0
-  exec 9>>"$JOB_LOCK_FILE" || return 0
+  command -v flock >/dev/null 2>&1 \
+    || { log "flock not available; continuing without the upgrade lock"; return 0; }
+  # Brace group scopes the stderr silence to the open attempt (a bare
+  # `exec 9>>… 2>/dev/null` would blackhole this shell's stderr for good —
+  # the exact bug wrapper.sh's lock open once had). Proceeding without the
+  # lock is deliberate but must never be silent: the orchestrator's stop +
+  # single-mount remain the real exclusion, and the log line is the only
+  # record that the in-image backstop was absent for this run.
+  if ! { exec 9>>"$JOB_LOCK_FILE"; } 2>/dev/null; then
+    log "could not open $JOB_LOCK_FILE; continuing without the upgrade lock"
+    return 0
+  fi
   if ! flock -n 9; then
     die 2 "the volume is in use — another upgrade job, or a still-running database container, holds the upgrade lock"
   fi
@@ -217,17 +257,29 @@ ensure_clean_shutdown() {
   esac
 
   log "cluster state is '$state' — replaying WAL and shutting down cleanly before upgrade"
-  as_postgres "$OLD_BINDIR/pg_ctl" -D "$PGDATA" -w -t 600 \
+  # The server's own output goes to a log file that is PRINTED on failure:
+  # a WAL-replay failure is exactly the moment the FATAL lines matter, and
+  # discarding them leaves the job log with nothing but a generic message.
+  local quiesce_log="/tmp/pg-quiesce.log"
+  rm -f "$quiesce_log"
+  as_postgres "$OLD_BINDIR/pg_ctl" -D "$PGDATA" -w -t 600 -l "$quiesce_log" \
     -o "-c listen_addresses='' -k /tmp" start >/dev/null 2>&1 \
-    || die 3 "the old server could not start to complete crash recovery"
+    || { print_quiesce_log "$quiesce_log"; die 3 "the old server could not start to complete crash recovery (server log above)"; }
   as_postgres "$OLD_BINDIR/pg_ctl" -D "$PGDATA" -w -t 600 -m fast stop >/dev/null 2>&1 \
-    || die 3 "the old server did not shut down cleanly after recovery"
+    || { print_quiesce_log "$quiesce_log"; die 3 "the old server did not shut down cleanly after recovery (server log above)"; }
 
   state="$(cluster_state)"
   case "$state" in
     "shut down"|"shut down in recovery") log "cluster is now cleanly shut down" ;;
-    *) die 3 "cluster still not cleanly shut down (state: $state)" ;;
+    *) print_quiesce_log "$quiesce_log"; die 3 "cluster still not cleanly shut down (state: $state; server log above)" ;;
   esac
+}
+
+print_quiesce_log() {
+  [ -f "$1" ] || return 0
+  echo "----- old server log ($1) -----"
+  tail -100 "$1"
+  echo "----- end of old server log -----"
 }
 
 check_from_major() {
@@ -303,9 +355,12 @@ init_new_cluster() {
   fi
   # Locale/encoding inherit the image defaults, which match how the runtime
   # image initdb'd the old cluster; pg_upgrade --check verifies the pairing
-  # and aborts on any mismatch before anything is touched.
+  # and aborts on any mismatch before anything is touched. The superuser must
+  # be the OLD cluster's install user (see PG_SUPERUSER) — pg_upgrade
+  # requires both clusters' install users to match, and a custom
+  # POSTGRES_USER cluster has no 'postgres' role at all.
   # shellcheck disable=SC2046
-  as_postgres "$NEW_BINDIR/initdb" $(checksum_flag) --username=postgres -D "$target_dir" >/dev/null \
+  as_postgres "$NEW_BINDIR/initdb" $(checksum_flag) --username="$PG_SUPERUSER" -D "$target_dir" >/dev/null \
     || die 3 "initdb of the target cluster failed"
 }
 
@@ -317,12 +372,32 @@ run_pg_upgrade() {
     --new-bindir "$NEW_BINDIR" \
     --old-datadir "$PGDATA" \
     --new-datadir "$new_dir" \
-    --username=postgres \
+    --username="$PG_SUPERUSER" \
     --jobs "$(detect_cpus)" \
     $extra 2>&1)
   rc=$?
   echo "$out"
   return $rc
+}
+
+# check's throwaway target cluster lives in /tmp, so a plain --check never
+# exercises the real sibling slot next to $PGDATA — which is exactly where
+# upgrade mode puts the target cluster, and where a real Railway volume's
+# root:root ownership once failed every upgrade AFTER a green preflight (see
+# init_new_cluster's history). Prove the slot is creatable the same way the
+# real run will create it, then remove the probe. Uses a distinct suffix so
+# it can never collide with (or destroy) a real in-flight upgrade directory.
+probe_sibling_slot() {
+  local probe="${NEW_DATA_DIR}.preflight"
+  rm -rf "$probe" 2>/dev/null
+  if ! mkdir -p "$probe" 2>/dev/null; then
+    die 2 "cannot create the upgrade directory next to $PGDATA (volume root not writable?) — the real upgrade would fail after this check"
+  fi
+  if [ "$(id -u)" = "0" ] && ! chown postgres:postgres "$probe" 2>/dev/null; then
+    rm -rf "$probe"
+    die 2 "cannot hand the upgrade directory to postgres — the real upgrade would fail after this check"
+  fi
+  rm -rf "$probe"
 }
 
 # pg_upgrade --check prints its findings to stdout and detail files into cwd.
@@ -342,7 +417,8 @@ mode_status() {
   from="$(read_marker_field from)"
   to="$(read_marker_field to)"
   major="$(data_major)"
-  result "{\"ok\": true, \"mode\": \"status\", \"phase\": \"${phase:-none}\", \"from\": \"${from:-}\", \"to\": \"${to:-}\", \"dataMajor\": \"${major:-}\"}"
+  result "$(jq -nc --arg phase "${phase:-none}" --arg from "${from:-}" --arg to "${to:-}" --arg major "${major:-}" \
+    '{ok: true, mode: "status", phase: $phase, from: $from, to: $to, dataMajor: $major}')"
   exit 0
 }
 
@@ -350,7 +426,8 @@ mode_manifest() {
   local list
   list=$(ls /usr/share/postgresql/"$TO_MAJOR"/extension/*.control 2>/dev/null \
     | sed 's|.*/||; s|\.control$||' | sort -u | jq -R . | jq -sc .)
-  result "{\"ok\": true, \"mode\": \"manifest\", \"targetMajor\": \"$TO_MAJOR\", \"extensions\": ${list:-[]}}"
+  result "$(jq -nc --arg to "$TO_MAJOR" --argjson ext "${list:-[]}" \
+    '{ok: true, mode: "manifest", targetMajor: $to, extensions: $ext}')"
   exit 0
 }
 
@@ -361,6 +438,7 @@ mode_check() {
   # A marker mid-upgrade means the volume's state belongs to the upgrade
   # workflow, not to a preflight: name that instead of failing on whatever
   # half-swapped shape the disk happens to be in.
+  refuse_unreadable_marker
   local phase
   phase="$(read_marker_field phase)"
   if [ -n "$phase" ] && [ "$phase" != "completed" ]; then
@@ -370,6 +448,9 @@ mode_check() {
   clear_stale_pidfile
   check_from_major
   refuse_recovery_shapes
+  # Before the quiesce, so an unwritable volume root gets the precise
+  # refusal instead of a generic quiesce failure.
+  probe_sibling_slot
   # Quiesces an unclean cluster (WAL replay + clean shutdown — what the next
   # normal boot would do); see the header for why check is only strictly
   # read-only on a cleanly-shut-down volume.
@@ -382,13 +463,15 @@ mode_check() {
   if out=$(run_pg_upgrade "--check" "$tmp_new"); then
     log "$out"
     rm -rf "$tmp_new"
-    result "{\"ok\": true, \"mode\": \"check\", \"from\": \"$FROM_MAJOR\", \"to\": \"$TO_MAJOR\"}"
+    result "$(jq -nc --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" \
+      '{ok: true, mode: "check", from: $from, to: $to}')"
     exit 0
   else
     log "$out"
     print_check_details
     rm -rf "$tmp_new"
-    result "{\"ok\": false, \"mode\": \"check\", \"from\": \"$FROM_MAJOR\", \"to\": \"$TO_MAJOR\", \"error\": \"pg_upgrade --check found blockers\"}"
+    result "$(jq -nc --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" \
+      '{ok: false, mode: "check", from: $from, to: $to, error: "pg_upgrade --check found blockers"}')"
     exit 1
   fi
 }
@@ -426,20 +509,53 @@ carry_cluster_config() {
   done
 }
 
+# postgresql.conf and postgresql.auto.conf (ALTER SYSTEM settings) are NOT
+# carried into the new cluster — deliberately: either file can hold a GUC the
+# target major removed (old_snapshot_threshold in 17, promote_trigger_file in
+# 16, …), and an unrecognized parameter in those files refuses the whole
+# boot. The user's tuning must not silently evaporate either, so keep
+# reference copies at the volume root — they outlive the old dir's reclaim —
+# and the completed marker records needsConfigReview so the dashboard can
+# surface "re-apply your ALTER SYSTEM settings" instead of the user
+# discovering it via a post-upgrade max_connections regression.
+stash_old_config() {
+  local src="$1" f
+  for f in postgresql.conf postgresql.auto.conf; do
+    [ -f "$src/$f" ] || continue
+    cp -p "$src/$f" "$VOLUME_ROOT/.pre-upgrade-${FROM_MAJOR}-${f}" 2>/dev/null \
+      || log "could not stash $f at the volume root (non-fatal; the copy in $(basename "$OLD_KEEP_DIR") remains until reclaim)"
+  done
+}
+
 finish_swap() {
   # $PGDATA holds the OLD cluster and the NEW one is complete: move old aside,
   # promote new. Two renames; a crash between them leaves no $PGDATA, which
   # the marker (phase=upgraded) makes recoverable — and which wrapper.sh
   # refuses to boot into, so nothing can initdb over the gap.
   #
+  # Never begin the renames unless the target cluster is really there and
+  # really the target major (unless $PGDATA already IS the promoted target —
+  # the resume path after a crash between the second rename and the completed
+  # marker). The first rename takes $PGDATA apart; doing that on the strength
+  # of a marker alone would convert "resumable degenerate state" into "no
+  # data dir at all" when the new dir was lost or is a partial initdb.
+  if [ "$(data_major)" != "$TO_MAJOR" ] \
+    && [ "$(cat "$NEW_DATA_DIR/PG_VERSION" 2>/dev/null)" != "$TO_MAJOR" ]; then
+    die 3 "cannot finish the swap: $NEW_DATA_DIR is missing or is not a $TO_MAJOR cluster — volume left untouched; restore the pre-upgrade backup or re-run the upgrade from scratch"
+  fi
+
   # Before the renames, carry auth config + PITR sentinels from wherever the
   # old cluster currently sits (still at $PGDATA on a first pass, already
-  # moved aside on a resume after a crash between the renames).
+  # moved aside on a resume after a crash between the renames), and stash the
+  # old cluster's postgresql{,.auto}.conf as reference copies (see
+  # stash_old_config for why they are stashed, not carried).
   if [ -d "$NEW_DATA_DIR" ]; then
     if [ -d "$PGDATA" ] && [ "$(data_major)" = "$FROM_MAJOR" ]; then
       carry_cluster_config "$PGDATA" "$NEW_DATA_DIR"
+      stash_old_config "$PGDATA"
     elif [ -d "$OLD_KEEP_DIR" ]; then
       carry_cluster_config "$OLD_KEEP_DIR" "$NEW_DATA_DIR"
+      stash_old_config "$OLD_KEEP_DIR"
     fi
   fi
 
@@ -458,11 +574,15 @@ finish_swap() {
   # unconditionally and let the operator/dashboard drive the REINDEX; an
   # automatic REINDEX of an arbitrarily large database inside the upgrade
   # window is the wrong default (documented follow-up in the README).
+  # needsConfigReview: postgresql{,.auto}.conf were not carried (see
+  # stash_old_config) — the dashboard surfaces "re-apply your ALTER SYSTEM
+  # settings" off this flag, pointing at the stashed reference copies.
   write_marker "$(jq -nc \
     --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" --arg old "$(basename "$OLD_KEEP_DIR")" \
-    '{phase: "completed", from: $from, to: $to, oldDataDir: $old, needsAnalyze: true, needsReindex: true, completedAt: (now | todate)}')"
+    '{phase: "completed", from: $from, to: $to, oldDataDir: $old, needsAnalyze: true, needsReindex: true, needsConfigReview: true, completedAt: (now | todate)}')"
   log "upgrade $FROM_MAJOR -> $TO_MAJOR complete"
-  result "{\"ok\": true, \"mode\": \"upgrade\", \"phase\": \"completed\", \"from\": \"$FROM_MAJOR\", \"to\": \"$TO_MAJOR\"}"
+  result "$(jq -nc --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" \
+    '{ok: true, mode: "upgrade", phase: "completed", from: $from, to: $to}')"
   exit 0
 }
 
@@ -476,15 +596,22 @@ mode_upgrade() {
   # completed marker — reading that as "already done" would report success
   # while the data stays on the old major, and the workflow would flip the
   # image tag into a boot refusal.
+  refuse_unreadable_marker
   local marker_phase marker_from marker_to
   marker_phase="$(read_marker_field phase)"
   marker_from="$(read_marker_field from)"
   marker_to="$(read_marker_field to)"
   case "$marker_phase" in
     completed)
-      if [ "$marker_to" = "$TO_MAJOR" ]; then
-        log "marker says completed for ${marker_from:-?} -> $TO_MAJOR — nothing to do"
-        result "{\"ok\": true, \"mode\": \"upgrade\", \"phase\": \"completed\", \"alreadyDone\": true}"
+      # "Already done" needs BOTH the marker and the data directory to say
+      # so: a completed same-pair marker sitting over FROM-major data (a
+      # partial manual restore put the old cluster back without touching the
+      # volume-root marker) must re-run the upgrade, not no-op to success —
+      # the workflow would flip the image tag onto FROM data and the service
+      # would boot-refuse after a "successful" job.
+      if [ "$marker_to" = "$TO_MAJOR" ] && [ "$(data_major)" = "$TO_MAJOR" ]; then
+        log "marker says completed for ${marker_from:-?} -> $TO_MAJOR and the data directory is $TO_MAJOR — nothing to do"
+        result "$(jq -nc '{ok: true, mode: "upgrade", phase: "completed", alreadyDone: true}')"
         exit 0
       fi
       if [ "$(data_major)" != "$FROM_MAJOR" ]; then
@@ -518,6 +645,15 @@ mode_upgrade() {
         finish_swap
       fi
       ;;
+    *)
+      # A phase this job does not recognize (the HA workflow's "reseed" on a
+      # replica volume, or a future writer's new state) is someone else's
+      # in-flight state — same reading as postgres-ha's guards, where
+      # anything other than absent/completed is in flight. Proceeding would
+      # overwrite that owner's marker at our commit point and take away its
+      # ability to resolve the volume.
+      die 2 "marker phase '$marker_phase' is not this job's to resolve — refusing to upgrade over another writer's in-flight state"
+      ;;
   esac
 
   check_from_major
@@ -531,7 +667,8 @@ mode_upgrade() {
     log "$out"
     print_check_details
     rm -rf "$NEW_DATA_DIR"
-    result "{\"ok\": false, \"mode\": \"upgrade\", \"from\": \"$FROM_MAJOR\", \"to\": \"$TO_MAJOR\", \"error\": \"pg_upgrade --check found blockers\"}"
+    result "$(jq -nc --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" \
+      '{ok: false, mode: "upgrade", from: $from, to: $to, error: "pg_upgrade --check found blockers"}')"
     exit 1
   fi
   log "$out"
@@ -542,7 +679,8 @@ mode_upgrade() {
     # pg_upgrade's failed run and MUST NOT be restarted in place. The
     # workflow rolls back to the pre-upgrade backup.
     rm -rf "$NEW_DATA_DIR"
-    result "{\"ok\": false, \"mode\": \"upgrade\", \"from\": \"$FROM_MAJOR\", \"to\": \"$TO_MAJOR\", \"error\": \"pg_upgrade failed after check passed\"}"
+    result "$(jq -nc --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" \
+      '{ok: false, mode: "upgrade", from: $from, to: $to, error: "pg_upgrade failed after check passed"}')"
     exit 3
   fi
   log "$out"

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -126,10 +126,21 @@ MARKER_FILE="$VOLUME_ROOT/.railway-major-upgrade.json"
 # The job inherits the service's variables in production, so disambiguate by
 # the volume itself: a Patroni-managed data dir always carries
 # patroni.dynamic.json. Ad-hoc runs against a custom-user volume need -e.
-if [ -f "$PGDATA/patroni.dynamic.json" ]; then
+#
+# Checked for SHAPE, not just presence: a bare filename match would also fire
+# on a stray/empty file of the same name (a manual copy, a leftover from
+# mixing template types) that has nothing to do with Patroni, silently
+# picking PATRONI_SUPERUSER_USERNAME over the volume's real install user.
+# Patroni always writes a top-level `.postgresql` key into this file, so
+# require that too — cheap, and the failure mode either way is a safe
+# pg_upgrade install-user-mismatch refusal, never a wrong upgrade.
+if [ -f "$PGDATA/patroni.dynamic.json" ] && jq -e '.postgresql' "$PGDATA/patroni.dynamic.json" >/dev/null 2>&1; then
   PG_SUPERUSER="${PATRONI_SUPERUSER_USERNAME:-postgres}"
   echo "upgrade-job: patroni cluster detected (patroni.dynamic.json) — using install user '$PG_SUPERUSER' (POSTGRES_USER is the app user on postgres-ha)"
 else
+  if [ -f "$PGDATA/patroni.dynamic.json" ]; then
+    echo "upgrade-job: found patroni.dynamic.json but it doesn't look like a Patroni state file (no .postgresql key) — ignoring it"
+  fi
   PG_SUPERUSER="${POSTGRES_USER:-postgres}"
 fi
 

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -6,7 +6,8 @@
 # stopped. The orchestrating workflow guarantees exclusivity (volume lock +
 # service maintenance lock); this script still refuses the obvious hazards.
 #
-# Modes (first argument, default "upgrade"):
+# Modes (UPGRADE_JOB_MODE env var; falls back to a positional arg for local/
+# e2e runs; default "upgrade"):
 #   check    — initdb a throwaway target cluster and run pg_upgrade --check.
 #              Exit 0 = upgradeable, exit 1 = blockers (printed), exit 2 =
 #              precondition failure, exit 3 = environment failure (the
@@ -59,14 +60,9 @@ set -uo pipefail
 FROM_MAJOR="${PG_UPGRADE_FROM:?PG_UPGRADE_FROM not set}"
 TO_MAJOR="${PG_UPGRADE_TO:?PG_UPGRADE_TO not set}"
 
-# The cluster's superuser. The official entrypoint runs
-# `initdb --username="$POSTGRES_USER"`, so a service deployed with a custom
-# POSTGRES_USER has no 'postgres' role at all — pg_upgrade must connect as
-# the cluster's actual install user, and the target cluster must be initdb'd
-# with the SAME name (pg_upgrade requires the install users to match). The
-# job inherits the service's variables in production, so this resolves to
-# the right name there; ad-hoc runs against a custom-user volume need -e.
-PG_SUPERUSER="${POSTGRES_USER:-postgres}"
+# PG_SUPERUSER (the cluster's INSTALL user) is resolved below, after PGDATA
+# is normalized — which env var names it depends on the template family, and
+# the discriminator is on the volume itself.
 
 # The quiesce (WAL replay + clean stop) shares this timeout for both the
 # start and the stop. An interrupted crash recovery persists NO progress —
@@ -102,28 +98,53 @@ PGDATA="${PGDATA:-$VOLUME_ROOT/pgdata}"
 while [ "${PGDATA%/}" != "$PGDATA" ] && [ -n "${PGDATA%/}" ]; do PGDATA="${PGDATA%/}"; done
 MARKER_FILE="$VOLUME_ROOT/.railway-major-upgrade.json"
 
+# The cluster's INSTALL user — pg_upgrade must connect as it, and the target
+# cluster must be initdb'd with the SAME name (pg_upgrade requires the
+# install users to match). Which env var names it depends on the template
+# family, and the two DISAGREE:
+#   postgres-ssl: the official entrypoint runs `initdb --username="$POSTGRES_USER"`,
+#     so POSTGRES_USER IS the install user (a custom-user service has no
+#     'postgres' role at all).
+#   postgres-ha: Patroni bootstraps with PATRONI_SUPERUSER_USERNAME (default
+#     postgres, postgres-patroni config.rs + yaml.rs) and POSTGRES_USER is
+#     the APP user Patroni creates afterwards — trusting POSTGRES_USER there
+#     picks a non-superuser that is not the install user, and pg_upgrade
+#     fails the install-user match.
+# The job inherits the service's variables in production, so disambiguate by
+# the volume itself: a Patroni-managed data dir always carries
+# patroni.dynamic.json. Ad-hoc runs against a custom-user volume need -e.
+if [ -f "$PGDATA/patroni.dynamic.json" ]; then
+  PG_SUPERUSER="${PATRONI_SUPERUSER_USERNAME:-postgres}"
+  echo "upgrade-job: patroni cluster detected (patroni.dynamic.json) — using install user '$PG_SUPERUSER' (POSTGRES_USER is the app user on postgres-ha)"
+else
+  PG_SUPERUSER="${POSTGRES_USER:-postgres}"
+fi
+
 OLD_BINDIR="/usr/lib/postgresql/${FROM_MAJOR}/bin"
 NEW_BINDIR="/usr/lib/postgresql/${TO_MAJOR}/bin"
 NEW_DATA_DIR="${PGDATA}.upgrade-${TO_MAJOR}"
 OLD_KEEP_DIR="${PGDATA}.old-${FROM_MAJOR}"
 
-# Scan every positional arg for a recognized mode instead of trusting $1
-# alone. Railway's two container runtimes disagree on how a deployment's
-# startCommand combines with the image's own ENTRYPOINT: one REPLACES the
-# entrypoint outright (so the dispatcher must send the script name itself,
-# "upgrade-job.sh <mode>", or the exec target is a nonexistent program named
-# literally "check"/"upgrade"), the other KEEPS the entrypoint and appends
-# startCommand as further args (so that same two-word command arrives as
-# "upgrade-job.sh upgrade-job.sh <mode>" — the script's own name twice). A
-# bare positional read ($1) is correct for only one of those two shapes;
-# scanning for the first arg that IS a known mode is correct for both, and
-# for every existing bare-mode caller (local runs, the e2e harness) too.
-MODE="upgrade"
-for _arg in "$@"; do
-  case "$_arg" in
-    check | upgrade | status | manifest) MODE="$_arg" ;;
-  esac
-done
+# The dispatcher selects the mode via a real Railway variable, not
+# startCommand or argv: this repo's two container runtimes disagree on how a
+# deployment's startCommand combines with the image's own ENTRYPOINT (one
+# REPLACES the entrypoint outright, so a bare mode string tries to exec a
+# nonexistent program named "check"/"upgrade"; the other KEEPS the entrypoint
+# and appends startCommand as further args), so no single startCommand value
+# selects a mode on both. UPGRADE_JOB_MODE sidesteps that entirely — it
+# reaches the container the same way every other service variable already
+# does, regardless of which runtime or image is in play. Positional args are
+# kept only as a fallback for local/manual runs and the e2e harness, which
+# invoke this script directly (`upgrade-job.sh <mode>`) rather than through a
+# Railway deployment.
+MODE="${UPGRADE_JOB_MODE:-upgrade}"
+if [ -z "${UPGRADE_JOB_MODE:-}" ]; then
+  for _arg in "$@"; do
+    case "$_arg" in
+      check | upgrade | status | manifest) MODE="$_arg" ;;
+    esac
+  done
+fi
 
 log() { echo "upgrade-job: $*"; }
 # pg_upgrade's own combined output is forwarded verbatim for diagnosability,
@@ -331,7 +352,12 @@ ensure_clean_shutdown() {
 print_quiesce_log() {
   [ -f "$1" ] || return 0
   echo "----- old server log ($1) -----"
-  tail -100 "$1"
+  # Indented like log_upgrade_output and for the same reason: server log
+  # lines carry DB-superuser-controlled bytes (error detail, statement
+  # text), and a multi-line message's continuation lines have no
+  # log_line_prefix — unprefixed, one could open with the
+  # RAILWAY_UPGRADE_RESULT: sentinel and forge a result line.
+  tail -100 "$1" | sed 's/^/  server: /'
   echo "----- end of old server log -----"
 }
 
@@ -422,14 +448,20 @@ init_new_cluster() {
     chown postgres:postgres "$target_dir" \
       || die 3 "failed to chown the target cluster directory to postgres"
   fi
-  # Locale/encoding inherit the image defaults, which match how the runtime
-  # image initdb'd the old cluster; pg_upgrade --check verifies the pairing
-  # and aborts on any mismatch before anything is touched. The superuser must
-  # be the OLD cluster's install user (see PG_SUPERUSER) — pg_upgrade
-  # requires both clusters' install users to match, and a custom
-  # POSTGRES_USER cluster has no 'postgres' role at all.
-  # shellcheck disable=SC2046
-  as_postgres "$NEW_BINDIR/initdb" $(checksum_flag) --username="$PG_SUPERUSER" -D "$target_dir" >/dev/null \
+  # Locale/encoding must MATCH the old cluster or pg_upgrade --check refuses
+  # the pairing. The old cluster was initdb'd by the official entrypoint,
+  # which evals POSTGRES_INITDB_ARGS into its initdb call — so a service
+  # that customized locale/encoding at init time ("--locale=C", …) has a
+  # cluster the image-default initdb can never pair with. Replay the same
+  # env the same way (eval, mirroring docker-entrypoint's quoting; the var
+  # is the operator's own service variable, the exact trust the entrypoint
+  # already extends at every init). Our flags come LAST so --username and
+  # -D always win over anything in the user args; checksum parity stays
+  # owned by checksum_flag, derived from the old cluster's pg_controldata —
+  # which already reflects whatever the init args chose. pg_upgrade --check
+  # remains the final arbiter of the pairing. The superuser must be the OLD
+  # cluster's install user (see PG_SUPERUSER).
+  eval 'as_postgres "$NEW_BINDIR/initdb" '"$(checksum_flag) ${POSTGRES_INITDB_ARGS:-}"' --username="$PG_SUPERUSER" -D "$target_dir"' >/dev/null \
     || die 3 "initdb of the target cluster failed"
 }
 
@@ -482,7 +514,10 @@ print_check_details() {
   for f in "$new_dir"/pg_upgrade_output.d/*/*.txt "$new_dir"/pg_upgrade_output.d/*/log/*.log; do
     [ -f "$f" ] || continue
     echo "----- $(basename "$f") -----"
-    cat "$f"
+    # Indented for the same reason as log_upgrade_output: failure lists are
+    # made of relation/database names — DB-superuser-controlled bytes that
+    # must not be able to start a line with the result sentinel.
+    sed 's/^/  detail: /' "$f"
   done
 }
 
@@ -524,6 +559,11 @@ mode_check() {
 
   clear_stale_pidfile
   check_from_major
+  # Mirror upgrade mode's stale-rollback-body refusal: a green check must
+  # mean the real run won't refuse on a condition check could see.
+  if [ -e "$OLD_KEEP_DIR" ]; then
+    die 2 "$OLD_KEEP_DIR already exists next to $FROM_MAJOR-major data — a previous upgrade's rollback body was left in place; remove or rename it, then re-run"
+  fi
   refuse_recovery_shapes
   # Before the quiesce, so an unwritable volume root gets the precise
   # refusal instead of a generic quiesce failure.
@@ -637,6 +677,12 @@ finish_swap() {
   fi
 
   if [ -d "$PGDATA" ] && [ "$(data_major)" = "$FROM_MAJOR" ]; then
+    # Belt to mode_upgrade's upfront refusal: `mv` onto an EXISTING directory
+    # nests the source inside it instead of renaming — pgdata would end up at
+    # .old-<from>/pgdata, silently mangling the rollback body.
+    if [ -e "$OLD_KEEP_DIR" ]; then
+      die 3 "cannot move the old data dir aside: $OLD_KEEP_DIR already exists (a leftover rollback body) — remove or rename it, then re-run"
+    fi
     mv "$PGDATA" "$OLD_KEEP_DIR" || die 3 "failed to move old data dir aside"
   fi
   if [ ! -d "$PGDATA" ]; then
@@ -750,6 +796,16 @@ mode_upgrade() {
   esac
 
   check_from_major
+  # A pre-existing .old-<from> next to FROM-major data is a manual-
+  # intervention artifact (a partial restore COPIED the rollback body back
+  # and left the original — no normal flow produces this pairing: a first
+  # pass has no .old dir, and every resume path has no FROM-major $PGDATA).
+  # finish_swap's first rename would NEST pgdata inside it; refuse here,
+  # before anything is touched, and let the operator pick the authoritative
+  # copy.
+  if [ -e "$OLD_KEEP_DIR" ]; then
+    die 2 "$OLD_KEEP_DIR already exists next to $FROM_MAJOR-major data — a previous upgrade's rollback body was left in place; remove or rename it, then re-run"
+  fi
   clear_stale_pidfile
   refuse_recovery_shapes
   ensure_clean_shutdown

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -63,12 +63,14 @@ TO_MAJOR="${PG_UPGRADE_TO:?PG_UPGRADE_TO not set}"
 # The job inherits the service's own variables (that's how it gets PGDATA),
 # and both the postgres-ha and standalone postgres templates default
 # PGHOST=${{ RAILWAY_PRIVATE_DOMAIN }} — a common app-side pattern. pg_upgrade
-# reads libpq env vars directly and REFUSES outright on a non-local PGHOST
-# ("libpq environment variable PGHOST has a non-local server value"),
-# blocking --check before anything is touched. Same hazard wrapper.sh already
-# unsets for pgbackrest's libpq calls; this job only ever talks to Postgres
-# over the local socket, so clear both unconditionally.
+# reads libpq env vars directly and REFUSES outright on a non-local PGHOST OR
+# PGHOSTADDR ("libpq environment variable PG{HOST,HOSTADDR} has a non-local
+# server value" — verified against the binary for both), blocking --check
+# before anything is touched. Same hazard wrapper.sh already unsets for
+# pgbackrest's libpq calls; this job only ever talks to Postgres over the
+# local socket, so clear all three unconditionally.
 unset PGHOST
+unset PGHOSTADDR
 unset PGPORT
 
 # PG_SUPERUSER (the cluster's INSTALL user) is resolved below, after PGDATA
@@ -136,27 +138,6 @@ NEW_BINDIR="/usr/lib/postgresql/${TO_MAJOR}/bin"
 NEW_DATA_DIR="${PGDATA}.upgrade-${TO_MAJOR}"
 OLD_KEEP_DIR="${PGDATA}.old-${FROM_MAJOR}"
 
-# The dispatcher selects the mode via a real Railway variable, not
-# startCommand or argv: this repo's two container runtimes disagree on how a
-# deployment's startCommand combines with the image's own ENTRYPOINT (one
-# REPLACES the entrypoint outright, so a bare mode string tries to exec a
-# nonexistent program named "check"/"upgrade"; the other KEEPS the entrypoint
-# and appends startCommand as further args), so no single startCommand value
-# selects a mode on both. UPGRADE_JOB_MODE sidesteps that entirely — it
-# reaches the container the same way every other service variable already
-# does, regardless of which runtime or image is in play. Positional args are
-# kept only as a fallback for local/manual runs and the e2e harness, which
-# invoke this script directly (`upgrade-job.sh <mode>`) rather than through a
-# Railway deployment.
-MODE="${UPGRADE_JOB_MODE:-upgrade}"
-if [ -z "${UPGRADE_JOB_MODE:-}" ]; then
-  for _arg in "$@"; do
-    case "$_arg" in
-      check | upgrade | status | manifest) MODE="$_arg" ;;
-    esac
-  done
-fi
-
 log() { echo "upgrade-job: $*"; }
 # pg_upgrade's own combined output is forwarded verbatim for diagnosability,
 # and it can embed attacker-chosen bytes: a database/role/tablespace name a
@@ -188,6 +169,32 @@ die() {
   result "$(jq -nc --arg mode "$MODE" --arg error "$*" '{ok: false, mode: $mode, error: $error}')"
   exit "$code"
 }
+
+# The dispatcher selects the mode via a real Railway variable, not
+# startCommand or argv: this repo's two container runtimes disagree on how a
+# deployment's startCommand combines with the image's own ENTRYPOINT (one
+# REPLACES the entrypoint outright, so a bare mode string tries to exec a
+# nonexistent program named "check"/"upgrade"; the other KEEPS the entrypoint
+# and appends startCommand as further args), so no single startCommand value
+# selects a mode on both. UPGRADE_JOB_MODE sidesteps that entirely — it
+# reaches the container the same way every other service variable already
+# does, regardless of which runtime or image is in play. Positional args are
+# kept only as a fallback for local/manual runs and the e2e harness, which
+# invoke this script directly (`upgrade-job.sh <mode>`) rather than through a
+# Railway deployment — and an unrecognized one dies rather than falling
+# through to the "upgrade" default: silently running the destructive path on
+# a typo'd read-only mode is exactly the failure this fallback must not have,
+# since manual/incident-response invocation is the only place it's reachable.
+MODE="${UPGRADE_JOB_MODE:-}"
+if [ -z "$MODE" ] && [ "$#" -gt 0 ]; then
+  for _arg in "$@"; do
+    case "$_arg" in
+      check | upgrade | status | manifest) MODE="$_arg" ;;
+    esac
+  done
+  [ -n "$MODE" ] || die 2 "no recognized mode among arguments: $* (expected one of: check, upgrade, status, manifest)"
+fi
+MODE="${MODE:-upgrade}"
 
 # Plain `.field` with an explicit null map, not `// empty`: jq's `//` treats a
 # literal `false` as absent, so a boolean field would read back as missing.
@@ -589,7 +596,7 @@ mode_check() {
   # Mirror upgrade mode's stale-rollback-body refusal: a green check must
   # mean the real run won't refuse on a condition check could see.
   if [ -e "$OLD_KEEP_DIR" ]; then
-    die 2 "$OLD_KEEP_DIR already exists next to $FROM_MAJOR-major data — a previous upgrade's rollback body was left in place; remove or rename it, then re-run"
+    die 2 "$OLD_KEEP_DIR already exists next to $FROM_MAJOR-major data — a previous upgrade's rollback body was left in place; remove it or move it OUTSIDE ${PGDATA}.old-* (a rename within that prefix still matches the background reclaim's glob), then re-run"
   fi
   refuse_recovery_shapes
   # Before the quiesce, so an unwritable volume root gets the precise
@@ -708,7 +715,7 @@ finish_swap() {
     # nests the source inside it instead of renaming — pgdata would end up at
     # .old-<from>/pgdata, silently mangling the rollback body.
     if [ -e "$OLD_KEEP_DIR" ]; then
-      die 3 "cannot move the old data dir aside: $OLD_KEEP_DIR already exists (a leftover rollback body) — remove or rename it, then re-run"
+      die 3 "cannot move the old data dir aside: $OLD_KEEP_DIR already exists (a leftover rollback body) — remove it or move it OUTSIDE ${PGDATA}.old-* (a rename within that prefix still matches the background reclaim's glob), then re-run"
     fi
     mv "$PGDATA" "$OLD_KEEP_DIR" || die 3 "failed to move old data dir aside"
   fi
@@ -831,7 +838,7 @@ mode_upgrade() {
   # before anything is touched, and let the operator pick the authoritative
   # copy.
   if [ -e "$OLD_KEEP_DIR" ]; then
-    die 2 "$OLD_KEEP_DIR already exists next to $FROM_MAJOR-major data — a previous upgrade's rollback body was left in place; remove or rename it, then re-run"
+    die 2 "$OLD_KEEP_DIR already exists next to $FROM_MAJOR-major data — a previous upgrade's rollback body was left in place; remove it or move it OUTSIDE ${PGDATA}.old-* (a rename within that prefix still matches the background reclaim's glob), then re-run"
   fi
   clear_stale_pidfile
   refuse_recovery_shapes

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -234,8 +234,14 @@ as_postgres() {
   fi
 }
 
+# PG_VERSION is DB-superuser-writable (COPY TO PROGRAM runs as the postgres
+# OS user, which owns it) and several call sites interpolate this straight
+# into a die() message — stripped to digits so an embedded newline can never
+# ride along and forge a RAILWAY_UPGRADE_RESULT: line into the log. A
+# well-formed value in this job's supported range (14-18) is digits only, so
+# this is a no-op on every real input.
 data_major() {
-  [ -f "$PGDATA/PG_VERSION" ] && cat "$PGDATA/PG_VERSION" || echo ""
+  [ -f "$PGDATA/PG_VERSION" ] && tr -cd '0-9' < "$PGDATA/PG_VERSION" || echo ""
 }
 
 # ----- preconditions ---------------------------------------------------------
@@ -536,7 +542,17 @@ print_check_details() {
 
 mode_status() {
   local phase from to major
-  phase="$(read_marker_field phase)"
+  if [ -f "$MARKER_FILE" ] && [ -z "$(read_marker_field phase)" ]; then
+    # A marker that exists but can't be read (or has no phase) means an
+    # upgrade touched this volume in a way status can't characterize.
+    # check and upgrade both refuse outright on this same condition
+    # (refuse_unreadable_marker); status has no mutation to refuse, so it
+    # must say so explicitly instead of defaulting to "none" — which the
+    # workflow reads as "nothing in flight, safe to restart the old image."
+    phase="unreadable"
+  else
+    phase="$(read_marker_field phase)"
+  fi
   from="$(read_marker_field from)"
   to="$(read_marker_field to)"
   major="$(data_major)"

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -1,0 +1,353 @@
+#!/bin/bash
+# upgrade-job.sh — one-shot in-place major upgrade job (pg_upgrade --link).
+#
+# Runs as the entrypoint of the dual-binary upgrade image (Dockerfile.upgrade),
+# against the SAME volume the database service owns, while that service is
+# stopped. The orchestrating workflow guarantees exclusivity (volume lock +
+# service maintenance lock); this script still refuses the obvious hazards.
+#
+# Modes (first argument, default "upgrade"):
+#   check    — initdb a throwaway target cluster and run pg_upgrade --check.
+#              Read-only with respect to the volume. Exit 0 = upgradeable,
+#              exit 1 = blockers (printed), exit 2 = precondition failure.
+#   upgrade  — the real thing: --check first, then pg_upgrade --link into a
+#              new data dir on the volume, write the completion marker (the
+#              commit point), then swap directories. Crash-safe: re-running
+#              resumes from the marker. Exit 0 = upgraded (or already done).
+#   status   — print the marker + on-disk major as JSON and exit 0. Used by
+#              the workflow to decide roll-back vs roll-forward on resume.
+#   manifest — print the extensions available on the TARGET major as JSON.
+#              Feeds the dashboard preflight's extension check.
+#
+# Marker contract (volume root, .railway-major-upgrade.json):
+#   absent               — nothing committed; any failure rolls back.
+#   phase == "upgraded"  — pg_upgrade succeeded; directory swap may be
+#                          incomplete. Roll FORWARD (re-run upgrade mode).
+#   phase == "completed" — swap done; the runtime image of TO major boots.
+# The runtime wrapper.sh refuses to boot while a non-completed marker exists,
+# and refuses an image/data major mismatch, so no mismatched boot can ever
+# touch the data directory.
+
+set -uo pipefail
+
+FROM_MAJOR="${PG_UPGRADE_FROM:?PG_UPGRADE_FROM not set}"
+TO_MAJOR="${PG_UPGRADE_TO:?PG_UPGRADE_TO not set}"
+
+EXPECTED_VOLUME_MOUNT_PATH="/var/lib/postgresql/data"
+VOLUME_ROOT="$EXPECTED_VOLUME_MOUNT_PATH"
+PGDATA="${PGDATA:-$VOLUME_ROOT/pgdata}"
+MARKER_FILE="$VOLUME_ROOT/.railway-major-upgrade.json"
+
+OLD_BINDIR="/usr/lib/postgresql/${FROM_MAJOR}/bin"
+NEW_BINDIR="/usr/lib/postgresql/${TO_MAJOR}/bin"
+NEW_DATA_DIR="${PGDATA}.upgrade-${TO_MAJOR}"
+OLD_KEEP_DIR="${PGDATA}.old-${FROM_MAJOR}"
+
+MODE="${1:-upgrade}"
+
+log() { echo "upgrade-job: $*"; }
+# Machine-readable result line the workflow scrapes from the job logs.
+result() {
+  echo "RAILWAY_UPGRADE_RESULT: $1"
+}
+die() {
+  local code="$1"; shift
+  log "ERROR: $*"
+  result "{\"ok\": false, \"mode\": \"$MODE\", \"error\": \"$*\"}"
+  exit "$code"
+}
+
+# Plain `.field` with an explicit null map, not `// empty`: jq's `//` treats a
+# literal `false` as absent, so a boolean field would read back as missing.
+read_marker_field() {
+  [ -f "$MARKER_FILE" ] || { echo ""; return; }
+  jq -r ".$1" "$MARKER_FILE" 2>/dev/null | sed 's/^null$//'
+}
+
+write_marker() {
+  local json="$1"
+  local tmp="${MARKER_FILE}.tmp"
+  echo "$json" > "$tmp"
+  # The marker is the commit point — it must be durable before we act on it.
+  sync "$tmp"
+  mv "$tmp" "$MARKER_FILE"
+  sync "$MARKER_FILE" 2>/dev/null || sync
+}
+
+as_postgres() {
+  if [ "$(id -u)" = "0" ]; then
+    gosu postgres "$@"
+  else
+    "$@"
+  fi
+}
+
+data_major() {
+  [ -f "$PGDATA/PG_VERSION" ] && cat "$PGDATA/PG_VERSION" || echo ""
+}
+
+# ----- preconditions ---------------------------------------------------------
+
+check_mount() {
+  if [ -n "${RAILWAY_ENVIRONMENT:-}" ] && [ "${RAILWAY_VOLUME_MOUNT_PATH:-}" != "$EXPECTED_VOLUME_MOUNT_PATH" ]; then
+    die 2 "Railway volume not mounted at $EXPECTED_VOLUME_MOUNT_PATH (got '${RAILWAY_VOLUME_MOUNT_PATH:-}')"
+  fi
+  if [[ ! "$PGDATA" =~ ^"$EXPECTED_VOLUME_MOUNT_PATH" ]]; then
+    die 2 "PGDATA ($PGDATA) is not under the volume mount path"
+  fi
+  # The new cluster dir lives NEXT TO the data dir and must share its
+  # filesystem for --link's hardlinks; a PGDATA that IS the volume root has
+  # no sibling slot inside the volume. Legacy layouts upgrade via the
+  # dump/restore fallback instead.
+  if [ "$PGDATA" = "$VOLUME_ROOT" ] || [ "$PGDATA" = "$VOLUME_ROOT/" ]; then
+    die 2 "PGDATA is the volume root — this data layout is not supported for in-place upgrade"
+  fi
+}
+
+JOB_LOCK_FILE="$VOLUME_ROOT/.railway-major-upgrade.lock"
+
+# Exclude a second upgrade job on the same volume. This is the hazard that can
+# actually happen (an activity retry racing a still-running attempt); a
+# postgres running in ANOTHER container is not detectable from here — separate
+# PID and IPC namespaces make postmaster.pid's liveness and shmem checks
+# meaningless across containers — and is excluded by the orchestrator instead
+# (volume lock + service maintenance restriction + the deploy pipeline
+# stopping the incumbent before this container starts).
+take_job_lock() {
+  command -v flock >/dev/null 2>&1 || return 0
+  exec 9>"$JOB_LOCK_FILE" || return 0
+  if ! flock -n 9; then
+    die 2 "another upgrade job is already running on this volume"
+  fi
+}
+
+# Clear a stale postmaster.pid. Same reasoning wrapper.sh documents for the
+# runtime image: this script IS the container entrypoint, so no postgres of
+# ours is running yet, and any pid file on disk belongs to a container that
+# was killed rather than shut down (SIGKILL after the stop grace period —
+# bash as PID 1 never forwards SIGTERM to postgres).
+clear_stale_pidfile() {
+  if [ -f "$PGDATA/postmaster.pid" ]; then
+    log "removing stale postmaster.pid (no postgres running in this container)"
+    rm -f "$PGDATA/postmaster.pid" 2>/dev/null || true
+  fi
+}
+
+cluster_state() {
+  "$OLD_BINDIR/pg_controldata" "$PGDATA" 2>/dev/null \
+    | awk -F: '/Database cluster state/ {sub(/^ +/,"",$2); print $2}'
+}
+
+# pg_upgrade refuses a cluster that was not shut down cleanly, and it is right
+# to: unreplayed WAL would be silently dropped by --link. A container killed
+# mid-flight leaves exactly that state, so recover it here — start the OLD
+# server so it replays its WAL, then shut it down cleanly. Isolated to a unix
+# socket in /tmp with no TCP listener, so nothing can connect meanwhile.
+ensure_clean_shutdown() {
+  local state
+  state="$(cluster_state)"
+  case "$state" in
+    "shut down"|"shut down in recovery")
+      log "cluster state: $state"
+      return 0
+      ;;
+    "")
+      die 2 "could not read cluster state from $PGDATA (pg_controldata failed)"
+      ;;
+  esac
+
+  log "cluster state is '$state' — replaying WAL and shutting down cleanly before upgrade"
+  as_postgres "$OLD_BINDIR/pg_ctl" -D "$PGDATA" -w -t 600 \
+    -o "-c listen_addresses='' -k /tmp" start >/dev/null 2>&1 \
+    || die 3 "the old server could not start to complete crash recovery"
+  as_postgres "$OLD_BINDIR/pg_ctl" -D "$PGDATA" -w -t 600 -m fast stop >/dev/null 2>&1 \
+    || die 3 "the old server did not shut down cleanly after recovery"
+
+  state="$(cluster_state)"
+  case "$state" in
+    "shut down"|"shut down in recovery") log "cluster is now cleanly shut down" ;;
+    *) die 3 "cluster still not cleanly shut down (state: $state)" ;;
+  esac
+}
+
+check_from_major() {
+  local major
+  major="$(data_major)"
+  [ -n "$major" ] || die 2 "no PG_VERSION found at $PGDATA — nothing to upgrade"
+  if [ "$major" != "$FROM_MAJOR" ]; then
+    die 2 "data directory is major $major, this job upgrades $FROM_MAJOR -> $TO_MAJOR"
+  fi
+}
+
+# ----- initdb of the target cluster ------------------------------------------
+
+# Match the old cluster's page-checksum setting; pg_upgrade requires parity.
+checksum_flag() {
+  local version
+  version="$("$OLD_BINDIR/pg_controldata" "$PGDATA" 2>/dev/null | awk -F: '/Data page checksum version/ {gsub(/ /,"",$2); print $2}')"
+  if [ -n "$version" ] && [ "$version" != "0" ]; then
+    echo "--data-checksums"
+  fi
+}
+
+init_new_cluster() {
+  local target_dir="$1"
+  rm -rf "$target_dir"
+  as_postgres mkdir -p "$target_dir"
+  # Locale/encoding inherit the image defaults, which match how the runtime
+  # image initdb'd the old cluster; pg_upgrade --check verifies the pairing
+  # and aborts on any mismatch before anything is touched.
+  # shellcheck disable=SC2046
+  as_postgres "$NEW_BINDIR/initdb" $(checksum_flag) --username=postgres -D "$target_dir" >/dev/null \
+    || die 3 "initdb of the target cluster failed"
+}
+
+run_pg_upgrade() {
+  local extra="$1" new_dir="$2" out rc
+  cd /tmp || die 3 "cannot cd to /tmp"
+  out=$(as_postgres "$NEW_BINDIR/pg_upgrade" \
+    --old-bindir "$OLD_BINDIR" \
+    --new-bindir "$NEW_BINDIR" \
+    --old-datadir "$PGDATA" \
+    --new-datadir "$new_dir" \
+    --username=postgres \
+    --jobs "$(nproc)" \
+    $extra 2>&1)
+  rc=$?
+  echo "$out"
+  return $rc
+}
+
+# pg_upgrade --check prints its findings to stdout and detail files into cwd.
+print_check_details() {
+  for f in /tmp/pg_upgrade_output.d/*/*.txt /tmp/*.txt; do
+    [ -f "$f" ] || continue
+    echo "----- $(basename "$f") -----"
+    cat "$f"
+  done
+}
+
+# ----- modes ------------------------------------------------------------------
+
+mode_status() {
+  local phase from to major
+  phase="$(read_marker_field phase)"
+  from="$(read_marker_field from)"
+  to="$(read_marker_field to)"
+  major="$(data_major)"
+  result "{\"ok\": true, \"mode\": \"status\", \"phase\": \"${phase:-none}\", \"from\": \"${from:-}\", \"to\": \"${to:-}\", \"dataMajor\": \"${major:-}\"}"
+  exit 0
+}
+
+mode_manifest() {
+  local list
+  list=$(ls /usr/share/postgresql/"$TO_MAJOR"/extension/*.control 2>/dev/null \
+    | sed 's|.*/||; s|\.control$||' | sort -u | jq -R . | jq -sc .)
+  result "{\"ok\": true, \"mode\": \"manifest\", \"targetMajor\": \"$TO_MAJOR\", \"extensions\": ${list:-[]}}"
+  exit 0
+}
+
+mode_check() {
+  check_mount
+  take_job_lock
+  clear_stale_pidfile
+  check_from_major
+  ensure_clean_shutdown
+
+  local tmp_new="/tmp/pg-upgrade-check-target"
+  init_new_cluster "$tmp_new"
+
+  local out
+  if out=$(run_pg_upgrade "--check" "$tmp_new"); then
+    log "$out"
+    rm -rf "$tmp_new"
+    result "{\"ok\": true, \"mode\": \"check\", \"from\": \"$FROM_MAJOR\", \"to\": \"$TO_MAJOR\"}"
+    exit 0
+  else
+    log "$out"
+    print_check_details
+    rm -rf "$tmp_new"
+    result "{\"ok\": false, \"mode\": \"check\", \"from\": \"$FROM_MAJOR\", \"to\": \"$TO_MAJOR\", \"error\": \"pg_upgrade --check found blockers\"}"
+    exit 1
+  fi
+}
+
+finish_swap() {
+  # $PGDATA holds the OLD cluster and the NEW one is complete: move old aside,
+  # promote new. Two renames; a crash between them leaves no $PGDATA, which
+  # the marker (phase=upgraded) makes recoverable — and which wrapper.sh
+  # refuses to boot into, so nothing can initdb over the gap.
+  if [ -d "$PGDATA" ] && [ "$(data_major)" = "$FROM_MAJOR" ]; then
+    mv "$PGDATA" "$OLD_KEEP_DIR" || die 3 "failed to move old data dir aside"
+  fi
+  if [ ! -d "$PGDATA" ]; then
+    [ -d "$NEW_DATA_DIR" ] || die 3 "no new data dir to promote — volume needs the pre-upgrade backup"
+    mv "$NEW_DATA_DIR" "$PGDATA" || die 3 "failed to promote new data dir"
+  fi
+
+  write_marker "$(jq -nc \
+    --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" --arg old "$(basename "$OLD_KEEP_DIR")" \
+    '{phase: "completed", from: $from, to: $to, oldDataDir: $old, needsAnalyze: true, completedAt: (now | todate)}')"
+  log "upgrade $FROM_MAJOR -> $TO_MAJOR complete"
+  result "{\"ok\": true, \"mode\": \"upgrade\", \"phase\": \"completed\", \"from\": \"$FROM_MAJOR\", \"to\": \"$TO_MAJOR\"}"
+  exit 0
+}
+
+mode_upgrade() {
+  check_mount
+  take_job_lock
+
+  # Resume handling: the marker decides, never guesswork.
+  case "$(read_marker_field phase)" in
+    completed)
+      log "marker says completed — nothing to do"
+      result "{\"ok\": true, \"mode\": \"upgrade\", \"phase\": \"completed\", \"alreadyDone\": true}"
+      exit 0
+      ;;
+    upgraded)
+      log "marker says upgraded — resuming directory swap"
+      finish_swap
+      ;;
+  esac
+
+  check_from_major
+  clear_stale_pidfile
+  ensure_clean_shutdown
+  init_new_cluster "$NEW_DATA_DIR"
+
+  local out
+  if ! out=$(run_pg_upgrade "--check" "$NEW_DATA_DIR"); then
+    log "$out"
+    print_check_details
+    rm -rf "$NEW_DATA_DIR"
+    result "{\"ok\": false, \"mode\": \"upgrade\", \"from\": \"$FROM_MAJOR\", \"to\": \"$TO_MAJOR\", \"error\": \"pg_upgrade --check found blockers\"}"
+    exit 1
+  fi
+  log "$out"
+
+  if ! out=$(run_pg_upgrade "--link" "$NEW_DATA_DIR"); then
+    log "$out"
+    # No marker was written: the old cluster may have been modified by
+    # pg_upgrade's failed run and MUST NOT be restarted in place. The
+    # workflow rolls back to the pre-upgrade backup.
+    rm -rf "$NEW_DATA_DIR"
+    result "{\"ok\": false, \"mode\": \"upgrade\", \"from\": \"$FROM_MAJOR\", \"to\": \"$TO_MAJOR\", \"error\": \"pg_upgrade failed after check passed\"}"
+    exit 3
+  fi
+  log "$out"
+
+  # THE commit point: from here recovery always rolls forward.
+  write_marker "$(jq -nc \
+    --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" \
+    '{phase: "upgraded", from: $from, to: $to, upgradedAt: (now | todate)}')"
+
+  finish_swap
+}
+
+case "$MODE" in
+  check) mode_check ;;
+  upgrade) mode_upgrade ;;
+  status) mode_status ;;
+  manifest) mode_manifest ;;
+  *) die 2 "unknown mode '$MODE' (expected check|upgrade|status|manifest)" ;;
+esac

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -54,6 +54,15 @@ TO_MAJOR="${PG_UPGRADE_TO:?PG_UPGRADE_TO not set}"
 
 EXPECTED_VOLUME_MOUNT_PATH="/var/lib/postgresql/data"
 VOLUME_ROOT="$EXPECTED_VOLUME_MOUNT_PATH"
+# The dispatcher must pass the SERVICE's own PGDATA to this container. The
+# `:-` default below never applies in practice: the official postgres base
+# image this job is built FROM exports PGDATA=/var/lib/postgresql/data — the
+# volume ROOT — so a dispatch that doesn't set PGDATA is refused by
+# check_mount ("PGDATA is the volume root") rather than defaulting to the
+# pgdata subdir. In production the job runs as a deployment of the database
+# service and inherits its variables, which include the real PGDATA; any
+# ad-hoc `docker run` (harnesses, manual recovery) needs `-e PGDATA=…` —
+# postgres-ha's t_ha_major_upgrade_full_choreography hit exactly this.
 PGDATA="${PGDATA:-$VOLUME_ROOT/pgdata}"
 # Strip trailing slashes. Every sibling path below is built by appending a
 # suffix to $PGDATA, so "…/pgdata/" would put the new cluster INSIDE the data

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -8,8 +8,16 @@
 #
 # Modes (first argument, default "upgrade"):
 #   check    — initdb a throwaway target cluster and run pg_upgrade --check.
-#              Read-only with respect to the volume. Exit 0 = upgradeable,
-#              exit 1 = blockers (printed), exit 2 = precondition failure.
+#              Exit 0 = upgradeable, exit 1 = blockers (printed), exit 2 =
+#              precondition failure. NOT strictly read-only: a cluster that
+#              was not shut down cleanly (the platform stops containers with
+#              SIGKILL, so that is the common case) is first quiesced —
+#              start the old server, replay its WAL, shut down cleanly —
+#              which is exactly what the next normal boot would have done.
+#              Only a cleanly-shut-down volume is checked without writes.
+#              Volumes with recovery.signal / standby.signal are refused
+#              outright (exit 2) in both modes: quiescing would consume the
+#              recovery intent, and those shapes can't be upgraded in place.
 #   upgrade  — the real thing: --check first, then pg_upgrade --link into a
 #              new data dir on the volume, write the completion marker (the
 #              commit point), then swap directories. Crash-safe: re-running
@@ -47,6 +55,11 @@ TO_MAJOR="${PG_UPGRADE_TO:?PG_UPGRADE_TO not set}"
 EXPECTED_VOLUME_MOUNT_PATH="/var/lib/postgresql/data"
 VOLUME_ROOT="$EXPECTED_VOLUME_MOUNT_PATH"
 PGDATA="${PGDATA:-$VOLUME_ROOT/pgdata}"
+# Strip trailing slashes. Every sibling path below is built by appending a
+# suffix to $PGDATA, so "…/pgdata/" would put the new cluster INSIDE the data
+# dir ("…/pgdata/.upgrade-17") — the swap's first rename then orphans it and
+# the volume wedges at phase=upgraded forever.
+while [ "${PGDATA%/}" != "$PGDATA" ] && [ -n "${PGDATA%/}" ]; do PGDATA="${PGDATA%/}"; done
 MARKER_FILE="$VOLUME_ROOT/.railway-major-upgrade.json"
 
 OLD_BINDIR="/usr/lib/postgresql/${FROM_MAJOR}/bin"
@@ -75,14 +88,21 @@ read_marker_field() {
   jq -r ".$1" "$MARKER_FILE" 2>/dev/null | sed 's/^null$//'
 }
 
+# The marker is the commit point — it must be durable before we act on it,
+# so every step is checked and fatal. die(3) here fires BEFORE the caller
+# mutates any directory: after pg_upgrade the old cluster's pg_control has
+# been renamed away, so proceeding on a marker that may not exist would
+# leave a volume neither direction can interpret. The rename itself is only
+# durable once the PARENT DIRECTORY is fsynced — syncing the file alone
+# leaves the new directory entry volatile on ext4/xfs.
 write_marker() {
   local json="$1"
   local tmp="${MARKER_FILE}.tmp"
-  echo "$json" > "$tmp"
-  # The marker is the commit point — it must be durable before we act on it.
-  sync "$tmp"
-  mv "$tmp" "$MARKER_FILE"
-  sync "$MARKER_FILE" 2>/dev/null || sync
+  echo "$json" > "$tmp" || die 3 "failed to write the upgrade marker temp file"
+  sync "$tmp" || die 3 "failed to fsync the upgrade marker temp file"
+  mv "$tmp" "$MARKER_FILE" || die 3 "failed to move the upgrade marker into place"
+  sync "$MARKER_FILE" || die 3 "failed to fsync the upgrade marker"
+  sync "$VOLUME_ROOT" 2>/dev/null || sync || die 3 "failed to fsync the volume root after the marker rename"
 }
 
 as_postgres() {
@@ -117,18 +137,23 @@ check_mount() {
 
 JOB_LOCK_FILE="$VOLUME_ROOT/.railway-major-upgrade.lock"
 
-# Exclude a second upgrade job on the same volume. This is the hazard that can
-# actually happen (an activity retry racing a still-running attempt); a
-# postgres running in ANOTHER container is not detectable from here — separate
-# PID and IPC namespaces make postmaster.pid's liveness and shmem checks
-# meaningless across containers — and is excluded by the orchestrator instead
-# (volume lock + service maintenance restriction + the deploy pipeline
-# stopping the incumbent before this container starts).
+# Exclusive flock on the volume-root lock file, held for this job's lifetime.
+# The runtime image (wrapper.sh) holds the SAME file with a SHARED flock for
+# its container's whole life, so this excludes BOTH hazards that share the
+# volume: a second upgrade job (an activity retry racing a still-running
+# attempt) and a live database container the orchestrator failed to stop —
+# postmaster.pid can't detect the latter (separate PID/IPC namespaces make
+# its liveness and shmem checks meaningless across containers), but the
+# flock, living in the shared filesystem, can. The orchestrator's own
+# exclusion (volume lock + service maintenance restriction + stopping the
+# incumbent before this container starts) remains the first line of defense;
+# this is the in-image backstop that turns a workflow bug into a refusal
+# instead of a corrupted volume.
 take_job_lock() {
   command -v flock >/dev/null 2>&1 || return 0
-  exec 9>"$JOB_LOCK_FILE" || return 0
+  exec 9>>"$JOB_LOCK_FILE" || return 0
   if ! flock -n 9; then
-    die 2 "another upgrade job is already running on this volume"
+    die 2 "the volume is in use — another upgrade job, or a still-running database container, holds the upgrade lock"
   fi
 }
 
@@ -312,8 +337,22 @@ mode_manifest() {
 mode_check() {
   check_mount
   take_job_lock
+
+  # A marker mid-upgrade means the volume's state belongs to the upgrade
+  # workflow, not to a preflight: name that instead of failing on whatever
+  # half-swapped shape the disk happens to be in.
+  local phase
+  phase="$(read_marker_field phase)"
+  if [ -n "$phase" ] && [ "$phase" != "completed" ]; then
+    die 2 "a major upgrade is already in progress on this volume (marker phase: $phase) — resolve it before running check"
+  fi
+
   clear_stale_pidfile
   check_from_major
+  refuse_recovery_shapes
+  # Quiesces an unclean cluster (WAL replay + clean shutdown — what the next
+  # normal boot would do); see the header for why check is only strictly
+  # read-only on a cleanly-shut-down volume.
   ensure_clean_shutdown
 
   local tmp_new="/tmp/pg-upgrade-check-target"

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -20,10 +20,21 @@
 #              Feeds the dashboard preflight's extension check.
 #
 # Marker contract (volume root, .railway-major-upgrade.json):
-#   absent               — nothing committed; any failure rolls back.
+#   absent               — nothing committed; any failure rolls back. One
+#                          exception: when the disk shape itself proves
+#                          pg_upgrade finished (old cluster's pg_control
+#                          renamed to pg_control.old AND the new dir's
+#                          PG_VERSION is the target major), upgrade mode
+#                          rolls FORWARD — the old cluster can no longer be
+#                          started, so a lost marker must not brick the
+#                          volume.
 #   phase == "upgraded"  — pg_upgrade succeeded; directory swap may be
 #                          incomplete. Roll FORWARD (re-run upgrade mode).
 #   phase == "completed" — swap done; the runtime image of TO major boots.
+# Both phases are scoped to the marker's own (from, to) pair: a completed
+# marker of a PREVIOUS pair is history, not state — the job proceeds when
+# the data major matches its FROM (and overwrites the marker at its own
+# commit point); an in-flight marker of a foreign pair is refused outright.
 # The runtime wrapper.sh refuses to boot while a non-completed marker exists,
 # and refuses an image/data major mismatch, so no mismatched boot can ever
 # touch the data directory.
@@ -138,6 +149,21 @@ cluster_state() {
     | awk -F: '/Database cluster state/ {sub(/^ +/,"",$2); print $2}'
 }
 
+# A recovery.signal or standby.signal volume can't be upgraded in place:
+# it's a standby or a mid-restore cluster whose recovery intent lives in
+# those files, and ensure_clean_shutdown's quiesce would CONSUME them —
+# postgres eats recovery.signal on promote — silently turning a
+# point-in-time restore into "whatever WAL happened to be local". Refuse
+# loudly in both modes, before anything touches the cluster.
+refuse_recovery_shapes() {
+  local sig
+  for sig in recovery.signal standby.signal; do
+    if [ -f "$PGDATA/$sig" ]; then
+      die 2 "$PGDATA/$sig is present — this cluster is mid-recovery or a standby, which cannot be upgraded in place. Let recovery finish (or promote the standby), then re-run."
+    fi
+  done
+}
+
 # pg_upgrade refuses a cluster that was not shut down cleanly, and it is right
 # to: unreplayed WAL would be silently dropped by --link. A container killed
 # mid-flight leaves exactly that state, so recover it here — start the OLD
@@ -182,12 +208,48 @@ check_from_major() {
 # ----- initdb of the target cluster ------------------------------------------
 
 # Match the old cluster's page-checksum setting; pg_upgrade requires parity.
+# Both directions must be EXPLICIT: initdb's default flipped to checksums-ON
+# in PostgreSQL 18, so a checksums-off source (the fleet default for clusters
+# initdb'd before 18) meeting an 18 target's default fails --check with "old
+# cluster does not use data checksums but the new one does". Emit
+# --no-data-checksums when the target's initdb knows the flag (18+; older
+# initdb rejects it, and its default is off anyway).
 checksum_flag() {
   local version
   version="$("$OLD_BINDIR/pg_controldata" "$PGDATA" 2>/dev/null | awk -F: '/Data page checksum version/ {gsub(/ /,"",$2); print $2}')"
   if [ -n "$version" ] && [ "$version" != "0" ]; then
     echo "--data-checksums"
+  elif [ "$version" = "0" ] && "$NEW_BINDIR/initdb" --help 2>/dev/null | grep -q -- "--no-data-checksums"; then
+    echo "--no-data-checksums"
   fi
+}
+
+# Effective CPU allocation for --jobs: cgroup v2 cpu.max, then cgroup v1
+# cfs quota, then nproc. Same derivation as wrapper.sh's detect_cpus — a
+# Railway container's nproc reports the HOST's cores, so sizing off it
+# oversubscribes a small allocation badly (pg_upgrade forks per-database
+# workers that each fork dump/restore pipelines).
+detect_cpus() {
+  local quota period
+
+  if [ -r /sys/fs/cgroup/cpu.max ]; then
+    read -r quota period < /sys/fs/cgroup/cpu.max
+    if [ "$quota" != "max" ] && [ -n "$quota" ] && [ -n "$period" ] && [ "$period" -gt 0 ]; then
+      echo $(( (quota + period - 1) / period ))
+      return
+    fi
+  fi
+
+  if [ -r /sys/fs/cgroup/cpu/cpu.cfs_quota_us ] && [ -r /sys/fs/cgroup/cpu/cpu.cfs_period_us ]; then
+    quota=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+    period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+    if [ "$quota" -gt 0 ] && [ "$period" -gt 0 ]; then
+      echo $(( (quota + period - 1) / period ))
+      return
+    fi
+  fi
+
+  nproc 2>/dev/null || echo 1
 }
 
 init_new_cluster() {
@@ -211,7 +273,7 @@ run_pg_upgrade() {
     --old-datadir "$PGDATA" \
     --new-datadir "$new_dir" \
     --username=postgres \
-    --jobs "$(nproc)" \
+    --jobs "$(detect_cpus)" \
     $extra 2>&1)
   rc=$?
   echo "$out"
@@ -272,11 +334,56 @@ mode_check() {
   fi
 }
 
+# Carry per-cluster files the new data dir must inherit from the old one,
+# called before the swap's renames (idempotent — re-copying from the same
+# source on a resume is a no-op in effect):
+#
+#   pg_hba.conf / pg_ident.conf — the new cluster's copies are bare initdb
+#     defaults, which lack the `host all all all <method>` line the official
+#     entrypoint appends at init time (and any custom rules the user added).
+#     Without the carry, every remote client gets "no pg_hba.conf entry"
+#     after the upgrade — localhost still works via the default local trust
+#     line, which is exactly why it's easy to miss. wrapper.sh additionally
+#     self-heals a missing host line from config state (belt and braces).
+#
+#   .pitr_configured / .pitr_staging / .pgbackrest_restored — PITR lifecycle
+#     sentinels that live inside $PGDATA but describe VOLUME-level history.
+#     A PITR-restored fork keeps WAL_RECOVER_FROM_* + POSTGRES_RECOVERY_TARGET_TIME
+#     set forever; only these sentinels tell wrapper.sh that recovery already
+#     promoted. Losing them to the swap makes the next boot re-stage archive
+#     recovery against the source bucket and the database never becomes
+#     ready. wrapper.sh also treats a completed upgrade marker as proof of
+#     promoted recovery (defense in depth); this carry keeps the sentinels
+#     themselves truthful.
+carry_cluster_config() {
+  local src="$1" dst="$2" f
+  for f in pg_hba.conf pg_ident.conf; do
+    [ -f "$src/$f" ] || continue
+    cp -p "$src/$f" "$dst/$f" || die 3 "failed to carry $f into the new data dir"
+  done
+  for f in .pitr_configured .pitr_staging .pgbackrest_restored; do
+    [ -f "$src/$f" ] || continue
+    cp -p "$src/$f" "$dst/$f" || die 3 "failed to carry $f into the new data dir"
+  done
+}
+
 finish_swap() {
   # $PGDATA holds the OLD cluster and the NEW one is complete: move old aside,
   # promote new. Two renames; a crash between them leaves no $PGDATA, which
   # the marker (phase=upgraded) makes recoverable — and which wrapper.sh
   # refuses to boot into, so nothing can initdb over the gap.
+  #
+  # Before the renames, carry auth config + PITR sentinels from wherever the
+  # old cluster currently sits (still at $PGDATA on a first pass, already
+  # moved aside on a resume after a crash between the renames).
+  if [ -d "$NEW_DATA_DIR" ]; then
+    if [ -d "$PGDATA" ] && [ "$(data_major)" = "$FROM_MAJOR" ]; then
+      carry_cluster_config "$PGDATA" "$NEW_DATA_DIR"
+    elif [ -d "$OLD_KEEP_DIR" ]; then
+      carry_cluster_config "$OLD_KEEP_DIR" "$NEW_DATA_DIR"
+    fi
+  fi
+
   if [ -d "$PGDATA" ] && [ "$(data_major)" = "$FROM_MAJOR" ]; then
     mv "$PGDATA" "$OLD_KEEP_DIR" || die 3 "failed to move old data dir aside"
   fi
@@ -297,21 +404,59 @@ mode_upgrade() {
   check_mount
   take_job_lock
 
-  # Resume handling: the marker decides, never guesswork.
-  case "$(read_marker_field phase)" in
+  # Resume handling: the marker decides, but only for THIS job's version
+  # pair. Markers are never deleted after an upgrade, so a later upgrade of
+  # the same volume (16→17 done, now 17→18) finds the previous pair's
+  # completed marker — reading that as "already done" would report success
+  # while the data stays on the old major, and the workflow would flip the
+  # image tag into a boot refusal.
+  local marker_phase marker_from marker_to
+  marker_phase="$(read_marker_field phase)"
+  marker_from="$(read_marker_field from)"
+  marker_to="$(read_marker_field to)"
+  case "$marker_phase" in
     completed)
-      log "marker says completed — nothing to do"
-      result "{\"ok\": true, \"mode\": \"upgrade\", \"phase\": \"completed\", \"alreadyDone\": true}"
-      exit 0
+      if [ "$marker_to" = "$TO_MAJOR" ]; then
+        log "marker says completed for ${marker_from:-?} -> $TO_MAJOR — nothing to do"
+        result "{\"ok\": true, \"mode\": \"upgrade\", \"phase\": \"completed\", \"alreadyDone\": true}"
+        exit 0
+      fi
+      if [ "$(data_major)" != "$FROM_MAJOR" ]; then
+        die 2 "marker records a completed ${marker_from:-?} -> ${marker_to:-?} upgrade but the data directory is major '$(data_major)'; this job upgrades $FROM_MAJOR -> $TO_MAJOR"
+      fi
+      log "marker records a completed ${marker_from:-?} -> ${marker_to:-?} upgrade (history); data is $FROM_MAJOR — proceeding with $FROM_MAJOR -> $TO_MAJOR"
       ;;
     upgraded)
+      # A foreign-pair in-flight marker must NOT drive finish_swap: this
+      # job's NEW_DATA_DIR/OLD_KEEP_DIR names embed ITS majors, so it would
+      # be swapping directories that belong to a different job. Refuse
+      # loudly; only the matching pair's job can resolve the volume.
+      if [ "$marker_from" != "$FROM_MAJOR" ] || [ "$marker_to" != "$TO_MAJOR" ]; then
+        die 2 "marker records an in-flight ${marker_from:-?} -> ${marker_to:-?} upgrade; this job ($FROM_MAJOR -> $TO_MAJOR) refuses to finish another pair's swap — run the ${marker_from:-?}-${marker_to:-?} job to resolve it"
+      fi
       log "marker says upgraded — resuming directory swap"
       finish_swap
+      ;;
+    "")
+      # No marker, but the disk shape can still prove pg_upgrade finished:
+      # --link renames the old cluster's pg_control to pg_control.old as its
+      # last act, and the new data dir carries the target major's
+      # PG_VERSION. If the marker write was lost (crash after pg_upgrade,
+      # or a marker durability failure on an earlier image), this is the
+      # only window where "no marker" does NOT mean "roll back" — the old
+      # cluster can't be restarted (pg_control is gone), so roll forward.
+      # This keeps the marker from being a single point of failure.
+      if [ -f "$PGDATA/global/pg_control.old" ] \
+        && [ "$(cat "$NEW_DATA_DIR/PG_VERSION" 2>/dev/null)" = "$TO_MAJOR" ]; then
+        log "no marker, but the disk shape shows a finished pg_upgrade (pg_control.old present, new dir is $TO_MAJOR) — resuming directory swap"
+        finish_swap
+      fi
       ;;
   esac
 
   check_from_major
   clear_stale_pidfile
+  refuse_recovery_shapes
   ensure_clean_shutdown
   init_new_cluster "$NEW_DATA_DIR"
 

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -431,9 +431,16 @@ finish_swap() {
     mv "$NEW_DATA_DIR" "$PGDATA" || die 3 "failed to promote new data dir"
   fi
 
+  # needsReindex: pg_upgrade preserves index FILES verbatim, but any index on
+  # collatable columns (text/varchar btree) is only valid for the glibc that
+  # built it — and the source cluster may have run on an older base image.
+  # We can't read the OLD runtime image's glibc from here, so record the flag
+  # unconditionally and let the operator/dashboard drive the REINDEX; an
+  # automatic REINDEX of an arbitrarily large database inside the upgrade
+  # window is the wrong default (documented follow-up in the README).
   write_marker "$(jq -nc \
     --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" --arg old "$(basename "$OLD_KEEP_DIR")" \
-    '{phase: "completed", from: $from, to: $to, oldDataDir: $old, needsAnalyze: true, completedAt: (now | todate)}')"
+    '{phase: "completed", from: $from, to: $to, oldDataDir: $old, needsAnalyze: true, needsReindex: true, completedAt: (now | todate)}')"
   log "upgrade $FROM_MAJOR -> $TO_MAJOR complete"
   result "{\"ok\": true, \"mode\": \"upgrade\", \"phase\": \"completed\", \"from\": \"$FROM_MAJOR\", \"to\": \"$TO_MAJOR\"}"
   exit 0

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -178,21 +178,31 @@ die() {
 # and appends startCommand as further args), so no single startCommand value
 # selects a mode on both. UPGRADE_JOB_MODE sidesteps that entirely — it
 # reaches the container the same way every other service variable already
-# does, regardless of which runtime or image is in play. Positional args are
-# kept only as a fallback for local/manual runs and the e2e harness, which
-# invoke this script directly (`upgrade-job.sh <mode>`) rather than through a
-# Railway deployment — and an unrecognized one dies rather than falling
-# through to the "upgrade" default: silently running the destructive path on
-# a typo'd read-only mode is exactly the failure this fallback must not have,
-# since manual/incident-response invocation is the only place it's reachable.
+# does, regardless of which runtime or image is in play.
+#
+# On Railway this env var is the ONLY dispatch mechanism, full stop — never
+# fall back to argv there. The image's own CMD ["upgrade"] always supplies a
+# recognized positional arg ($1="upgrade") on every real container start
+# regardless of runtime, so if the env var were ever lost (a mono-side bug,
+# a variable-injection regression), scanning argv would silently find
+# "upgrade" and run the single most destructive mode there is — including on
+# a resume dispatch that only meant to run `status` to decide roll-back vs
+# roll-forward. RAILWAY_ENVIRONMENT (same discriminator check_mount already
+# uses below) distinguishes a real deployment from local/manual/e2e use,
+# where positional args are the only invocation method and stay supported.
 MODE="${UPGRADE_JOB_MODE:-}"
-if [ -z "$MODE" ] && [ "$#" -gt 0 ]; then
-  for _arg in "$@"; do
-    case "$_arg" in
-      check | upgrade | status | manifest) MODE="$_arg" ;;
-    esac
-  done
-  [ -n "$MODE" ] || die 2 "no recognized mode among arguments: $* (expected one of: check, upgrade, status, manifest)"
+if [ -z "$MODE" ]; then
+  if [ -n "${RAILWAY_ENVIRONMENT:-}" ]; then
+    die 2 "UPGRADE_JOB_MODE is not set on a Railway deployment — refusing to guess a mode from argv (the image's own CMD supplies one, which would silently run the wrong mode)"
+  fi
+  if [ "$#" -gt 0 ]; then
+    for _arg in "$@"; do
+      case "$_arg" in
+        check | upgrade | status | manifest) MODE="$_arg" ;;
+      esac
+    done
+    [ -n "$MODE" ] || die 2 "no recognized mode among arguments: $* (expected one of: check, upgrade, status, manifest)"
+  fi
 fi
 MODE="${MODE:-upgrade}"
 
@@ -338,6 +348,18 @@ refuse_recovery_shapes() {
 # mid-flight leaves exactly that state, so recover it here — start the OLD
 # server so it replays its WAL, then shut it down cleanly. Isolated to a unix
 # socket in /tmp with no TCP listener, so nothing can connect meanwhile.
+#
+# On a PITR-enabled volume this server still has archive_mode/archive_command
+# configured (conf.d/pgbackrest.conf lives in PGDATA), and this image ships
+# no pgbackrest — every segment it tries to archive fails loudly (exit 127)
+# for the whole quiesce. That's the correct behavior, not noise to silence:
+# the segments stay .ready, nothing gets falsely marked archived, and a
+# rollback to the old image resumes pushing them. "Fixing" the log spam with
+# archive_command=/bin/true or -c archive_mode=off would punch a real WAL
+# hole into the rollback path. The unavoidable side effect either way: WAL
+# written between the last successful push and the upgrade never reaches the
+# old archive prefix — the pre-upgrade backup is what covers that point, not
+# the archive.
 ensure_clean_shutdown() {
   local state
   state="$(cluster_state)"
@@ -479,13 +501,14 @@ init_new_cluster() {
   # cluster the image-default initdb can never pair with. Replay the same
   # env the same way (eval, mirroring docker-entrypoint's quoting; the var
   # is the operator's own service variable, the exact trust the entrypoint
-  # already extends at every init). Our flags come LAST so --username and
-  # -D always win over anything in the user args; checksum parity stays
-  # owned by checksum_flag, derived from the old cluster's pg_controldata —
-  # which already reflects whatever the init args chose. pg_upgrade --check
-  # remains the final arbiter of the pairing. The superuser must be the OLD
-  # cluster's install user (see PG_SUPERUSER).
-  eval 'as_postgres "$NEW_BINDIR/initdb" '"$(checksum_flag) ${POSTGRES_INITDB_ARGS:-}"' --username="$PG_SUPERUSER" -D "$target_dir"' >/dev/null \
+  # already extends at every init). checksum_flag comes AFTER the user args
+  # (initdb is last-wins on a repeated toggle flag) so a stale --data-
+  # checksums/--no-data-checksums the user happened to carry in the var can
+  # never override the parity this job derived from the OLD cluster's own
+  # pg_controldata — --username and -D come last of all so they always win
+  # too. pg_upgrade --check remains the final arbiter of the pairing. The
+  # superuser must be the OLD cluster's install user (see PG_SUPERUSER).
+  eval 'as_postgres "$NEW_BINDIR/initdb" '"${POSTGRES_INITDB_ARGS:-} $(checksum_flag)"' --username="$PG_SUPERUSER" -D "$target_dir"' >/dev/null \
     || die 3 "initdb of the target cluster failed"
 }
 
@@ -548,6 +571,12 @@ print_check_details() {
 # ----- modes ------------------------------------------------------------------
 
 mode_status() {
+  # check and upgrade both refuse on a bad mount; status must too — the
+  # workflow's roll-back/roll-forward decision needs the mount to actually
+  # be the volume it thinks it's reading, not a report that's
+  # byte-identical in shape to "fresh volume, nothing has ever happened
+  # here" for a container whose volume didn't attach right.
+  check_mount
   local phase from to major
   if [ -f "$MARKER_FILE" ] && [ -z "$(read_marker_field phase)" ]; then
     # A marker that exists but can't be read (or has no phase) means an
@@ -692,7 +721,7 @@ finish_swap() {
   # data dir at all" when the new dir was lost or is a partial initdb.
   if [ "$(data_major)" != "$TO_MAJOR" ] \
     && [ "$(cat "$NEW_DATA_DIR/PG_VERSION" 2>/dev/null)" != "$TO_MAJOR" ]; then
-    die 3 "cannot finish the swap: $NEW_DATA_DIR is missing or is not a $TO_MAJOR cluster — volume left untouched; restore the pre-upgrade backup or re-run the upgrade from scratch"
+    die 3 "cannot finish the swap: $NEW_DATA_DIR is missing or is not a $TO_MAJOR cluster — volume left untouched; a plain re-run dies here again (the marker still says upgraded), restore the pre-upgrade backup or remove the marker to redo pg_upgrade from scratch"
   fi
 
   # Before the renames, carry auth config + PITR sentinels from wherever the

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -60,6 +60,17 @@ set -uo pipefail
 FROM_MAJOR="${PG_UPGRADE_FROM:?PG_UPGRADE_FROM not set}"
 TO_MAJOR="${PG_UPGRADE_TO:?PG_UPGRADE_TO not set}"
 
+# The job inherits the service's own variables (that's how it gets PGDATA),
+# and both the postgres-ha and standalone postgres templates default
+# PGHOST=${{ RAILWAY_PRIVATE_DOMAIN }} — a common app-side pattern. pg_upgrade
+# reads libpq env vars directly and REFUSES outright on a non-local PGHOST
+# ("libpq environment variable PGHOST has a non-local server value"),
+# blocking --check before anything is touched. Same hazard wrapper.sh already
+# unsets for pgbackrest's libpq calls; this job only ever talks to Postgres
+# over the local socket, so clear both unconditionally.
+unset PGHOST
+unset PGPORT
+
 # PG_SUPERUSER (the cluster's INSTALL user) is resolved below, after PGDATA
 # is normalized — which env var names it depends on the template family, and
 # the discriminator is on the volume itself.

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -33,11 +33,16 @@
 #   absent               — nothing committed; any failure rolls back. One
 #                          exception: when the disk shape itself proves
 #                          pg_upgrade finished (old cluster's pg_control
-#                          renamed to pg_control.old AND the new dir's
-#                          PG_VERSION is the target major), upgrade mode
-#                          rolls FORWARD — the old cluster can no longer be
-#                          started, so a lost marker must not brick the
-#                          volume.
+#                          renamed to pg_control.old AND the job's own
+#                          completion sentinel inside the target-major new
+#                          dir), upgrade mode rolls FORWARD — a lost marker
+#                          must not brick the volume. pg_control.old alone
+#                          proves only that pg_upgrade STARTED linking (the
+#                          rename lands before the first user file is
+#                          linked — verified empirically), so without the
+#                          sentinel the job rolls BACK instead: it reverses
+#                          the rename (safe while the new cluster has never
+#                          been started) and redoes the upgrade.
 #   phase == "upgraded"  — pg_upgrade succeeded; directory swap may be
 #                          incomplete. Roll FORWARD (re-run upgrade mode).
 #   phase == "completed" — swap done; the runtime image of TO major boots.
@@ -63,6 +68,21 @@ TO_MAJOR="${PG_UPGRADE_TO:?PG_UPGRADE_TO not set}"
 # the right name there; ad-hoc runs against a custom-user volume need -e.
 PG_SUPERUSER="${POSTGRES_USER:-postgres}"
 
+# The quiesce (WAL replay + clean stop) shares this timeout for both the
+# start and the stop. An interrupted crash recovery persists NO progress —
+# verified empirically (killed while pg_control said "in crash recovery":
+# the checkpoint pointer had not moved): restartpoints can only land on
+# replayed CHECKPOINT records, and the replay range — the last completed
+# checkpoint's redo point to WAL end — contains none by construction. So
+# every retry replays the same WAL from scratch, and a volume whose replay
+# genuinely outruns this timeout (a customer-raised max_wal_size on a slow
+# disk) would die 3 forever with no way to give it more time short of
+# editing the image. The job is already a stop-the-world window; a generous
+# override costs nothing. pg_ctl's timeout also does NOT stop the server —
+# it keeps recovering until this container's exit SIGKILLs it, which is the
+# same unclean state we started from.
+UPGRADE_QUIESCE_TIMEOUT_SECONDS="${UPGRADE_QUIESCE_TIMEOUT_SECONDS:-600}"
+
 EXPECTED_VOLUME_MOUNT_PATH="/var/lib/postgresql/data"
 VOLUME_ROOT="$EXPECTED_VOLUME_MOUNT_PATH"
 # The dispatcher must pass the SERVICE's own PGDATA to this container. The
@@ -87,9 +107,39 @@ NEW_BINDIR="/usr/lib/postgresql/${TO_MAJOR}/bin"
 NEW_DATA_DIR="${PGDATA}.upgrade-${TO_MAJOR}"
 OLD_KEEP_DIR="${PGDATA}.old-${FROM_MAJOR}"
 
-MODE="${1:-upgrade}"
+# Scan every positional arg for a recognized mode instead of trusting $1
+# alone. Railway's two container runtimes disagree on how a deployment's
+# startCommand combines with the image's own ENTRYPOINT: one REPLACES the
+# entrypoint outright (so the dispatcher must send the script name itself,
+# "upgrade-job.sh <mode>", or the exec target is a nonexistent program named
+# literally "check"/"upgrade"), the other KEEPS the entrypoint and appends
+# startCommand as further args (so that same two-word command arrives as
+# "upgrade-job.sh upgrade-job.sh <mode>" — the script's own name twice). A
+# bare positional read ($1) is correct for only one of those two shapes;
+# scanning for the first arg that IS a known mode is correct for both, and
+# for every existing bare-mode caller (local runs, the e2e harness) too.
+MODE="upgrade"
+for _arg in "$@"; do
+  case "$_arg" in
+    check | upgrade | status | manifest) MODE="$_arg" ;;
+  esac
+done
 
 log() { echo "upgrade-job: $*"; }
+# pg_upgrade's own combined output is forwarded verbatim for diagnosability,
+# and it can embed attacker-chosen bytes: a database/role/tablespace name a
+# superuser controls can appear in its check messages, and Postgres allows a
+# literal newline inside a quoted identifier. The existing jq hardening on
+# RAILWAY_UPGRADE_RESULT closes value injection into OUR OWN payload, but a
+# crafted identifier containing "\nRAILWAY_UPGRADE_RESULT: {...}\n" would ride
+# through a bare `log "$out"` as an indistinguishable extra line — and the
+# real sentinel always prints last, so whichever scraping convention the
+# dispatcher uses, an attacker-controlled earlier line is the wrong thing to
+# risk matching. Prefix every line so none of them can start with the literal
+# sentinel string.
+log_upgrade_output() {
+  printf '%s\n' "$1" | sed 's/^/  pg_upgrade: /'
+}
 # Machine-readable result line the workflow scrapes from the job logs.
 result() {
   echo "RAILWAY_UPGRADE_RESULT: $1"
@@ -252,6 +302,9 @@ ensure_clean_shutdown() {
       return 0
       ;;
     "")
+      if [ -f "$PGDATA/global/pg_control.old" ]; then
+        die 2 "no pg_control at $PGDATA but pg_control.old exists — an interrupted pg_upgrade disabled this cluster; run upgrade mode, which restores it and re-runs"
+      fi
       die 2 "could not read cluster state from $PGDATA (pg_controldata failed)"
       ;;
   esac
@@ -262,11 +315,11 @@ ensure_clean_shutdown() {
   # discarding them leaves the job log with nothing but a generic message.
   local quiesce_log="/tmp/pg-quiesce.log"
   rm -f "$quiesce_log"
-  as_postgres "$OLD_BINDIR/pg_ctl" -D "$PGDATA" -w -t 600 -l "$quiesce_log" \
+  as_postgres "$OLD_BINDIR/pg_ctl" -D "$PGDATA" -w -t "$UPGRADE_QUIESCE_TIMEOUT_SECONDS" -l "$quiesce_log" \
     -o "-c listen_addresses='' -k /tmp" start >/dev/null 2>&1 \
-    || { print_quiesce_log "$quiesce_log"; die 3 "the old server could not start to complete crash recovery (server log above)"; }
-  as_postgres "$OLD_BINDIR/pg_ctl" -D "$PGDATA" -w -t 600 -m fast stop >/dev/null 2>&1 \
-    || { print_quiesce_log "$quiesce_log"; die 3 "the old server did not shut down cleanly after recovery (server log above)"; }
+    || { print_quiesce_log "$quiesce_log"; die 3 "the old server could not start to complete crash recovery within ${UPGRADE_QUIESCE_TIMEOUT_SECONDS}s (server log above; override with UPGRADE_QUIESCE_TIMEOUT_SECONDS)"; }
+  as_postgres "$OLD_BINDIR/pg_ctl" -D "$PGDATA" -w -t "$UPGRADE_QUIESCE_TIMEOUT_SECONDS" -m fast stop >/dev/null 2>&1 \
+    || { print_quiesce_log "$quiesce_log"; die 3 "the old server did not shut down cleanly after recovery within ${UPGRADE_QUIESCE_TIMEOUT_SECONDS}s (server log above)"; }
 
   state="$(cluster_state)"
   case "$state" in
@@ -280,6 +333,22 @@ print_quiesce_log() {
   echo "----- old server log ($1) -----"
   tail -100 "$1"
   echo "----- end of old server log -----"
+}
+
+# Reverse pg_upgrade's disable of the old cluster. pg_upgrade renames
+# global/pg_control to pg_control.old BEFORE it links the first user
+# relation file (verified empirically on 16->17; its own failure output
+# prescribes this rename-back as the recovery), so a crash anywhere in the
+# link phase leaves the old cluster intact but unstartable. Renaming back
+# is safe exactly while the NEW cluster has never been started — linking
+# never modifies the old cluster's files, and this job never starts the
+# target cluster — which is pg_upgrade's own documented criterion.
+restore_disabled_pg_control() {
+  [ -f "$PGDATA/global/pg_control.old" ] || return 0
+  [ -f "$PGDATA/global/pg_control" ] && return 0
+  mv "$PGDATA/global/pg_control.old" "$PGDATA/global/pg_control" \
+    || die 3 "pg_upgrade left the old cluster disabled (global/pg_control.old) and restoring it failed — restore the pre-upgrade backup"
+  log "restored global/pg_control — pg_upgrade had disabled the old cluster before linking; the old cluster is startable again"
 }
 
 check_from_major() {
@@ -400,9 +469,17 @@ probe_sibling_slot() {
   rm -rf "$probe"
 }
 
-# pg_upgrade --check prints its findings to stdout and detail files into cwd.
+# pg_upgrade --check writes its per-item detail files (and, on a failed
+# upgrade, its server/internal logs) under pg_upgrade_output.d INSIDE THE NEW
+# CLUSTER'S DATA DIRECTORY (since PG 15) — not the invocation cwd, whatever
+# the "into cwd" phrasing below used to assume. Verified empirically: a
+# failing --check leaves nothing under /tmp except the timestamped dir this
+# function must be pointed at. Getting this wrong doesn't just print nothing —
+# the caller then rm -rf's $new_dir, so an unmatched glob deletes the very
+# files it was supposed to show.
 print_check_details() {
-  for f in /tmp/pg_upgrade_output.d/*/*.txt /tmp/*.txt; do
+  local new_dir="$1"
+  for f in "$new_dir"/pg_upgrade_output.d/*/*.txt "$new_dir"/pg_upgrade_output.d/*/log/*.log; do
     [ -f "$f" ] || continue
     echo "----- $(basename "$f") -----"
     cat "$f"
@@ -461,14 +538,14 @@ mode_check() {
 
   local out
   if out=$(run_pg_upgrade "--check" "$tmp_new"); then
-    log "$out"
+    log_upgrade_output "$out"
     rm -rf "$tmp_new"
     result "$(jq -nc --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" \
       '{ok: true, mode: "check", from: $from, to: $to}')"
     exit 0
   else
-    log "$out"
-    print_check_details
+    log_upgrade_output "$out"
+    print_check_details "$tmp_new"
     rm -rf "$tmp_new"
     result "$(jq -nc --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" \
       '{ok: false, mode: "check", from: $from, to: $to, error: "pg_upgrade --check found blockers"}')"
@@ -567,6 +644,12 @@ finish_swap() {
     mv "$NEW_DATA_DIR" "$PGDATA" || die 3 "failed to promote new data dir"
   fi
 
+  # The completion sentinel has served its purpose once the swap is done;
+  # don't leave job bookkeeping inside the live data directory (pgbackrest
+  # would carry it into every backup). Best-effort: a survivor is inert —
+  # the marker-less resume only ever reads it inside a NEW_DATA_DIR sibling.
+  rm -f "$PGDATA/.railway_pg_upgrade_complete" 2>/dev/null || true
+
   # needsReindex: pg_upgrade preserves index FILES verbatim, but any index on
   # collatable columns (text/varchar btree) is only valid for the glibc that
   # built it — and the source cluster may have run on an older base image.
@@ -631,18 +714,28 @@ mode_upgrade() {
       finish_swap
       ;;
     "")
-      # No marker, but the disk shape can still prove pg_upgrade finished:
-      # --link renames the old cluster's pg_control to pg_control.old as its
-      # last act, and the new data dir carries the target major's
-      # PG_VERSION. If the marker write was lost (crash after pg_upgrade,
-      # or a marker durability failure on an earlier image), this is the
-      # only window where "no marker" does NOT mean "roll back" — the old
-      # cluster can't be restarted (pg_control is gone), so roll forward.
-      # This keeps the marker from being a single point of failure.
-      if [ -f "$PGDATA/global/pg_control.old" ] \
-        && [ "$(cat "$NEW_DATA_DIR/PG_VERSION" 2>/dev/null)" = "$TO_MAJOR" ]; then
-        log "no marker, but the disk shape shows a finished pg_upgrade (pg_control.old present, new dir is $TO_MAJOR) — resuming directory swap"
-        finish_swap
+      # No marker, but the disk can still say where pg_upgrade got to.
+      # pg_control.old proves only that pg_upgrade DISABLED the old cluster
+      # — the rename lands before the first user relation file is linked
+      # (verified empirically; pg_upgrade's own output prescribes the
+      # rename-back as the recovery) — so on its own it must never drive a
+      # roll-forward: a crash mid-link leaves exactly this shape around a
+      # PARTIALLY-linked target dir, and promoting that is data loss. The
+      # job's completion sentinel, written the moment pg_upgrade exits 0,
+      # is the proof of a FINISHED run whose marker write was lost: with
+      # both, roll forward — only the swap remains, and the marker stays a
+      # non-single-point-of-failure. With pg_control.old but no sentinel,
+      # roll BACK: reverse the rename (safe — the target cluster has never
+      # been started, and linking never modifies the old cluster's files)
+      # and let the normal flow below redo the upgrade from scratch.
+      if [ -f "$PGDATA/global/pg_control.old" ]; then
+        if [ -f "$NEW_DATA_DIR/.railway_pg_upgrade_complete" ] \
+          && [ "$(cat "$NEW_DATA_DIR/PG_VERSION" 2>/dev/null)" = "$TO_MAJOR" ]; then
+          log "no marker, but the disk shape shows a finished pg_upgrade (pg_control.old present, completion sentinel in the $TO_MAJOR dir) — resuming directory swap"
+          finish_swap
+        fi
+        log "pg_control.old present without a completion sentinel — pg_upgrade crashed mid-run; rolling back to the old cluster and re-running the upgrade"
+        restore_disabled_pg_control
       fi
       ;;
     *)
@@ -664,26 +757,44 @@ mode_upgrade() {
 
   local out
   if ! out=$(run_pg_upgrade "--check" "$NEW_DATA_DIR"); then
-    log "$out"
-    print_check_details
+    log_upgrade_output "$out"
+    print_check_details "$NEW_DATA_DIR"
     rm -rf "$NEW_DATA_DIR"
     result "$(jq -nc --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" \
       '{ok: false, mode: "upgrade", from: $from, to: $to, error: "pg_upgrade --check found blockers"}')"
     exit 1
   fi
-  log "$out"
+  log_upgrade_output "$out"
 
   if ! out=$(run_pg_upgrade "--link" "$NEW_DATA_DIR"); then
-    log "$out"
-    # No marker was written: the old cluster may have been modified by
-    # pg_upgrade's failed run and MUST NOT be restarted in place. The
-    # workflow rolls back to the pre-upgrade backup.
+    log_upgrade_output "$out"
+    # No marker was written, so this is a roll-back. print BEFORE rm -rf:
+    # this is the undiagnosable-failure case round 3 already worried about —
+    # pg_upgrade's own server/internal logs live under $NEW_DATA_DIR too, and
+    # would otherwise vanish with it, unread. If pg_upgrade got far enough
+    # to disable the old cluster (the pg_control rename lands before the
+    # first user file is linked), reverse that too: the target cluster was
+    # never started, so the old cluster's files are untouched and renaming
+    # pg_control back returns the volume to a bootable FROM-major state
+    # instead of forcing a backup restore.
+    print_check_details "$NEW_DATA_DIR"
+    restore_disabled_pg_control
     rm -rf "$NEW_DATA_DIR"
     result "$(jq -nc --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" \
       '{ok: false, mode: "upgrade", from: $from, to: $to, error: "pg_upgrade failed after check passed"}')"
     exit 3
   fi
-  log "$out"
+  log_upgrade_output "$out"
+
+  # Proof of completion for the marker-less resume: pg_control.old is
+  # renamed away before linking even BEGINS, so only this sentinel can
+  # distinguish "pg_upgrade finished but the marker write was lost" from
+  # "pg_upgrade crashed mid-link". finish_swap removes it after the promote.
+  # Durability is best-effort by design: a lost sentinel re-runs the upgrade
+  # from scratch (safe — see restore_disabled_pg_control), and a phantom one
+  # cannot exist because success is the only writer.
+  touch "$NEW_DATA_DIR/.railway_pg_upgrade_complete" \
+    || die 3 "failed to write the completion sentinel in $NEW_DATA_DIR"
 
   # THE commit point: from here recovery always rolls forward.
   write_marker "$(jq -nc \

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -289,7 +289,18 @@ detect_cpus() {
 init_new_cluster() {
   local target_dir="$1"
   rm -rf "$target_dir"
-  as_postgres mkdir -p "$target_dir"
+  # target_dir is a SIBLING of PGDATA under the volume root, and on a real
+  # Railway volume only PGDATA itself is postgres-owned (the entrypoint chowns
+  # exactly that path) — the volume root is root:root. `as_postgres mkdir`
+  # would run the mkdir AS postgres, which can't create an entry in a
+  # root-owned parent. Create it as whatever user we already are (root in
+  # every real deployment), then hand ownership to postgres so everything
+  # written INTO it from here on can run unprivileged.
+  mkdir -p "$target_dir" || die 3 "failed to create the target cluster directory"
+  if [ "$(id -u)" = "0" ]; then
+    chown postgres:postgres "$target_dir" \
+      || die 3 "failed to chown the target cluster directory to postgres"
+  fi
   # Locale/encoding inherit the image defaults, which match how the runtime
   # image initdb'd the old cluster; pg_upgrade --check verifies the pairing
   # and aborts on any mismatch before anything is touched.

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -841,6 +841,22 @@ mode_upgrade() {
         if [ -f "$NEW_DATA_DIR/.railway_pg_upgrade_complete" ] \
           && [ "$(cat "$NEW_DATA_DIR/PG_VERSION" 2>/dev/null)" = "$TO_MAJOR" ]; then
           log "no marker, but the disk shape shows a finished pg_upgrade (pg_control.old present, completion sentinel in the $TO_MAJOR dir) — resuming directory swap"
+          # Every other route into finish_swap is entered with a
+          # phase=upgraded marker already durably on disk; this is the one
+          # resume path that reconstructs the same conclusion from disk
+          # shape instead. Without a marker here, a crash between
+          # finish_swap's two renames leaves $PGDATA absent, both sibling
+          # dirs holding the split cluster, and nothing — no marker, no
+          # $PGDATA/PG_VERSION for wrapper.sh's guards to key on — to say so:
+          # a re-run wedges ("nothing to upgrade"), status reports
+          # phase=none (indistinguishable from a fresh volume), and a
+          # runtime boot would initdb an empty cluster over the wreckage.
+          # Writing the marker first makes this call site symmetric with
+          # the other two: any crash from here on is the already-covered
+          # "resume from an upgraded marker" case.
+          write_marker "$(jq -nc \
+            --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" \
+            '{phase: "upgraded", from: $from, to: $to, upgradedAt: (now | todate)}')"
           finish_swap
         fi
         log "pg_control.old present without a completion sentinel — pg_upgrade crashed mid-run; rolling back to the old cluster and re-running the upgrade"

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -129,6 +129,28 @@ ssl_ca_file = '$SSL_DIR/root.crt'
 EOF
 fi
 
+# Re-append the remote-access rule when pg_hba.conf has lost it. The official
+# entrypoint writes `host all all all <method>` ONCE, at initdb time — any
+# path that regenerates pg_hba.conf afterwards (a major upgrade promotes a
+# freshly initdb'd data directory; the upgrade job carries the old pg_hba
+# across, but this heals every other route too) leaves only initdb's default
+# local/loopback lines, so the database comes back healthy-looking while
+# EVERY remote client fails with "no pg_hba.conf entry". Same shape as the
+# SSL re-apply above: keyed on the CONFIG state itself, so it self-heals no
+# matter what reset it. The method mirrors the entrypoint's default. The
+# check accepts any host-family keyword (hostssl/hostnossl/…) so a user who
+# deliberately narrowed the rule to TLS-only doesn't get it silently
+# re-widened.
+PG_HBA_FILE="$PGDATA/pg_hba.conf"
+if [ -f "$POSTGRES_CONF_FILE" ] && [ -f "$PG_HBA_FILE" ] \
+  && ! grep -qE "^[[:space:]]*host(ssl|nossl|gssenc|nogssenc)?([[:space:]]+all){3}([[:space:]]|$)" "$PG_HBA_FILE"; then
+  echo "wrapper: pg_hba.conf has no 'host all all all' rule, re-appending (remote clients would be refused)"
+  cat >> "$PG_HBA_FILE" <<EOF
+
+host all all all ${POSTGRES_HOST_AUTH_METHOD:-scram-sha-256}
+EOF
+fi
+
 # Adds pg_stat_statements to shared_preload_libraries in a config file
 # Usage: add_pg_stat_statements <config_file>
 add_pg_stat_statements() {
@@ -1049,6 +1071,22 @@ configure_pgbackrest_recovery() {
   [ -z "$POSTGRES_RECOVERY_TARGET_TIME" ] && return 0
   [ ! -f "$POSTGRES_CONF_FILE" ] && return 0
 
+  # A COMPLETED major-upgrade marker is proof recovery already promoted on
+  # this volume, equivalent to .pitr_configured. Two layers guard the
+  # upgraded-restored-fork case (WAL_RECOVER_FROM_* + the target time stay
+  # set forever on a fork, so re-staging would point archive recovery at the
+  # source bucket and the database would never become ready): the upgrade
+  # job carries .pitr_configured/.pitr_staging/.pgbackrest_restored into the
+  # new data dir across its swap (layer 1), and this marker check (layer 2)
+  # covers any volume whose sentinels were still lost — the job refuses
+  # recovery.signal/standby.signal volumes, so only a cluster whose recovery
+  # had finished can ever have been upgraded.
+  local upgrade_completed=0
+  if [ -f "$UPGRADE_MARKER_FILE" ] \
+    && [ "$(jq -r '.phase // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null || true)" = "completed" ]; then
+    upgrade_completed=1
+  fi
+
   # /etc/pgbackrest lives on the container's root filesystem, not the
   # mounted volume, so it's gone on a genuine redeploy (a brand-new
   # container) even though it'd survive a plain in-place restart of the
@@ -1065,7 +1103,7 @@ configure_pgbackrest_recovery() {
   # avoid leaking source-bucket creds onto disk for a long-running promoted
   # service with no functional benefit.
   local recovery_genuinely_done=0
-  if [ -f "$PITR_DONE_MARKER" ]; then
+  if [ -f "$PITR_DONE_MARKER" ] || [ "$upgrade_completed" = 1 ]; then
     recovery_genuinely_done=1
   elif [ -f "$PGBACKREST_RESTORED_MARKER" ] && [ ! -f "$PGDATA/recovery.signal" ]; then
     recovery_genuinely_done=1
@@ -1100,8 +1138,12 @@ EOF
   # postgresql.auto.conf: skip the conf.d write AND the staging path.
   # Unchanged from before — this gate is about the empty-volume-restore
   # case having already written its own restore_command directly, not about
-  # whether recovery has actually finished (that's handled above).
-  if [ -f "$PGBACKREST_RESTORED_MARKER" ] || [ -f "$PITR_DONE_MARKER" ]; then
+  # whether recovery has actually finished (that's handled above). The
+  # completed-upgrade marker joins the gate for the same reason it sets
+  # recovery_genuinely_done: staging recovery on a post-upgrade volume would
+  # hang the database against the source bucket forever.
+  if [ -f "$PGBACKREST_RESTORED_MARKER" ] || [ -f "$PITR_DONE_MARKER" ] \
+    || [ "$upgrade_completed" = 1 ]; then
     return 0
   fi
 

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -15,6 +15,14 @@ if [ -n "$RAILWAY_ENVIRONMENT" ] && [ "$RAILWAY_VOLUME_MOUNT_PATH" != "$EXPECTED
   exit 1
 fi
 
+# Strip trailing slashes from PGDATA. Postgres itself tolerates them, but
+# the major-upgrade job builds sibling paths by appending to $PGDATA
+# ("${PGDATA}.upgrade-<to>"), so a value with a trailing slash must never be
+# allowed to take root on a volume — normalize here exactly like
+# upgrade-job.sh does, so both programs agree on every derived path.
+while [ "${PGDATA%/}" != "$PGDATA" ] && [ -n "${PGDATA%/}" ]; do PGDATA="${PGDATA%/}"; done
+export PGDATA
+
 # check if PGDATA starts with the expected volume mount path
 # this ensures data files are stored in the correct location
 # if not, print error and exit to prevent data loss or access issues
@@ -22,6 +30,37 @@ if [[ ! "$PGDATA" =~ ^"$EXPECTED_VOLUME_MOUNT_PATH" ]]; then
   echo "PGDATA variable does not start with the expected volume mount path, expected to start with $EXPECTED_VOLUME_MOUNT_PATH"
   echo "Please update the PGDATA variable to start with the expected volume mount path and redeploy the service"
   exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Volume-lifetime lock shared with the major-upgrade job. upgrade-job.sh
+# holds this file EXCLUSIVELY (flock -n) for its whole run; the runtime
+# holds it SHARED for the container's lifetime. Together they make both
+# races refuse instead of corrupting: a job dispatched against a live
+# database fails its exclusive lock, and a database deployed while a job is
+# mid-flight fails here. The fd is opened by THIS shell, which stays alive
+# as PID 1 (docker-entrypoint.sh below is a child, not an exec), so the
+# lock is held exactly as long as the container regardless of what postgres
+# does with its inherited copy of the fd — closing a duplicate descriptor
+# does not release a flock while the original stays open.
+#
+# Legacy PGDATA-at-the-volume-root layouts skip the lock on first init:
+# creating the lock file inside an empty PGDATA would make docker-entrypoint
+# skip initdb (it checks `ls -A`), and that layout can't take an in-place
+# upgrade anyway (no sibling slot on the volume for the new data dir).
+# -----------------------------------------------------------------------------
+UPGRADE_LOCK_FILE="$EXPECTED_VOLUME_MOUNT_PATH/.railway-major-upgrade.lock"
+if command -v flock >/dev/null 2>&1 && [ -d "$EXPECTED_VOLUME_MOUNT_PATH" ] \
+  && ! { [ "$PGDATA" = "$EXPECTED_VOLUME_MOUNT_PATH" ] && [ ! -f "$PGDATA/PG_VERSION" ]; }; then
+  if exec 8>>"$UPGRADE_LOCK_FILE" 2>/dev/null; then
+    if ! flock -n -s 8; then
+      echo "A major version upgrade job is currently running against this volume."
+      echo "The database must not start until it finishes; retry the deploy once the upgrade completes."
+      exit 1
+    fi
+  else
+    echo "wrapper: could not open $UPGRADE_LOCK_FILE; continuing without the upgrade lock" >&2
+  fi
 fi
 
 # -----------------------------------------------------------------------------
@@ -1515,10 +1554,63 @@ fork_post_upgrade_analyze() {
   ) &
 }
 
+# After a completed upgrade the previous cluster stays at ${PGDATA}.old-<from>
+# as the rollback body. pg_upgrade --link hardlinked the data files, so the
+# kept directory pins every pre-upgrade inode: space freed inside the upgraded
+# database (dropped tables, VACUUM FULL) is not returned to the volume while
+# the old directory holds the second link. Keep it until the upgrade is
+# CONFIRMED — the upgraded database up and answering, past a grace period
+# measured from the marker's completedAt (default 24h;
+# UPGRADE_OLD_DIR_RETENTION_SECONDS overrides, mainly for tests) — then
+# reclaim it in the background and stamp oldDataDirRemovedAt in the marker.
+# Forked on every boot alongside the analyze task, and it sleeps out the
+# remaining grace inside a long-lived container, so the reclaim does not
+# depend on a redeploy happening to land after the grace elapses.
+fork_old_datadir_reclaim() {
+  [ -f "$UPGRADE_MARKER_FILE" ] || return 0
+  [ "$(jq -r '.phase // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null || true)" = "completed" ] || return 0
+  [ -z "$(jq -r '.oldDataDirRemovedAt // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null || true)" ] || return 0
+  compgen -G "${PGDATA}.old-*" >/dev/null 2>&1 || return 0
+  (
+    retention="${UPGRADE_OLD_DIR_RETENTION_SECONDS:-86400}"
+    completed_at=$(jq -r '.completedAt // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null) || exit 0
+    completed_epoch=$(date -d "$completed_at" +%s 2>/dev/null) || exit 0
+    [ -n "$completed_epoch" ] || exit 0
+    wait_secs=$(( completed_epoch + retention - $(date +%s) ))
+    if [ "$wait_secs" -gt 0 ]; then
+      echo "post-upgrade: keeping the pre-upgrade data dir for rollback; reclaiming in ${wait_secs}s"
+      sleep "$wait_secs"
+    fi
+    # Confirmation = the upgraded database is actually up and answering, not
+    # merely "the grace elapsed": a crash-looping upgrade must keep its
+    # rollback body. If postgres never becomes ready, leave everything in
+    # place — the next boot retries.
+    for _ in $(seq 1 120); do
+      pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null && break
+      sleep 5
+    done
+    pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null || exit 0
+    echo "post-upgrade: reclaiming the pre-upgrade data dir (${PGDATA}.old-*)"
+    if ! rm -rf "${PGDATA}".old-*; then
+      echo "post-upgrade: could not remove the pre-upgrade data dir; will retry on next boot"
+      exit 0
+    fi
+    tmp_marker="${UPGRADE_MARKER_FILE}.tmp"
+    if jq --arg t "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.oldDataDirRemovedAt = $t' \
+        "$UPGRADE_MARKER_FILE" > "$tmp_marker" 2>/dev/null; then
+      mv "$tmp_marker" "$UPGRADE_MARKER_FILE"
+    else
+      rm -f "$tmp_marker"
+    fi
+    echo "post-upgrade: pre-upgrade data dir reclaimed"
+  ) &
+}
+
 bootstrap_pgbackrest_stanza
 fork_pgbackrest_backup_watcher
 fork_collation_refresh
 fork_post_upgrade_analyze
+fork_old_datadir_reclaim
 
 # H1 (audit): we considered `exec docker-entrypoint.sh` and a
 # trap+wait+forward-SIGTERM pattern to make `docker stop` flush

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -96,10 +96,38 @@ if [ -f "$UPGRADE_MARKER_FILE" ]; then
   fi
 fi
 
+# The image's own major, for the mismatch guard. Filesystem first, PG_MAJOR
+# env second — deliberately in that order (mirrors postgres-ha's
+# image_major()): the installed server tree under /usr/lib/postgresql is
+# baked into the image and nothing at deploy time can change it, while
+# PG_MAJOR is an env var a service variable can override — trusted alone, a
+# stray user-set PG_MAJOR=16 on a 17 image would refuse every boot of a
+# perfectly matched data directory. Exactly one numeric entry = the image's
+# major; zero or several (never true for runtime images) falls back to the
+# env; neither = the guard abstains.
+detect_image_major() {
+  local d name majors=()
+  for d in /usr/lib/postgresql/*/; do
+    [ -d "$d" ] || continue
+    name="${d%/}"; name="${name##*/}"
+    case "$name" in ''|*[!0-9]*) continue ;; esac
+    majors+=("$name")
+  done
+  if [ "${#majors[@]}" -eq 1 ]; then
+    if [ -n "${PG_MAJOR:-}" ] && [ "$PG_MAJOR" != "${majors[0]}" ]; then
+      echo "wrapper: PG_MAJOR=${PG_MAJOR} disagrees with the installed server tree (${majors[0]}); trusting the filesystem — a service variable can override the env, not the image contents" >&2
+    fi
+    echo "${majors[0]}"
+    return 0
+  fi
+  echo "${PG_MAJOR:-}"
+}
+
+IMAGE_MAJOR=$(detect_image_major)
 if [ -f "$PGDATA/PG_VERSION" ]; then
   DATA_MAJOR=$(cat "$PGDATA/PG_VERSION")
-  if [ -n "$PG_MAJOR" ] && [ "$DATA_MAJOR" != "$PG_MAJOR" ]; then
-    echo "This image runs PostgreSQL $PG_MAJOR but the data directory holds major version $DATA_MAJOR."
+  if [ -n "$IMAGE_MAJOR" ] && [ "$DATA_MAJOR" != "$IMAGE_MAJOR" ]; then
+    echo "This image runs PostgreSQL $IMAGE_MAJOR but the data directory holds major version $DATA_MAJOR."
     echo "Changing the image tag does not upgrade the data files. Set the image back to postgres $DATA_MAJOR,"
     echo "or run a major version upgrade from the service's settings."
     exit 1
@@ -175,22 +203,36 @@ ssl_ca_file = '$SSL_DIR/root.crt'
 EOF
 fi
 
-# Re-append the remote-access rule when pg_hba.conf has lost it. The official
-# entrypoint writes `host all all all <method>` ONCE, at initdb time — any
-# path that regenerates pg_hba.conf afterwards (a major upgrade promotes a
-# freshly initdb'd data directory; the upgrade job carries the old pg_hba
-# across, but this heals every other route too) leaves only initdb's default
-# local/loopback lines, so the database comes back healthy-looking while
-# EVERY remote client fails with "no pg_hba.conf entry". Same shape as the
-# SSL re-apply above: keyed on the CONFIG state itself, so it self-heals no
-# matter what reset it. The method mirrors the entrypoint's default. The
-# check accepts any host-family keyword (hostssl/hostnossl/…) so a user who
-# deliberately narrowed the rule to TLS-only doesn't get it silently
-# re-widened.
+# Re-append the remote-access rule when pg_hba.conf has been reset to
+# initdb's defaults. The official entrypoint writes `host all all all
+# <method>` ONCE, at initdb time — any path that regenerates pg_hba.conf
+# afterwards (a major upgrade promotes a freshly initdb'd data directory;
+# the upgrade job carries the old pg_hba across, but this heals every other
+# route too) leaves only initdb's default local/loopback lines, so the
+# database comes back healthy-looking while EVERY remote client fails with
+# "no pg_hba.conf entry". The method mirrors the entrypoint's default.
+#
+# The heal fires ONLY on the recognizable bare-initdb shape: loopback host
+# rules present, and no host-family rule with any other address. Anything
+# else is an authored policy and is left alone — a config the operator
+# narrowed by address (`host all all 10.0.0.0/8 …`), by database/user
+# (`host mydb appuser all …`), or by TLS (`hostssl …`) must never get a
+# wide-open `host all all all` silently appended under it: pg_hba is
+# first-match-wins, so the append would re-admit exactly the clients the
+# narrowing excluded. Likewise a file with NO host rules at all is a
+# deliberate local-only lockdown, not an initdb reset (initdb always writes
+# the loopback lines).
 PG_HBA_FILE="$PGDATA/pg_hba.conf"
+hba_has_loopback_host_rule() {
+  grep -qE "^[[:space:]]*host([[:space:]]+[^[:space:]]+){2}[[:space:]]+(127\.0\.0\.1/32|::1/128)([[:space:]]|$)" "$PG_HBA_FILE"
+}
+hba_has_authored_host_rule() {
+  grep -E "^[[:space:]]*host(ssl|nossl|gssenc|nogssenc)?[[:space:]]" "$PG_HBA_FILE" \
+    | grep -vE "[[:space:]](127\.0\.0\.1/32|::1/128)([[:space:]]|$)" | grep -q .
+}
 if [ -f "$POSTGRES_CONF_FILE" ] && [ -f "$PG_HBA_FILE" ] \
-  && ! grep -qE "^[[:space:]]*host(ssl|nossl|gssenc|nogssenc)?([[:space:]]+all){3}([[:space:]]|$)" "$PG_HBA_FILE"; then
-  echo "wrapper: pg_hba.conf has no 'host all all all' rule, re-appending (remote clients would be refused)"
+  && hba_has_loopback_host_rule && ! hba_has_authored_host_rule; then
+  echo "wrapper: pg_hba.conf holds only initdb's loopback host rules, re-appending the remote-access rule (remote clients would be refused)"
   cat >> "$PG_HBA_FILE" <<EOF
 
 host all all all ${POSTGRES_HOST_AUTH_METHOD:-scram-sha-256}
@@ -1561,10 +1603,21 @@ fork_post_upgrade_analyze() {
     for _ in $(seq 1 120); do
       if pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null; then
         echo "post-upgrade: rebuilding planner statistics in stages"
-        if vacuumdb --all --analyze-in-stages -h /var/run/postgresql -p 5432 -U postgres >/dev/null 2>&1; then
-          tmp_marker="${UPGRADE_MARKER_FILE}.tmp"
-          jq '.needsAnalyze = false' "$UPGRADE_MARKER_FILE" > "$tmp_marker" 2>/dev/null \
-            && mv "$tmp_marker" "$UPGRADE_MARKER_FILE"
+        # Connect as the cluster's actual superuser: a custom-POSTGRES_USER
+        # cluster has no 'postgres' role (the entrypoint initdb's with
+        # --username="$POSTGRES_USER"), and -U postgres would fail here on
+        # every boot forever.
+        if vacuumdb --all --analyze-in-stages -h /var/run/postgresql -p 5432 \
+             -U "${POSTGRES_USER:-postgres}" >/dev/null 2>&1; then
+          # mktemp, not a fixed .tmp suffix: fork_old_datadir_reclaim updates
+          # the same marker from a sibling fork, and a shared literal tmp
+          # path lets the two writers clobber each other's staged update.
+          if tmp_marker=$(mktemp "${UPGRADE_MARKER_FILE}.XXXX") \
+            && jq '.needsAnalyze = false' "$UPGRADE_MARKER_FILE" > "$tmp_marker" 2>/dev/null; then
+            mv "$tmp_marker" "$UPGRADE_MARKER_FILE"
+          else
+            rm -f "$tmp_marker" 2>/dev/null
+          fi
           echo "post-upgrade: statistics rebuild complete"
         else
           echo "post-upgrade: statistics rebuild failed; will retry on next boot"
@@ -1617,12 +1670,15 @@ fork_old_datadir_reclaim() {
       echo "post-upgrade: could not remove the pre-upgrade data dir; will retry on next boot"
       exit 0
     fi
-    tmp_marker="${UPGRADE_MARKER_FILE}.tmp"
-    if jq --arg t "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.oldDataDirRemovedAt = $t' \
+    # mktemp for the same reason as fork_post_upgrade_analyze's marker
+    # update: two forks share this marker, a fixed tmp name lets them
+    # clobber each other's staged write.
+    if tmp_marker=$(mktemp "${UPGRADE_MARKER_FILE}.XXXX") \
+      && jq --arg t "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.oldDataDirRemovedAt = $t' \
         "$UPGRADE_MARKER_FILE" > "$tmp_marker" 2>/dev/null; then
       mv "$tmp_marker" "$UPGRADE_MARKER_FILE"
     else
-      rm -f "$tmp_marker"
+      rm -f "$tmp_marker" 2>/dev/null
     fi
     echo "post-upgrade: pre-upgrade data dir reclaimed"
   ) &

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1724,36 +1724,69 @@ fork_post_upgrade_analyze() {
 fork_old_datadir_reclaim() {
   [ -f "$UPGRADE_MARKER_FILE" ] || return 0
   [ "$(jq -r '.phase // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null || true)" = "completed" ] || return 0
-  [ -z "$(jq -r '.oldDataDirRemovedAt // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null || true)" ] || return 0
   compgen -G "${PGDATA}.old-*" >/dev/null 2>&1 || return 0
   (
     retention="${UPGRADE_OLD_DIR_RETENTION_SECONDS:-86400}"
-    completed_at=$(jq -r '.completedAt // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null) || exit 0
-    completed_epoch=$(date -d "$completed_at" +%s 2>/dev/null) || exit 0
-    [ -n "$completed_epoch" ] || exit 0
-    wait_secs=$(( completed_epoch + retention - $(date +%s) ))
-    if [ "$wait_secs" -gt 0 ]; then
-      echo "post-upgrade: keeping the pre-upgrade data dir for rollback; reclaiming in ${wait_secs}s"
-      sleep "$wait_secs"
-    fi
-    # Confirmation = the upgraded database is actually up and answering, not
-    # merely "the grace elapsed": a crash-looping upgrade must keep its
-    # rollback body. If postgres never becomes ready, leave everything in
-    # place — the next boot retries.
-    for _ in $(seq 1 120); do
-      pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null && break
-      sleep 5
+    marker_stamped=0
+    [ -n "$(jq -r '.oldDataDirRemovedAt // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null || true)" ] && marker_stamped=1
+
+    # A chained upgrade (16->17, then 17->18 before the first reclaim ever
+    # runs) leaves TWO .old-<major> siblings on the volume at once — each
+    # job's own pre-existing-rollback-body refusal only checks ITS OWN
+    # FROM-suffixed name, never a glob, so nothing stops them coexisting.
+    # Keying reclaim off the CURRENT marker's completedAt alone (as a single
+    # `rm -rf "${PGDATA}".old-*` gated on one timestamp) would judge every
+    # generation by the LATEST upgrade's clock — sweeping an older, unrelated
+    # rollback body early if a later upgrade used a shorter retention
+    # override, or holding it hostage to a later upgrade's own wait. A
+    # directory's own mtime is set once, by the `mv` that created it in
+    # finish_swap, and nothing writes into it afterward — that makes it an
+    # independent per-generation clock. Loop so each sibling is judged, and
+    # reclaimed, on its own schedule; the earliest deadline first, so a
+    # long-overdue orphan from a previous chain link doesn't wait behind a
+    # much younger one.
+    while :; do
+      remaining=()
+      for old_dir in "${PGDATA}".old-*; do
+        [ -d "$old_dir" ] || continue
+        dir_mtime=$(stat -c %Y "$old_dir" 2>/dev/null) || continue
+        remaining+=("$(( dir_mtime + retention )):${old_dir}")
+      done
+      [ "${#remaining[@]}" -eq 0 ] && break
+
+      next=$(printf '%s\n' "${remaining[@]}" | sort -n | head -1)
+      next_deadline="${next%%:*}"
+      next_dir="${next#*:}"
+      wait_secs=$(( next_deadline - $(date +%s) ))
+      if [ "$wait_secs" -gt 0 ]; then
+        echo "post-upgrade: keeping ${next_dir} for rollback; reclaiming in ${wait_secs}s"
+        sleep "$wait_secs"
+      fi
+
+      # Confirmation = the upgraded database is actually up and answering, not
+      # merely "the grace elapsed": a crash-looping upgrade must keep every
+      # rollback body in place. If postgres never becomes ready, stop
+      # entirely — the next boot's fork re-evaluates everything from scratch.
+      ready=0
+      for _ in $(seq 1 120); do
+        if pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null; then ready=1; break; fi
+        sleep 5
+      done
+      [ "$ready" = 1 ] || exit 0
+
+      echo "post-upgrade: reclaiming the pre-upgrade data dir (${next_dir})"
+      if ! rm -rf "$next_dir"; then
+        echo "post-upgrade: could not remove ${next_dir}; will retry on next boot"
+        break
+      fi
+      if [ "$marker_stamped" = 0 ]; then
+        # Serialized against the analyze fork's update — see update_upgrade_marker.
+        update_upgrade_marker --arg t "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.oldDataDirRemovedAt = $t' \
+          || echo "post-upgrade: could not stamp oldDataDirRemovedAt (reclaim already done; cosmetic)"
+        marker_stamped=1
+      fi
+      echo "post-upgrade: pre-upgrade data dir reclaimed (${next_dir})"
     done
-    pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null || exit 0
-    echo "post-upgrade: reclaiming the pre-upgrade data dir (${PGDATA}.old-*)"
-    if ! rm -rf "${PGDATA}".old-*; then
-      echo "post-upgrade: could not remove the pre-upgrade data dir; will retry on next boot"
-      exit 0
-    fi
-    # Serialized against the analyze fork's update — see update_upgrade_marker.
-    update_upgrade_marker --arg t "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.oldDataDirRemovedAt = $t' \
-      || echo "post-upgrade: could not stamp oldDataDirRemovedAt (reclaim already done; cosmetic)"
-    echo "post-upgrade: pre-upgrade data dir reclaimed"
   ) &
 }
 

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -96,6 +96,23 @@ if [ -f "$UPGRADE_MARKER_FILE" ]; then
   fi
 fi
 
+# The marker above catches every phase pg_upgrade writes one for — but the
+# upgrade job only writes its FIRST marker on pg_upgrade's own success, so a
+# crash DURING pg_upgrade --link leaves no marker at all. pg_upgrade renames
+# global/pg_control to .old before it links the first relation file (its own
+# recovery advice is to rename it back), so this exact shape — .old present,
+# the real file absent — means a link was interrupted. PG_VERSION at the
+# PGDATA root is untouched by that rename, so it still matches THIS image's
+# major and the version-mismatch guard below would not catch it either;
+# without this check postgres would fail deep in startup with a bare "could
+# not open file "global/pg_control"" instead of naming the actual cause.
+if [ -f "$PGDATA/global/pg_control.old" ] && [ ! -f "$PGDATA/global/pg_control" ]; then
+  echo "This looks like an interrupted major version upgrade: pg_control is disabled (renamed to pg_control.old),"
+  echo "the shape pg_upgrade leaves if it crashes mid-link. A database major-version-upgrade job resolves this"
+  echo "volume; starting postgres against it directly will fail."
+  exit 1
+fi
+
 # The image's own major, for the mismatch guard. Filesystem first, PG_MAJOR
 # env second — deliberately in that order (mirrors postgres-ha's
 # image_major()): the installed server tree under /usr/lib/postgresql is

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -563,11 +563,26 @@ write_pgbackrest_repo_path_marker() {
 #
 # Safe to write wholesale because the watcher is forked strictly after this
 # runs — wrapper.sh has no concurrent writer at this point in the boot.
+#
+# One field survives the wholesale replace: archive_migration_orig_path.
+# The watcher composes successive WAL_REGRESSION migration suffixes off that
+# ORIGINAL path (cluster-X-e1, cluster-X-e2 — flat siblings) precisely so
+# they never chain (cluster-X-e1-e2); recreating the state file without it
+# would resurrect the deepening-chain bug its docblock warns about.
 write_backup_state_migration_gate() {
-  local new_path="$1" state_file="$PGDATA/.pgbackrest_backup_state" tmp
+  local new_path="$1" state_file="$PGDATA/.pgbackrest_backup_state" tmp orig_path=""
+  if [ -f "$state_file" ]; then
+    orig_path=$(grep -E "^archive_migration_orig_path=" "$state_file" 2>/dev/null | tail -1 | cut -d= -f2-)
+  fi
   tmp=$(mktemp "${state_file}.XXXX") || return 1
-  printf 'archive_migration_pending_new_path=%s\n' "$new_path" > "$tmp" \
-    || { rm -f "$tmp"; return 1; }
+  if ! printf 'archive_migration_pending_new_path=%s\n' "$new_path" > "$tmp"; then
+    rm -f "$tmp"; return 1
+  fi
+  if [ -n "$orig_path" ]; then
+    if ! printf 'archive_migration_orig_path=%s\n' "$orig_path" >> "$tmp"; then
+      rm -f "$tmp"; return 1
+    fi
+  fi
   chown postgres:postgres "$tmp" 2>/dev/null || true
   chmod 0640 "$tmp" 2>/dev/null || true
   mv "$tmp" "$state_file" || { rm -f "$tmp"; return 1; }

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -24,6 +24,42 @@ if [[ ! "$PGDATA" =~ ^"$EXPECTED_VOLUME_MOUNT_PATH" ]]; then
   exit 1
 fi
 
+# -----------------------------------------------------------------------------
+# Major-version guards. Both are fail-stop and loud, and both run before
+# anything touches the data directory, so a mismatched boot can never corrupt
+# data or initdb over a half-swapped upgrade.
+#
+# 1. A major-upgrade marker (written by the upgrade job image) in any phase
+#    other than "completed" means the volume is mid-upgrade: the data
+#    directory may be absent or half-swapped. Refuse to boot; the upgrade
+#    workflow resolves it (roll forward or roll back), never this container.
+# 2. On-disk PG_VERSION must match this image's major. Postgres itself would
+#    refuse anyway, but deep in startup with a confusing error; failing here
+#    names the actual problem and the fix. A fresh volume (no PG_VERSION)
+#    skips the check — that's first init.
+# -----------------------------------------------------------------------------
+UPGRADE_MARKER_FILE="$EXPECTED_VOLUME_MOUNT_PATH/.railway-major-upgrade.json"
+if [ -f "$UPGRADE_MARKER_FILE" ]; then
+  # `|| true` so an unreadable marker still lands in the fail-stop branch
+  # below instead of tripping set -e with no message.
+  MARKER_PHASE=$(jq -r '.phase // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null || true)
+  if [ "$MARKER_PHASE" != "completed" ]; then
+    echo "A major version upgrade is in progress on this volume (marker phase: ${MARKER_PHASE:-unreadable})."
+    echo "The database must not start until the upgrade workflow finishes or rolls back."
+    exit 1
+  fi
+fi
+
+if [ -f "$PGDATA/PG_VERSION" ]; then
+  DATA_MAJOR=$(cat "$PGDATA/PG_VERSION")
+  if [ -n "$PG_MAJOR" ] && [ "$DATA_MAJOR" != "$PG_MAJOR" ]; then
+    echo "This image runs PostgreSQL $PG_MAJOR but the data directory holds major version $DATA_MAJOR."
+    echo "Changing the image tag does not upgrade the data files. Set the image back to postgres $DATA_MAJOR,"
+    echo "or run a major version upgrade from the service's settings."
+    exit 1
+  fi
+fi
+
 # Set up needed variables
 SSL_DIR="/var/lib/postgresql/data/certs"
 INIT_SSL_SCRIPT="/docker-entrypoint-initdb.d/init-ssl.sh"
@@ -1142,9 +1178,37 @@ if [ -n "${WAL_ARCHIVE_BUCKET:-}" ] && [ -f "$PGDATA/global/pg_control" ] && [ !
   unset _early_repo_path
 fi
 
+# After a major upgrade, planner statistics start empty (pg_upgrade does not
+# carry them across majors before 18). Rebuild them in stages in the
+# background once postgres accepts connections, so the database is usable
+# immediately and reaches full statistics without operator action. The
+# marker's needsAnalyze flag makes this one-shot across restarts.
+fork_post_upgrade_analyze() {
+  [ -f "$UPGRADE_MARKER_FILE" ] || return 0
+  [ "$(jq -r '.needsAnalyze // false' "$UPGRADE_MARKER_FILE" 2>/dev/null)" = "true" ] || return 0
+  (
+    for _ in $(seq 1 120); do
+      if pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null; then
+        echo "post-upgrade: rebuilding planner statistics in stages"
+        if vacuumdb --all --analyze-in-stages -h /var/run/postgresql -p 5432 -U postgres >/dev/null 2>&1; then
+          tmp_marker="${UPGRADE_MARKER_FILE}.tmp"
+          jq '.needsAnalyze = false' "$UPGRADE_MARKER_FILE" > "$tmp_marker" 2>/dev/null \
+            && mv "$tmp_marker" "$UPGRADE_MARKER_FILE"
+          echo "post-upgrade: statistics rebuild complete"
+        else
+          echo "post-upgrade: statistics rebuild failed; will retry on next boot"
+        fi
+        exit 0
+      fi
+      sleep 5
+    done
+  ) &
+}
+
 bootstrap_pgbackrest_stanza
 fork_pgbackrest_backup_watcher
 fork_collation_refresh
+fork_post_upgrade_analyze
 
 # H1 (audit): we considered `exec docker-entrypoint.sh` and a
 # trap+wait+forward-SIGTERM pattern to make `docker stop` flush

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -614,24 +614,22 @@ write_pgbackrest_repo_path_marker() {
 # Safe to write wholesale because the watcher is forked strictly after this
 # runs — wrapper.sh has no concurrent writer at this point in the boot.
 #
-# One field survives the wholesale replace: archive_migration_orig_path.
-# The watcher composes successive WAL_REGRESSION migration suffixes off that
-# ORIGINAL path (cluster-X-e1, cluster-X-e2 — flat siblings) precisely so
-# they never chain (cluster-X-e1-e2); recreating the state file without it
-# would resurrect the deepening-chain bug its docblock warns about.
+# Every call here follows a genuine re-identification (this function's only
+# caller, reanchor_pgbackrest_repo_path_if_reidentified, returns early unless
+# anchor_sysid/anchor_major mismatched the live cluster) — never the
+# watcher's own same-cluster WAL_REGRESSION retries, which manage
+# archive_migration_orig_path entirely on their own (read_state /
+# write_state_field_required) and never call this function. So any
+# archive_migration_orig_path already on disk belongs to the OLD identity's
+# suffix chain: carrying it into the new one would compose the new cluster's
+# next WAL_REGRESSION migration off the old family (cluster-<OLD
+# SYSID>-<epoch>) instead of the new one. Wholesale-replace really does mean
+# wholesale — there is no field to preserve.
 write_backup_state_migration_gate() {
-  local new_path="$1" state_file="$PGDATA/.pgbackrest_backup_state" tmp orig_path=""
-  if [ -f "$state_file" ]; then
-    orig_path=$(grep -E "^archive_migration_orig_path=" "$state_file" 2>/dev/null | tail -1 | cut -d= -f2-)
-  fi
+  local new_path="$1" state_file="$PGDATA/.pgbackrest_backup_state" tmp
   tmp=$(mktemp "${state_file}.XXXX") || return 1
   if ! printf 'archive_migration_pending_new_path=%s\n' "$new_path" > "$tmp"; then
     rm -f "$tmp"; return 1
-  fi
-  if [ -n "$orig_path" ]; then
-    if ! printf 'archive_migration_orig_path=%s\n' "$orig_path" >> "$tmp"; then
-      rm -f "$tmp"; return 1
-    fi
   fi
   chown postgres:postgres "$tmp" 2>/dev/null || true
   chmod 0640 "$tmp" 2>/dev/null || true

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -597,7 +597,8 @@ write_pgbackrest_repo_path_marker() {
 }
 
 # Replace the backup watcher's state file with nothing but the migration gate
-# (`archive_migration_pending_new_path`, empty to release it).
+# (`archive_migration_pending_new_path`). Releasing the gate is the separate,
+# field-preserving clear_backup_state_migration_gate below — never this.
 #
 # Replaced rather than edited because every field in it describes backups at
 # the OLD path. Clearing last_full_at is what trips the watcher's
@@ -632,6 +633,24 @@ write_backup_state_migration_gate() {
       rm -f "$tmp"; return 1
     fi
   fi
+  chown postgres:postgres "$tmp" 2>/dev/null || true
+  chmod 0640 "$tmp" 2>/dev/null || true
+  mv "$tmp" "$state_file" || { rm -f "$tmp"; return 1; }
+}
+
+# Release the watcher's migration gate WITHOUT touching the rest of its
+# state. The gate-SET path deliberately replaces the whole file (see
+# write_backup_state_migration_gate), but the CLEAR must not: on the
+# re-anchor RETRY path (marker already flipped by an earlier attempt whose
+# final anchor write failed) the state file holds real post-migration
+# watcher state — a last_full_at from a full that already landed at the new
+# path — and wiping it would re-arm NEEDS_INITIAL_BACKUP into one redundant
+# full upload per boot until the anchor write finally succeeds.
+clear_backup_state_migration_gate() {
+  local state_file="$PGDATA/.pgbackrest_backup_state" tmp
+  [ ! -f "$state_file" ] && return 0
+  tmp=$(mktemp "${state_file}.XXXX") || return 1
+  grep -vE "^archive_migration_pending_new_path=" "$state_file" > "$tmp" 2>/dev/null || true
   chown postgres:postgres "$tmp" 2>/dev/null || true
   chmod 0640 "$tmp" 2>/dev/null || true
   mv "$tmp" "$state_file" || { rm -f "$tmp"; return 1; }
@@ -686,9 +705,10 @@ reanchor_pgbackrest_repo_path() {
   clean_archive_spool_statuses
   # The old cluster's gap sentinel describes the old path's coverage.
   rm -f "$PGDATA/.pgbackrest_gap_pending" 2>/dev/null || true
-  # Cleanup done: release the watcher's backup gate. Failing here is safe —
+  # Cleanup done: release the watcher's backup gate — field-preserving, so
+  # the retry path's real watcher state survives. Failing here is safe —
   # the watcher retries the same cleanup and clears the gate itself.
-  write_backup_state_migration_gate "" \
+  clear_backup_state_migration_gate \
     || echo "pgbackrest: could not clear the pending-migration gate; the watcher will retry it" >&2
   return 0
 }
@@ -1591,6 +1611,32 @@ fi
 # starting — the watcher retries.
 reanchor_pgbackrest_repo_path_if_reidentified || true
 
+# Serialized read-modify-write for the upgrade marker. Two background forks
+# (the staged analyze and the old-dir reclaim) both update it; their mktemp
+# staging keeps the WRITES apart, but without mutual exclusion the classic
+# lost update remains — reclaim re-reads a marker analyze is about to
+# replace and writes back a stale needsAnalyze, or reclaim's own stamp is
+# clobbered. flock on a sibling lock file closes it; when flock (or the
+# open) is unavailable this degrades to the old unserialized behavior,
+# whose worst outcomes were benign (a re-run analyze, a missing timestamp).
+# Runs in a subshell so fd 7 never leaks into the caller.
+update_upgrade_marker() {
+  (
+    if command -v flock >/dev/null 2>&1; then
+      if { exec 7>>"${UPGRADE_MARKER_FILE}.updatelock"; } 2>/dev/null; then
+        flock 7 || true
+      fi
+    fi
+    tmp_marker=$(mktemp "${UPGRADE_MARKER_FILE}.XXXX") || exit 1
+    if jq "$@" "$UPGRADE_MARKER_FILE" > "$tmp_marker" 2>/dev/null; then
+      mv "$tmp_marker" "$UPGRADE_MARKER_FILE"
+    else
+      rm -f "$tmp_marker" 2>/dev/null
+      exit 1
+    fi
+  )
+}
+
 # After a major upgrade, planner statistics start empty (pg_upgrade does not
 # carry them across majors before 18). Rebuild them in stages in the
 # background once postgres accepts connections, so the database is usable
@@ -1607,20 +1653,16 @@ fork_post_upgrade_analyze() {
         # cluster has no 'postgres' role (the entrypoint initdb's with
         # --username="$POSTGRES_USER"), and -U postgres would fail here on
         # every boot forever.
-        if vacuumdb --all --analyze-in-stages -h /var/run/postgresql -p 5432 \
-             -U "${POSTGRES_USER:-postgres}" >/dev/null 2>&1; then
-          # mktemp, not a fixed .tmp suffix: fork_old_datadir_reclaim updates
-          # the same marker from a sibling fork, and a shared literal tmp
-          # path lets the two writers clobber each other's staged update.
-          if tmp_marker=$(mktemp "${UPGRADE_MARKER_FILE}.XXXX") \
-            && jq '.needsAnalyze = false' "$UPGRADE_MARKER_FILE" > "$tmp_marker" 2>/dev/null; then
-            mv "$tmp_marker" "$UPGRADE_MARKER_FILE"
-          else
-            rm -f "$tmp_marker" 2>/dev/null
-          fi
+        if analyze_out=$(vacuumdb --all --analyze-in-stages -h /var/run/postgresql -p 5432 \
+             -U "${POSTGRES_USER:-postgres}" 2>&1); then
+          update_upgrade_marker '.needsAnalyze = false' || true
           echo "post-upgrade: statistics rebuild complete"
         else
+          # Print WHY — an auth-hardened local rule or a missing role makes
+          # this fail on every boot forever, and a bare "failed" gives the
+          # operator nothing to fix.
           echo "post-upgrade: statistics rebuild failed; will retry on next boot"
+          printf '%s\n' "$analyze_out" | tail -20 | sed 's/^/post-upgrade:   /'
         fi
         exit 0
       fi
@@ -1670,16 +1712,9 @@ fork_old_datadir_reclaim() {
       echo "post-upgrade: could not remove the pre-upgrade data dir; will retry on next boot"
       exit 0
     fi
-    # mktemp for the same reason as fork_post_upgrade_analyze's marker
-    # update: two forks share this marker, a fixed tmp name lets them
-    # clobber each other's staged write.
-    if tmp_marker=$(mktemp "${UPGRADE_MARKER_FILE}.XXXX") \
-      && jq --arg t "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.oldDataDirRemovedAt = $t' \
-        "$UPGRADE_MARKER_FILE" > "$tmp_marker" 2>/dev/null; then
-      mv "$tmp_marker" "$UPGRADE_MARKER_FILE"
-    else
-      rm -f "$tmp_marker" 2>/dev/null
-    fi
+    # Serialized against the analyze fork's update — see update_upgrade_marker.
+    update_upgrade_marker --arg t "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.oldDataDirRemovedAt = $t' \
+      || echo "post-upgrade: could not stamp oldDataDirRemovedAt (reclaim already done; cosmetic)"
     echo "post-upgrade: pre-upgrade data dir reclaimed"
   ) &
 }

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -113,6 +113,24 @@ if [ -f "$PGDATA/global/pg_control.old" ] && [ ! -f "$PGDATA/global/pg_control" 
   exit 1
 fi
 
+# Belt-and-suspenders for a crash between finish_swap's two renames: PGDATA
+# itself is gone at that point (renamed to .old-<from>), so neither guard
+# above has anything to check — the pg_control.old one above looks under
+# $PGDATA, which no longer exists. No legitimate first init ever has
+# upgrade-job sibling directories sitting next to an empty/missing PGDATA;
+# only a job that started swapping directories and never finished does.
+# Without this, docker-entrypoint would initdb a fresh empty cluster over
+# what's actually a split, unfinished upgrade sitting in those siblings.
+if [ ! -f "$PGDATA/PG_VERSION" ] \
+  && { compgen -G "${PGDATA}.upgrade-*" >/dev/null 2>&1 || compgen -G "${PGDATA}.old-*" >/dev/null 2>&1; }; then
+  echo "PGDATA is empty or missing, but upgrade-job sibling directories exist next to it"
+  echo "(${PGDATA}.upgrade-* / ${PGDATA}.old-*) — this looks like an interrupted major version"
+  echo "upgrade caught mid-swap, not a fresh volume. A database major-version-upgrade job"
+  echo "resolves this volume; starting postgres against it directly would initdb a new, empty"
+  echo "cluster over real data sitting in those siblings."
+  exit 1
+fi
+
 # The image's own major, for the mismatch guard. Filesystem first, PG_MAJOR
 # env second — deliberately in that order (mirrors postgres-ha's
 # image_major()): the installed server tree under /usr/lib/postgresql is
@@ -1595,10 +1613,15 @@ fi
 # subshells. Customer-set PGHOST=${{ Postgres.RAILWAY_PRIVATE_DOMAIN }} (a
 # common app-side pattern) leaks into pgbackrest's libpq calls — pgbackrest
 # then tries to connect to itself via the privnet domain and times out
-# (`unable to find primary cluster`). A local-only connection is what we want
-# from inside the container; clearing PGHOST/PGPORT lets libpq fall back to
-# the Unix socket.
+# (`unable to find primary cluster`). PGHOSTADDR is the same hazard: libpq
+# honors it even over an explicit -h to the local socket, so it silently
+# breaks stanza bootstrap, the watcher's probes, and everything else forked
+# below that talks libpq — the exact class upgrade-job.sh's own PGHOST/
+# PGHOSTADDR/PGPORT clearing cites this block as precedent for. A local-only
+# connection is what we want from inside the container; clearing all three
+# lets libpq fall back to the Unix socket.
 unset PGHOST
+unset PGHOSTADDR
 unset PGPORT
 
 # Write the per-cluster repo-path marker synchronously when archive is on

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -52,7 +52,14 @@ fi
 UPGRADE_LOCK_FILE="$EXPECTED_VOLUME_MOUNT_PATH/.railway-major-upgrade.lock"
 if command -v flock >/dev/null 2>&1 && [ -d "$EXPECTED_VOLUME_MOUNT_PATH" ] \
   && ! { [ "$PGDATA" = "$EXPECTED_VOLUME_MOUNT_PATH" ] && [ ! -f "$PGDATA/PG_VERSION" ]; }; then
-  if exec 8>>"$UPGRADE_LOCK_FILE" 2>/dev/null; then
+  # The 2>/dev/null MUST be scoped by the brace group, never put on the exec
+  # itself: redirections on a bare `exec` are permanent for the shell, so
+  # `exec 8>>file 2>/dev/null` would silence stderr for THIS SHELL AND
+  # EVERYTHING IT SPAWNS — postgres's entire log stream and pgBackRest's
+  # archive errors would vanish from `docker logs`. The brace group scopes
+  # the stderr redirect to the open attempt; the fd opened by exec is
+  # permanent either way.
+  if { exec 8>>"$UPGRADE_LOCK_FILE"; } 2>/dev/null; then
     if ! flock -n -s 8; then
       echo "A major version upgrade job is currently running against this volume."
       echo "The database must not start until it finishes; retry the deploy once the upgrade completes."

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -110,6 +110,25 @@ if [ -f "$POSTGRES_CONF_FILE" ] && [ ! -f "$SSL_DIR/server.crt" ]; then
   bash "$INIT_SSL_SCRIPT"
 fi
 
+# Re-apply the ssl settings when the certificates exist but postgresql.conf
+# doesn't reference them. The checks above are keyed on the CERTIFICATE, which
+# lives at the volume root and therefore survives anything that replaces the
+# data directory — a major upgrade promotes a freshly initdb'd $PGDATA, so
+# postgresql.conf loses `ssl = on` while server.crt is still right there. The
+# result is a database that silently comes back with SSL off, rejecting every
+# sslmode=require client. Keying this on the CONFIG instead self-heals that
+# and any other path that resets postgresql.conf.
+if [ -f "$POSTGRES_CONF_FILE" ] && [ -f "$SSL_DIR/server.crt" ] \
+  && ! grep -qE "^[[:space:]]*ssl[[:space:]]*=" "$POSTGRES_CONF_FILE"; then
+  echo "wrapper: postgresql.conf has no ssl settings but certificates exist, re-applying"
+  cat >> "$POSTGRES_CONF_FILE" <<EOF
+ssl = on
+ssl_cert_file = '$SSL_DIR/server.crt'
+ssl_key_file = '$SSL_DIR/server.key'
+ssl_ca_file = '$SSL_DIR/root.crt'
+EOF
+fi
+
 # Adds pg_stat_statements to shared_preload_libraries in a config file
 # Usage: add_pg_stat_statements <config_file>
 add_pg_stat_statements() {

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -264,6 +264,26 @@ PGBACKREST_RESTORED_MARKER="$PGDATA/.pgbackrest_restored"
 # the user can browse and restore from.
 PGBACKREST_REPO_PATH_MARKER="$PGDATA/.pgbackrest_repo_path"
 
+# Identity fingerprint of the cluster the repo-path marker was derived from
+# (`sysid=` + `pg_version=`), written next to the marker every time the marker
+# is derived. The marker on its own cannot say whether it still belongs to the
+# cluster on disk — it is a bare path that wins VERBATIM over derivation, by
+# design, so that the effective repo path is stable across boots. When the
+# cluster underneath it is REPLACED (pg_upgrade initdb's a new cluster: new
+# system_identifier and new PG_VERSION), a marker that outlives the swap keeps
+# archiving into the previous cluster's repo — archive-push then fails against
+# that repo's archive.info forever and stanza-create errors on the system-id
+# mismatch. Comparing this fingerprint against the live values on every boot
+# catches that whatever the cause, which is the point: the major-upgrade
+# marker is deleted/aged out eventually, and a cluster re-identified by any
+# other route needs exactly the same handling.
+#
+# Holds no path on purpose. The marker is the sole authority on the active
+# path, so there is nothing here that can drift out of sync with it — and a
+# WAL_REGRESSION migration (which re-points the path of a cluster whose
+# identity did NOT change) must not look like a re-identification.
+PGBACKREST_REPO_ANCHOR_FILE="$PGDATA/.pgbackrest_repo_anchor"
+
 # Sentinel: WAL_ARCHIVE_BUCKET was set to something we couldn't honor (an
 # unresolved Railway template ref, a bucket-id UUID, whitespace, …). The
 # monitor reads this to distinguish "PITR was never enabled" from "PITR is
@@ -362,6 +382,37 @@ read_postgres_sysid() {
     | awk -F: '/Database system identifier/ { gsub(/[ \t]/,"",$2); print $2 }'
 }
 
+# The cluster's on-disk major. Empty pre-initdb. `|| true` because this file
+# runs under `set -e` and an unreadable PG_VERSION must never abort the boot.
+read_postgres_major() {
+  [ ! -f "$PGDATA/PG_VERSION" ] && return 0
+  cat "$PGDATA/PG_VERSION" 2>/dev/null || true
+}
+
+# Field reader for the anchor file. Empty when the file or the field is absent.
+# grep sits mid-pipeline so a no-match exits 0 overall — a bare `grep` here
+# would abort the boot under `set -e` the first time a field is missing.
+read_pgbackrest_anchor_field() {
+  local field="$1"
+  [ ! -f "$PGBACKREST_REPO_ANCHOR_FILE" ] && return 0
+  grep -E "^${field}=" "$PGBACKREST_REPO_ANCHOR_FILE" 2>/dev/null | tail -1 | cut -d= -f2-
+}
+
+# Record which cluster the current repo-path marker belongs to. tmp+rename so
+# a reader never sees a half-written fingerprint, and so a crash can only ever
+# leave the PREVIOUS anchor in place — which is what makes the re-anchor
+# retryable (see reanchor_pgbackrest_repo_path_if_reidentified).
+write_pgbackrest_repo_anchor() {
+  local sysid="$1" major="$2" tmp
+  [ -z "$sysid" ] && return 1
+  [ -z "$major" ] && return 1
+  tmp=$(mktemp "${PGBACKREST_REPO_ANCHOR_FILE}.XXXX") || return 1
+  printf 'sysid=%s\npg_version=%s\n' "$sysid" "$major" > "$tmp" || { rm -f "$tmp"; return 1; }
+  chown postgres:postgres "$tmp" 2>/dev/null || true
+  chmod 0640 "$tmp" 2>/dev/null || true
+  mv "$tmp" "$PGBACKREST_REPO_ANCHOR_FILE" || { rm -f "$tmp"; return 1; }
+}
+
 # Resolve the effective repo1-path for archiving:
 #
 #   1. Marker file present → trust it. Idempotent across boots; survives
@@ -394,14 +445,203 @@ derive_pgbackrest_repo_path() {
 
   local cluster_path="${user_path%/}/cluster-${sysid}"
   write_pgbackrest_repo_path_marker "$cluster_path"
+  # Fingerprint the cluster this path was derived FROM, so a later boot can
+  # tell whether the marker still belongs to the cluster on disk. Written here
+  # rather than inside the marker writer: the marker writer is also the flip
+  # step of a re-anchor, where the anchor must land last, as the commit point.
+  write_pgbackrest_repo_anchor "$sysid" "$(read_postgres_major)" \
+    || echo "pgbackrest: could not write the repo-path anchor for cluster ${sysid}" >&2
   echo "$cluster_path"
 }
 
+# tmp+rename: the archive-push wrapper `cat`s this file on every WAL switch,
+# so a reader must see either the whole old path or the whole new one — same
+# reasoning as the watcher's apply_active_path, which is the other writer.
 write_pgbackrest_repo_path_marker() {
-  local path="$1"
-  echo "$path" > "$PGBACKREST_REPO_PATH_MARKER"
-  chown postgres:postgres "$PGBACKREST_REPO_PATH_MARKER" 2>/dev/null || true
-  chmod 0640 "$PGBACKREST_REPO_PATH_MARKER" 2>/dev/null || true
+  local path="$1" tmp
+  [ -z "$path" ] && return 1
+  tmp=$(mktemp "${PGBACKREST_REPO_PATH_MARKER}.XXXX") || return 1
+  printf '%s\n' "$path" > "$tmp" || { rm -f "$tmp"; return 1; }
+  chown postgres:postgres "$tmp" 2>/dev/null || true
+  chmod 0640 "$tmp" 2>/dev/null || true
+  mv "$tmp" "$PGBACKREST_REPO_PATH_MARKER" || { rm -f "$tmp"; return 1; }
+}
+
+# Replace the backup watcher's state file with nothing but the migration gate
+# (`archive_migration_pending_new_path`, empty to release it).
+#
+# Replaced rather than edited because every field in it describes backups at
+# the OLD path. Clearing last_full_at is what trips the watcher's
+# NEEDS_INITIAL_BACKUP, so an immediate full fires at the new path; every other
+# field the watcher reads defaults sanely when absent.
+#
+# The gate itself is the watcher's own migration interlock (see
+# pgbackrest-backup-watcher.sh): while set, the watcher takes no backups and
+# keeps retrying the spool cleanup. Setting it BEFORE the marker flip means a
+# re-anchor that dies halfway can never leave the watcher backing up against
+# stale old-path async statuses.
+#
+# Safe to write wholesale because the watcher is forked strictly after this
+# runs — wrapper.sh has no concurrent writer at this point in the boot.
+write_backup_state_migration_gate() {
+  local new_path="$1" state_file="$PGDATA/.pgbackrest_backup_state" tmp
+  tmp=$(mktemp "${state_file}.XXXX") || return 1
+  printf 'archive_migration_pending_new_path=%s\n' "$new_path" > "$tmp" \
+    || { rm -f "$tmp"; return 1; }
+  chown postgres:postgres "$tmp" 2>/dev/null || true
+  chmod 0640 "$tmp" 2>/dev/null || true
+  mv "$tmp" "$state_file" || { rm -f "$tmp"; return 1; }
+}
+
+# Drop async status files left by the previous cluster. A stale `.ok` is the
+# dangerous one: pgBackRest treats it as proof the segment was already pushed
+# and skips the upload, so it would silently punch holes in the NEW path's WAL
+# coverage. The spool is a coordination cache, never durable data — async
+# re-pushes from pg_wal on the next archive_command.
+#
+# Unlike the watcher's mid-flight equivalent there is no async daemon to drain
+# and kill here: wrapper.sh runs exactly once per container start, before any
+# postmaster of ours exists, so nothing can be writing these files.
+clean_archive_spool_statuses() {
+  local out_dir="$PGBACKREST_SPOOL_DIR/archive/main/out"
+  [ ! -d "$out_dir" ] && return 0
+  rm -f "$out_dir"/*.ok "$out_dir"/*.error 2>/dev/null || true
+  return 0
+}
+
+# Move archiving onto $2, leaving the previous cluster's archive at $1 intact.
+# Split out from the detection so the ordering below is readable as a unit; see
+# reanchor_pgbackrest_repo_path_if_reidentified for why the order is what it is.
+reanchor_pgbackrest_repo_path() {
+  local current_path="$1" new_path="$2"
+
+  # `current_path == new_path` means an earlier attempt already flipped the
+  # marker and then died before writing the anchor. The state reset always
+  # PRECEDES the flip, so a flipped marker also implies the state was reset —
+  # do not redo it (that would re-arm a full for a path that may already have
+  # one) and just finish the tail.
+  if [ "$current_path" != "$new_path" ]; then
+    write_backup_state_migration_gate "$new_path" || {
+      echo "pgbackrest: could not reset the backup-watcher state; leaving archiving at ${current_path}" >&2
+      return 1
+    }
+    write_pgbackrest_repo_path_marker "$new_path" || {
+      echo "pgbackrest: could not write the repo-path marker for ${new_path}" >&2
+      return 1
+    }
+    # Defense-in-depth for callers that read the conf instead of the marker
+    # (operator `docker exec` shells, mono's SSH `pgbackrest info` probe when
+    # it can't export the env override). bootstrap_pgbackrest_stanza rewrites
+    # this again from the marker once Postgres is up; both are idempotent.
+    if [ -f "$PGBACKREST_CONF_FILE" ]; then
+      sed -i "s|^repo1-path=.*|repo1-path=${new_path}|" "$PGBACKREST_CONF_FILE" \
+        || echo "pgbackrest: could not rewrite repo1-path in ${PGBACKREST_CONF_FILE} (the marker is authoritative)" >&2
+    fi
+  fi
+
+  clean_archive_spool_statuses
+  # The old cluster's gap sentinel describes the old path's coverage.
+  rm -f "$PGDATA/.pgbackrest_gap_pending" 2>/dev/null || true
+  # Cleanup done: release the watcher's backup gate. Failing here is safe —
+  # the watcher retries the same cleanup and clears the gate itself.
+  write_backup_state_migration_gate "" \
+    || echo "pgbackrest: could not clear the pending-migration gate; the watcher will retry it" >&2
+  return 0
+}
+
+# Re-anchor archiving onto the current cluster's own repo path when the cluster
+# that anchored the marker is gone. Runs on EVERY boot, before stanza bootstrap
+# and before Postgres starts — the only window where the flip is free: no
+# postmaster means no archive_command in flight, and no async daemon of ours
+# exists yet.
+#
+# Detection is the anchor fingerprint, never the major-upgrade marker: a
+# pg_upgrade is only the most common way to acquire a new system_identifier,
+# the upgrade marker is deleted/aged out eventually, and any other route to a
+# re-identified cluster needs the identical response. Today's upgrade job
+# reaches the same end state by a different road — its directory swap promotes
+# a freshly initdb'd data dir, so the new PGDATA inherits none of the old
+# cluster's pgbackrest files and the path is simply DERIVED fresh. This check
+# is what keeps that from being load-bearing: any upgrade route that carries
+# $PGDATA's config forward (or the dump/restore fallback for the legacy
+# PGDATA-is-the-volume-root layout, where these files sit outside the swapped
+# directory entirely) hands us a surviving marker pointing at the previous
+# cluster's repo.
+#
+# The new path needs no uniqueness suffix — unlike the watcher's WAL_REGRESSION
+# migration, which re-points the path of a cluster whose identity did NOT
+# change and therefore has to disambiguate with an epoch. A fresh
+# system_identifier makes `cluster-<sysid>` collision-free by construction,
+# and deterministic: a crashed attempt recomputes exactly the same target
+# instead of stranding a sibling prefix per retry.
+#
+# Order is chosen so every interruption converges on the next boot:
+#   1. gate the watcher + clear its timestamps (state describes the old path)
+#   2. flip the marker (+ conf) — the instant archiving moves
+#   3. drop the old path's spool statuses, release the watcher gate
+#   4. write the new anchor LAST
+# The anchor is the commit point: while it still names the old cluster the next
+# boot re-detects and re-runs, and every step is idempotent. Nothing here can
+# fail the boot — a database that is up with degraded archiving beats a
+# database that refuses to start, which is how the rest of this file treats
+# archive failures.
+reanchor_pgbackrest_repo_path_if_reidentified() {
+  [ -z "${WAL_ARCHIVE_BUCKET:-}" ] && return 0
+  [ ! -f "$PGDATA/global/pg_control" ] && return 0
+  # No marker: nothing is anchored yet, so there is nothing to re-anchor.
+  # derive_pgbackrest_repo_path writes both files from the live cluster.
+  [ ! -f "$PGBACKREST_REPO_PATH_MARKER" ] && return 0
+
+  local live_sysid live_major
+  live_sysid=$(read_postgres_sysid)
+  live_major=$(read_postgres_major)
+  if [ -z "$live_sysid" ] || [ -z "$live_major" ]; then
+    echo "pgbackrest: could not read the cluster identity (sysid='${live_sysid}', PG_VERSION='${live_major}'); leaving the archive path as-is" >&2
+    return 0
+  fi
+
+  local anchor_sysid anchor_major
+  anchor_sysid=$(read_pgbackrest_anchor_field sysid)
+  anchor_major=$(read_pgbackrest_anchor_field pg_version)
+
+  # Volume written before the anchor existed: adopt the live identity for the
+  # path already in the marker. Backfilling is the only safe reading of a
+  # missing anchor — "no fingerprint" is not evidence of a changed cluster,
+  # and the marker's path is where this cluster's archive already lives.
+  # Re-anchoring on a missing anchor would move every existing PITR-enabled
+  # service to a new prefix on its next redeploy.
+  if [ -z "$anchor_sysid" ] || [ -z "$anchor_major" ]; then
+    if write_pgbackrest_repo_anchor "$live_sysid" "$live_major"; then
+      echo "pgbackrest: adopted repo-path anchor (sysid=${live_sysid}, pg=${live_major}) for the existing archive path"
+    else
+      echo "pgbackrest: could not write the repo-path anchor; cluster re-identification stays undetectable until it succeeds" >&2
+    fi
+    return 0
+  fi
+
+  if [ "$anchor_sysid" = "$live_sysid" ] && [ "$anchor_major" = "$live_major" ]; then
+    return 0
+  fi
+
+  local current_path new_path user_path
+  current_path=$(cat "$PGBACKREST_REPO_PATH_MARKER" 2>/dev/null || true)
+  user_path="${WAL_ARCHIVE_PATH:-/pgbackrest}"
+  new_path="${user_path%/}/cluster-${live_sysid}"
+
+  echo "pgbackrest: cluster re-identified (anchored sysid=${anchor_sysid} pg=${anchor_major}, on disk sysid=${live_sysid} pg=${live_major}); re-anchoring archiving from ${current_path} to ${new_path}"
+
+  if ! reanchor_pgbackrest_repo_path "$current_path" "$new_path"; then
+    echo "pgbackrest: re-anchor to ${new_path} did not complete; the backup watcher retries it. Archiving stays degraded until then — the database is starting regardless." >&2
+    return 0
+  fi
+
+  if ! write_pgbackrest_repo_anchor "$live_sysid" "$live_major"; then
+    echo "pgbackrest: re-anchored to ${new_path} but could not write the anchor; the next boot re-runs this (idempotent)" >&2
+    return 0
+  fi
+
+  echo "pgbackrest: re-anchored to ${new_path}; stanza-create and an immediate full backup follow there. The previous cluster's archive is untouched at ${current_path}."
+  return 0
 }
 
 # Detect the container's effective CPU allocation. Reads cgroup v2 cpu.max
@@ -1177,6 +1417,15 @@ if [ -n "${WAL_ARCHIVE_BUCKET:-}" ] && [ -f "$PGDATA/global/pg_control" ] && [ !
   echo "pgbackrest: pre-fork repo-path marker = ${_early_repo_path}"
   unset _early_repo_path
 fi
+
+# …and when a marker IS present, check it still belongs to the cluster on disk.
+# Disjoint from the block above (that one only fires with no marker at all) and
+# deliberately ahead of stanza bootstrap: a stale marker would make
+# stanza-create fail on a system-id mismatch and every archive-push fail
+# against the previous cluster's archive.info. `|| true` because this file runs
+# under `set -e` and a failed re-anchor must never stop the database from
+# starting — the watcher retries.
+reanchor_pgbackrest_repo_path_if_reidentified || true
 
 # After a major upgrade, planner statistics start empty (pg_upgrade does not
 # carry them across majors before 18). Rebuild them in stages in the


### PR DESCRIPTION
The in-place major-upgrade job for the Postgres major-version upgrade feature (RFC: "One-click Postgres major version upgrades"), plus the runtime guards that make a cross-major mismatch impossible to boot into. Dispatched by railwayapp/mono#34384.

## The job image

`Dockerfile.upgrade` builds per source→target pair: target major as the base image, source major's server binaries added, pgvector for both (pg_upgrade starts the old server, and `--check` fails unless every library the old cluster references resolves in the new one). `upgrade-job.sh` is the whole program, with four modes selected via the `UPGRADE_JOB_MODE` env var — not `startCommand`, since Railway's two container runtimes disagree on how it composes with the image's own ENTRYPOINT. A positional arg still works for local/manual runs and the e2e harness, which invoke the script directly, but only as a fallback behind the env var, and an unrecognized one refuses rather than silently defaulting to `upgrade` — a typo'd read-only check must not become the destructive path:

| Mode | Effect |
|---|---|
| `check` | `pg_upgrade --check` against a throwaway target cluster. Not strictly read-only: an unclean cluster (the platform SIGKILLs on stop) is first quiesced — WAL replayed with the old binaries, then a clean shutdown, exactly what the next boot would have done. |
| `upgrade` | `--check`, then `pg_upgrade --link`, then the completion marker, then the directory swap. |
| `status` | Marker phase + on-disk major as JSON — how the workflow decides roll-back vs roll-forward. |
| `manifest` | The target major's installable extensions as JSON, for the dashboard preflight. |

Each mode prints one `RAILWAY_UPGRADE_RESULT:` JSON line as its contract with the orchestrator, built with `jq --arg` rather than string interpolation — several inputs (the on-disk `PG_VERSION`, marker fields) are DB-superuser-controlled, and a hand-built payload would let a crafted value plant a duplicate key or forge an extra result line. Volumes with `recovery.signal`/`standby.signal` are refused outright (those shapes can't upgrade in place). `pg_upgrade --jobs` is sized from the cgroup CPU quota, not the host's `nproc`.

## The commit point

`.railway-major-upgrade.json` at the volume root, outside PGDATA (which pg_upgrade replaces wholesale). `phase: upgraded` = pg_upgrade succeeded, the swap may be incomplete, recovery rolls forward. `phase: completed` = swap done; also records `needsAnalyze` and `needsReindex`.

Resume is scoped to the job's own version pair — a completed marker from a prior upgrade of the same volume is history, not state, so 16→17 followed later by 17→18 works correctly instead of the second job no-opping while the data stays on 17. A lost marker rolls forward only when the disk proves pg_upgrade finished: `pg_control.old` present **and** the job's own completion sentinel in the target directory. The sentinel matters because pg_upgrade renames `pg_control` before it links the first relation file, so `pg_control.old` alone only proves linking started; without the sentinel the job rolls back instead — reversing the rename (safe while the target cluster has never booted) and redoing the upgrade.

## Runtime guards (wrapper.sh)

A non-completed marker refuses every boot, either major. On-disk `PG_VERSION` must match the image's installed major, derived from the server tree with `PG_MAJOR` as a logged fallback — a stray service-variable override can't refuse a healthy boot. A shared `flock` on the volume-root lock file, held for the container's lifetime, makes a job-vs-live-runtime race and a runtime-vs-job race both refuse instead of bricking the volume.

## State carried across the swap

pg_upgrade promotes a fresh `initdb`, so anything living in the old PGDATA is lost unless carried explicitly:

- **SSL**: certs survive at the volume root; the wrapper re-applies `ssl` settings whenever the config has none while certs exist.
- **pg_hba.conf**: the job carries the old cluster's `pg_hba.conf`/`pg_ident.conf` forward, and the wrapper re-appends the default remote-access rule only on the recognizable bare-initdb shape — an authored, narrowed policy is never re-widened.
- **PITR sentinels**: carried across the swap; a completed marker is itself treated as proof of promoted recovery, so an upgraded PITR fork doesn't re-stage archive recovery and hang at startup forever.
- **postgresql.conf**/`postgresql.auto.conf`: not carried (a removed GUC would refuse the boot), but stashed at the volume root and flagged via `needsConfigReview` so tuning loss isn't silent.
- **PGHOST/PGHOSTADDR/PGPORT**: both templates default `PGHOST` to the private-network domain, which the job inherits like every other service variable. pg_upgrade reads libpq env vars directly and refuses outright on a non-local host (verified against the binary for both `PGHOST` and `PGHOSTADDR`), so all three are cleared unconditionally before invoking it.

## Disk reclaim

The pre-upgrade cluster is kept at `${PGDATA}.old-<from>` as an instant-rollback body (the `--link` hardlinks pin its inodes, so it isn't kept forever). Reclaimed in the background once the upgraded database has been up and answering past a grace period (24h from `completedAt`, `UPGRADE_OLD_DIR_RETENTION_SECONDS` overrides); the marker records `oldDataDirRemovedAt`.

## Archive re-anchoring (PITR)

An upgraded cluster has a new `system_identifier`, so archiving follows it to a fresh `cluster-<sysid>` prefix. A PITR restore itself never trips this (it preserves the sysid); today's job derives the path fresh, so this is defense in depth for future PGDATA-carrying routes. The re-anchor writes a fresh watcher state file rather than carrying anything forward — the watcher's own same-cluster WAL_REGRESSION retries track their pre-migration path independently, and a genuine re-identification means that bookkeeping belongs to an identity that no longer exists. The PITR window restarts at a major upgrade — the old prefix stays restorable but orphaned (cleanup is an open follow-up on the backboard side).

## Collation caveat

pg_upgrade keeps index files verbatim, but collatable-column indexes are only valid for the glibc that built them, which the job can't see. Every upgrade sets `needsReindex: true` on the marker; the image deliberately doesn't auto-REINDEX — surfacing the flag and driving the reindex is the dashboard's job.

## Tests

`test/e2e-upgrade.sh` (43 assertions): happy path with pgvector, check pass/blocker paths (source-major-gated `reg*`/`aclitem` checks), unclean-shutdown recovery, wrong major, concurrent job, idempotent re-run, crash-mid-link rollback and re-run, remote-client auth across the upgrade, PITR-fork upgrade, chained 16→17→18 on one volume, foreign-pair marker refusal, job/runtime lock refusals, custom `POSTGRES_USER` and postgres-ha's inverted Patroni superuser convention, custom `POSTGRES_INITDB_ARGS`, a real-Railway-shaped root-owned volume root, the PGHOST/PGHOSTADDR/PGPORT fix, mode selection via `UPGRADE_JOB_MODE` specifically (every other test drives the mode through the positional fallback, so this is the only one that exercises the actual production dispatch path), an unrecognized positional arg refusing instead of defaulting to `upgrade`, and a crafted `PG_VERSION` value confirming it can't forge a second `RAILWAY_UPGRADE_RESULT:` line into the log. Wired into `.github/workflows/e2e.yml` with 16→17 and 17→18 cells.

Verified against a real Railway project, not just docker: deployed Postgres 16 on a real volume, built the job image from git source against this branch, ran the upgrade, repinned to 17 — exact row count and checksum match afterward. That run is what found the root-owned-volume-root bug above: a real Railway volume's root is `root:root`, only PGDATA itself is postgres-owned, so creating the sibling upgrade directory as postgres failed permission on every real deployment (docker masks this locally by copying the image's own, differently-owned, permissions onto a fresh named volume).
