### PR TITLE
ci: content gate — publish nothing when neither repo code nor upstream moved

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 0 * * 1"  # Every Monday at midnight UTC
   workflow_dispatch:
+    inputs:
+      force:
+        description: "Bypass the content gate and rebuild+push everything"
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -55,7 +60,55 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Skip the build entirely — same digest, no fleet redeploys — unless
+      # something REAL moved: the repo code that reaches the image, the
+      # upstream base image, or Debian's pending-security-fix set for that
+      # base. The key is planted on the published image as a label;
+      # digest-tracking consumers (the vuln auto-update machinery runs
+      # tagMode "sha" against these images) therefore only see a new digest
+      # when there is something worth redeploying for. Fails OPEN to
+      # building — a gate error must never silently freeze a tag. The
+      # package probe runs on amd64 and stands proxy for both platforms.
+      - name: Content gate
+        id: gate
+        run: |
+          set -o pipefail
+          IMG="ghcr.io/${{ github.repository }}"
+          TAG="${{ steps.get_version.outputs.minor_version }}"
+          BASE="postgres:${{ steps.get_version.outputs.minor_version }}"
+
+          GATE_OK=true
+          CODE_KEY=$(git ls-tree HEAD | grep -E "\.sh$|Dockerfile\.${{ matrix.postgres_major }}$" | sha256sum | cut -c1-16) || GATE_OK=false
+          BASE_DIGEST=$(docker buildx imagetools inspect "$BASE" --format '{{json .Manifest.Digest}}' | tr -d '"') || GATE_OK=false
+          docker pull -q "$BASE" >/dev/null || GATE_OK=false
+          PKG_KEY=$(docker run --rm "$BASE" bash -c "apt-get update -qq >/dev/null 2>&1; apt list --upgradable 2>/dev/null | sort" | sha256sum | cut -c1-16) || GATE_OK=false
+
+          if [ "$GATE_OK" != "true" ] || [ -z "$CODE_KEY" ] || [ -z "$BASE_DIGEST" ] || [ -z "$PKG_KEY" ]; then
+            echo "::warning::content gate failed for ${TAG}; building unconditionally"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "key=gate-error-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          KEY=$(printf '%s\n' "$CODE_KEY" "$BASE_DIGEST" "$PKG_KEY" | sha256sum | cut -c1-32)
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+          PUBLISHED_KEY=$(docker buildx imagetools inspect "$IMG:$TAG" --format '{{json .Image}}' 2>/dev/null \
+            | jq -r '(.config // .["linux/amd64"].config) | .Labels["railway.content-key"] // empty' 2>/dev/null || true)
+
+          if [ "${{ github.event.inputs.force || 'false' }}" = "true" ]; then
+            echo "force requested — building"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif [ "$KEY" = "$PUBLISHED_KEY" ]; then
+            echo "unchanged (key $KEY) — skipping build; digest stays put"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed (key $KEY, published ${PUBLISHED_KEY:-<none>}) — building"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push with multiple tags
+        if: steps.gate.outputs.changed == 'true'
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile.${{ matrix.postgres_major }}
@@ -63,10 +116,27 @@ jobs:
           push: true
           build-args: |
             POSTGRES_VERSION=${{ steps.get_version.outputs.minor_version }}
+            PKG_REFRESH=${{ steps.gate.outputs.key }}
+          labels: |
+            railway.content-key=${{ steps.gate.outputs.key }}
           tags: |
             ghcr.io/${{ github.repository }}:${{ matrix.postgres_major }}
             ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.minor_version }}
             ${{ matrix.postgres_major == env.LATEST_POSTGRES_MAJOR && format('ghcr.io/{0}:latest', github.repository) || '' }}
+
+      # Unchanged image: keep the :major (and :latest) pointers current
+      # WITHOUT minting a new digest — imagetools create only adds tag
+      # references to the existing manifest index.
+      - name: Refresh pointers on unchanged image
+        if: steps.gate.outputs.changed == 'false'
+        run: |
+          IMG="ghcr.io/${{ github.repository }}"
+          SRC="$IMG:${{ steps.get_version.outputs.minor_version }}"
+          tags="-t $IMG:${{ matrix.postgres_major }}"
+          if [ "${{ matrix.postgres_major }}" = "${{ env.LATEST_POSTGRES_MAJOR }}" ]; then
+            tags="$tags -t $IMG:latest"
+          fi
+          docker buildx imagetools create $tags "$SRC"
 
 
   # One image per (source, target) major pair, carrying both majors' server
@@ -116,7 +186,49 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Same content gate as build-postgres (see that job for rationale).
+      # Single tag per pair, so an unchanged image needs no pointer refresh —
+      # the job simply publishes nothing.
+      - name: Content gate
+        id: gate
+        run: |
+          set -o pipefail
+          IMG="ghcr.io/${{ github.repository }}/upgrade"
+          TAG="${{ matrix.from }}-${{ matrix.to }}"
+          BASE="postgres:${{ matrix.to }}"
+
+          GATE_OK=true
+          CODE_KEY=$(git ls-tree HEAD | grep -E "\.sh$|Dockerfile\.upgrade$" | sha256sum | cut -c1-16) || GATE_OK=false
+          BASE_DIGEST=$(docker buildx imagetools inspect "$BASE" --format '{{json .Manifest.Digest}}' | tr -d '"') || GATE_OK=false
+          docker pull -q "$BASE" >/dev/null || GATE_OK=false
+          PKG_KEY=$(docker run --rm "$BASE" bash -c "apt-get update -qq >/dev/null 2>&1; apt list --upgradable 2>/dev/null | sort" | sha256sum | cut -c1-16) || GATE_OK=false
+
+          if [ "$GATE_OK" != "true" ] || [ -z "$CODE_KEY" ] || [ -z "$BASE_DIGEST" ] || [ -z "$PKG_KEY" ]; then
+            echo "::warning::content gate failed for upgrade:${TAG}; building unconditionally"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "key=gate-error-${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          KEY=$(printf '%s\n' "$CODE_KEY" "$BASE_DIGEST" "$PKG_KEY" | sha256sum | cut -c1-32)
+          echo "key=$KEY" >> "$GITHUB_OUTPUT"
+
+          PUBLISHED_KEY=$(docker buildx imagetools inspect "$IMG:$TAG" --format '{{json .Image}}' 2>/dev/null \
+            | jq -r '(.config // .["linux/amd64"].config) | .Labels["railway.content-key"] // empty' 2>/dev/null || true)
+
+          if [ "${{ github.event.inputs.force || 'false' }}" = "true" ]; then
+            echo "force requested — building"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif [ "$KEY" = "$PUBLISHED_KEY" ]; then
+            echo "unchanged (key $KEY) — skipping build; digest stays put"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed (key $KEY, published ${PUBLISHED_KEY:-<none>}) — building"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push the upgrade job image
+        if: steps.gate.outputs.changed == 'true'
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile.upgrade
@@ -125,5 +237,8 @@ jobs:
           build-args: |
             FROM_VERSION=${{ matrix.from }}
             TO_VERSION=${{ matrix.to }}
+            PKG_REFRESH=${{ steps.gate.outputs.key }}
+          labels: |
+            railway.content-key=${{ steps.gate.outputs.key }}
           tags: |
             ghcr.io/${{ github.repository }}/upgrade:${{ matrix.from }}-${{ matrix.to }}

--- a/Dockerfile.13
+++ b/Dockerfile.13
@@ -4,7 +4,14 @@ FROM postgres:${POSTGRES_VERSION}
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
-RUN apt-get update && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-13-pgvector \
+# CI passes its content key here (see the build workflow's content gate):
+# the value only changes when the repo code, the upstream base, or Debian's
+# pending-security-fix set moved, so this layer re-runs exactly when there
+# is something to pick up — and stays byte-cached (stable digest) otherwise.
+ARG PKG_REFRESH=none
+RUN echo "refresh key: ${PKG_REFRESH}" \
+    && apt-get update && apt-get upgrade -y \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-13-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.14
+++ b/Dockerfile.14
@@ -4,7 +4,14 @@ FROM postgres:${POSTGRES_VERSION}
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
-RUN apt-get update && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-14-pgvector \
+# CI passes its content key here (see the build workflow's content gate):
+# the value only changes when the repo code, the upstream base, or Debian's
+# pending-security-fix set moved, so this layer re-runs exactly when there
+# is something to pick up — and stays byte-cached (stable digest) otherwise.
+ARG PKG_REFRESH=none
+RUN echo "refresh key: ${PKG_REFRESH}" \
+    && apt-get update && apt-get upgrade -y \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-14-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.15
+++ b/Dockerfile.15
@@ -4,7 +4,14 @@ FROM postgres:${POSTGRES_VERSION}
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
-RUN apt-get update && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-15-pgvector \
+# CI passes its content key here (see the build workflow's content gate):
+# the value only changes when the repo code, the upstream base, or Debian's
+# pending-security-fix set moved, so this layer re-runs exactly when there
+# is something to pick up — and stays byte-cached (stable digest) otherwise.
+ARG PKG_REFRESH=none
+RUN echo "refresh key: ${PKG_REFRESH}" \
+    && apt-get update && apt-get upgrade -y \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-15-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.16
+++ b/Dockerfile.16
@@ -4,7 +4,14 @@ FROM postgres:${POSTGRES_VERSION}
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
-RUN apt-get update && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-16-pgvector \
+# CI passes its content key here (see the build workflow's content gate):
+# the value only changes when the repo code, the upstream base, or Debian's
+# pending-security-fix set moved, so this layer re-runs exactly when there
+# is something to pick up — and stays byte-cached (stable digest) otherwise.
+ARG PKG_REFRESH=none
+RUN echo "refresh key: ${PKG_REFRESH}" \
+    && apt-get update && apt-get upgrade -y \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-16-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.17
+++ b/Dockerfile.17
@@ -4,7 +4,14 @@ FROM postgres:${POSTGRES_VERSION}
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
-RUN apt-get update && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-17-pgvector \
+# CI passes its content key here (see the build workflow's content gate):
+# the value only changes when the repo code, the upstream base, or Debian's
+# pending-security-fix set moved, so this layer re-runs exactly when there
+# is something to pick up — and stays byte-cached (stable digest) otherwise.
+ARG PKG_REFRESH=none
+RUN echo "refresh key: ${PKG_REFRESH}" \
+    && apt-get update && apt-get upgrade -y \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-17-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.18
+++ b/Dockerfile.18
@@ -4,7 +4,14 @@ FROM postgres:${POSTGRES_VERSION}
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
-RUN apt-get update && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-18-pgvector \
+# CI passes its content key here (see the build workflow's content gate):
+# the value only changes when the repo code, the upstream base, or Debian's
+# pending-security-fix set moved, so this layer re-runs exactly when there
+# is something to pick up — and stays byte-cached (stable digest) otherwise.
+ARG PKG_REFRESH=none
+RUN echo "refresh key: ${PKG_REFRESH}" \
+    && apt-get update && apt-get upgrade -y \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-18-pgvector \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.upgrade
+++ b/Dockerfile.upgrade
@@ -22,8 +22,14 @@ ENV PG_UPGRADE_TO=${TO_VERSION}
 # BOTH majors: pg_upgrade starts the old server (its loaded libraries must
 # resolve) and the new cluster must be able to load every library the old one
 # references, or --check fails with "loadable libraries" errors.
-RUN sed -ri "s/^(deb .*pgdg main).*$/\1 ${FROM_VERSION} ${TO_VERSION}/" /etc/apt/sources.list.d/pgdg.list \
+# CI content key (see the build workflow's content gate) — busts this layer
+# exactly when the repo code, the upstream base, or Debian's pending-fix set
+# moved, and keeps it byte-cached (stable digest) otherwise.
+ARG PKG_REFRESH=none
+RUN echo "refresh key: ${PKG_REFRESH}" \
+    && sed -ri "s/^(deb .*pgdg main).*$/\1 ${FROM_VERSION} ${TO_VERSION}/" /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
+    && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
       postgresql-${FROM_VERSION} \
       postgresql-${FROM_VERSION}-pgvector \


### PR DESCRIPTION
Same change as railwayapp-templates/postgres-ha#101, applied to this repo's main images and the upgrade-pair images.

## Problem

Every scheduled run re-minted every digest even when nothing changed. The platform's vuln auto-update machinery tracks these images with `tagMode: sha` — a moved digest is the redeploy signal.

## Fix

Both jobs compute a **content key** before building: a fingerprint of the repo files that reach the image (the major's Dockerfile / `Dockerfile.upgrade` + the root `*.sh` scripts — the same set the push paths-filter watches), the upstream base's manifest digest, and Debian's pending-security-fix set for that base (probed on amd64, standing proxy for both platforms of these multi-arch images).

Key equal to the `railway.content-key` label on the published tag → **skip build**; digest stays put; `:major`/`:latest` pointers are refreshed via `imagetools create` (index-level tag references only). Upgrade-pair images have a single tag and simply publish nothing. Key different → build+push with the key as label and layer-bust arg. Gate fails **open** to building; `workflow_dispatch` gains a `force` input.

Dockerfiles (13–18 + upgrade): the apt layers now run `apt-get upgrade -y` under a `PKG_REFRESH` arg, so base-package fixes actually reach the images instead of only our own installed packages being refreshed.

## Notes

- First run after merge rebuilds everything once (plants labels); quiet weeks after that publish nothing.
- Unlike postgres-ha, this repo still only builds each major's **newest** minor — superseded `:X.Y` tags stay frozen. If pinned-minor backfill (postgres-ha#100) is wanted here too, that's a separate follow-up.