### PR TITLE
fix(wrapper): write collation-refresh SQL before chowning it to postgres

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1042,11 +1042,6 @@ fork_collation_refresh() {
 
     local tmpfile
     tmpfile=$(mktemp /tmp/collation-refresh.XXXXXX.sql)
-    # mktemp runs as root (this subshell isn't gosu'd) and defaults to mode
-    # 0600 — unreadable by the postgres user that the psql call below drops
-    # to. Hand ownership over before writing the SQL body, or every boot on
-    # PG15+ logs "collation-refresh: psql: error: ...: Permission denied".
-    chown postgres:postgres "$tmpfile"
     cat > "$tmpfile" << 'ENDSQL'
 DO $body$
 DECLARE
@@ -1065,6 +1060,12 @@ BEGIN
 END
 $body$;
 ENDSQL
+    # mktemp runs as root (this subshell isn't gosu'd) and defaults to mode
+    # 0600, unreadable by the postgres user the psql call below drops to.
+    # Ownership must be handed over only AFTER writing the body: the
+    # container's root has CAP_CHOWN but not CAP_DAC_OVERRIDE, so the moment
+    # the file belongs to postgres, root itself can no longer write it.
+    chown postgres:postgres "$tmpfile"
     gosu postgres psql -v ON_ERROR_STOP=0 -q -f "$tmpfile" 2>&1 | \
       while IFS= read -r line; do [ -n "$line" ] && echo "collation-refresh: $line"; done
     rm -f "$tmpfile"


### PR DESCRIPTION
Reorders the collation-refresh temp-file handling so the SQL body is written while root still owns the file, and ownership is handed to `postgres` only afterwards.

#114 moved the permission failure instead of fixing it: with the `chown postgres:postgres` placed before the heredoc write, the write itself now fails on runtimes where the container's root has `CAP_CHOWN` but not `CAP_DAC_OVERRIDE` — once the file belongs to `postgres` (mode 0600), root can no longer write it. Boot logs went from `collation-refresh: psql: error: ...: Permission denied` (pre-#114) to `wrapper.sh: line 1050: /tmp/collation-refresh.XXXXXX.sql: Permission denied` (post-#114), and the refresh has still never run.

Validated the mechanism under `docker run --cap-drop=DAC_OVERRIDE`:

- chown-before-write: `bash: line N: /tmp/collation-refresh.XXXXXX.sql: Permission denied` (matches production boot logs)
- write-then-chown: write succeeds, and the non-root user reads the 0600 file fine afterwards

Note for reviewers: plain `docker run` masks this bug — root keeps `CAP_DAC_OVERRIDE` by default, so both orderings appear to work there.