### PR TITLE
fix(wrapper): chown collation-refresh temp file to postgres before writing it

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -321,6 +321,38 @@ t_vanilla_boot() {
   docker volume rm "$vol" >/dev/null
 }
 
+t_collation_refresh_no_permission_error() {
+  # Regression: fork_collation_refresh's mktemp ran as root (mode 0600,
+  # root-owned) while the gosu postgres psql call read it as the postgres
+  # user — a deterministic "Permission denied" on every PG15+ boot. Central
+  # Station thread production-postgres-crash-looping-after-b350b460
+  # (2026-08-04) reported a crash loop on a service that hit this.
+  local name=t-collation-${PG_VERSION}
+  local vol=${name}-vol
+  new_volume "$vol"
+  docker rm -f "$name" >/dev/null 2>&1 || true
+  docker run -d --name "$name" --label postgres-ssl-e2e=1 --network "$NET" \
+    -e POSTGRES_PASSWORD=test \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$IMAGE" >/dev/null
+  wait_for_pg "$name" || { ko t_collation_refresh_no_permission_error "postgres did not start"; fail_dump t_collation_refresh_no_permission_error "$name"; return; }
+
+  # fork_collation_refresh's pg_isready poll succeeds on its first 2s tick
+  # since postgres is already up; give psql a few seconds to run and its
+  # output to flush before reading logs.
+  sleep 5
+  local logs
+  logs=$(docker logs "$name" 2>&1)
+  if echo "$logs" | grep -q "collation-refresh:.*Permission denied"; then
+    ko t_collation_refresh_no_permission_error "collation-refresh temp file was not readable by postgres"
+    fail_dump t_collation_refresh_no_permission_error "$name"
+    return
+  fi
+  ok t_collation_refresh_no_permission_error
+  docker rm -f "$name" >/dev/null
+  docker volume rm "$vol" >/dev/null
+}
+
 t_invalid_bucket_skips_archive() {
   # Sets WAL_ARCHIVE_BUCKET to junk shapes the upstream resolver might leak
   # (unresolved Railway template ref + bucket-id UUID). The image guard must
@@ -3810,6 +3842,7 @@ t_invalid_bucket_sentinel_cleared_on_disable() {
 
 ALL_TESTS=(
   t_vanilla_boot
+  t_collation_refresh_no_permission_error
   t_invalid_bucket_skips_archive
   t_archiving_boot
   t_alter_system_survives_restart

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1042,6 +1042,11 @@ fork_collation_refresh() {
 
     local tmpfile
     tmpfile=$(mktemp /tmp/collation-refresh.XXXXXX.sql)
+    # mktemp runs as root (this subshell isn't gosu'd) and defaults to mode
+    # 0600 — unreadable by the postgres user that the psql call below drops
+    # to. Hand ownership over before writing the SQL body, or every boot on
+    # PG15+ logs "collation-refresh: psql: error: ...: Permission denied".
+    chown postgres:postgres "$tmpfile"
     cat > "$tmpfile" << 'ENDSQL'
 DO $body$
 DECLARE


### PR DESCRIPTION
## Summary

`fork_collation_refresh` (#101) creates its temp SQL file with a plain
`mktemp` — running as root, since this subshell is never `gosu`'d — which
defaults to mode `0600`, root-owned. The very next line drops to the
`postgres` user (`gosu postgres psql ... -f "$tmpfile"`) to read that same
file, which it can't. This is not intermittent: it reproduces on **every**
boot where PG major ≥ 15, unconditionally.

```
collation-refresh: psql: error: /tmp/collation-refresh.XXXXXX.sql: Permission denied
```

By itself this is cosmetic — the collation-mismatch WARNING just never gets
silenced — but it surfaced as a real production incident: a customer's
Postgres crash-looped after being redeployed by the CVE-2026-6473/6475
remediation campaign, reported on Central Station
(`production-postgres-crash-looping-after-b350b460`). Their own manual
`ALTER DATABASE ... REFRESH COLLATION VERSION;` stopped the crash loop.
Fleet-wide Central Station search turned up no other confirmed instance
(two other superficially-similar threads checked out as unrelated: one
customer's own accidental `railway up` mislink, one from an unrelated
February platform incident predating this code path) — narrow blast radius,
consistent with this alone not being sufficient to crash-loop, but worth
fixing regardless since it's a confirmed, 100%-reproducible defect.

Fix: `chown postgres:postgres "$tmpfile"` right after `mktemp`, matching
the `chown`-after-root-write idiom already used throughout this file for
every other file postgres needs to read back.

## Verification

Reproduced and fixed live, not just reasoned from the code:
- Built the PG17 image pre-fix, booted a vanilla container, confirmed the
  exact customer-reported log line appears on a completely vanilla boot
  (no PITR, no WAL archiving) — confirming this is universal, not
  configuration-dependent.
- Applied the fix, rebuilt, re-ran — clean boot, no permission error.

This feature shipped with no test coverage at all. Added
`t_collation_refresh_no_permission_error` to `test/e2e.sh` (registered in
`ALL_TESTS`), which boots vanilla and asserts the permission-denied line
never appears in the container logs.

## Test plan

- [x] `bash test/e2e.sh t_collation_refresh_no_permission_error` — fails
      against `wrapper.sh` pre-fix, passes post-fix (verified locally)
- [ ] CI (`e2e.yml`) green across the PG version matrix