### PR TITLE
fix(docker): hold the pinned minor's server packages through the OS upgrade

### DIFF
--- a/Dockerfile.13
+++ b/Dockerfile.13
@@ -9,9 +9,15 @@ FROM postgres:${POSTGRES_VERSION}
 # pending-security-fix set moved, so this layer re-runs exactly when there
 # is something to pick up — and stays byte-cached (stable digest) otherwise.
 ARG PKG_REFRESH=none
+# apt-mark hold: the OS upgrade must never touch the packages that define
+# the bundled Postgres minor — PGDG always carries the major's newest minor,
+# so an unheld upgrade can make the image bundle a newer server than the
+# minor tag it publishes under. Everything else upgrades freely.
 RUN echo "refresh key: ${PKG_REFRESH}" \
+    && apt-mark hold postgresql-13 postgresql-client-13 \
     && apt-get update && apt-get upgrade -y \
     && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-13-pgvector \
+    && apt-mark unhold postgresql-13 postgresql-client-13 \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.14
+++ b/Dockerfile.14
@@ -9,9 +9,15 @@ FROM postgres:${POSTGRES_VERSION}
 # pending-security-fix set moved, so this layer re-runs exactly when there
 # is something to pick up — and stays byte-cached (stable digest) otherwise.
 ARG PKG_REFRESH=none
+# apt-mark hold: the OS upgrade must never touch the packages that define
+# the bundled Postgres minor — PGDG always carries the major's newest minor,
+# so an unheld upgrade can make the image bundle a newer server than the
+# minor tag it publishes under. Everything else upgrades freely.
 RUN echo "refresh key: ${PKG_REFRESH}" \
+    && apt-mark hold postgresql-14 postgresql-client-14 \
     && apt-get update && apt-get upgrade -y \
     && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-14-pgvector \
+    && apt-mark unhold postgresql-14 postgresql-client-14 \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.15
+++ b/Dockerfile.15
@@ -9,9 +9,15 @@ FROM postgres:${POSTGRES_VERSION}
 # pending-security-fix set moved, so this layer re-runs exactly when there
 # is something to pick up — and stays byte-cached (stable digest) otherwise.
 ARG PKG_REFRESH=none
+# apt-mark hold: the OS upgrade must never touch the packages that define
+# the bundled Postgres minor — PGDG always carries the major's newest minor,
+# so an unheld upgrade can make the image bundle a newer server than the
+# minor tag it publishes under. Everything else upgrades freely.
 RUN echo "refresh key: ${PKG_REFRESH}" \
+    && apt-mark hold postgresql-15 postgresql-client-15 \
     && apt-get update && apt-get upgrade -y \
     && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-15-pgvector \
+    && apt-mark unhold postgresql-15 postgresql-client-15 \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.16
+++ b/Dockerfile.16
@@ -9,9 +9,15 @@ FROM postgres:${POSTGRES_VERSION}
 # pending-security-fix set moved, so this layer re-runs exactly when there
 # is something to pick up — and stays byte-cached (stable digest) otherwise.
 ARG PKG_REFRESH=none
+# apt-mark hold: the OS upgrade must never touch the packages that define
+# the bundled Postgres minor — PGDG always carries the major's newest minor,
+# so an unheld upgrade can make the image bundle a newer server than the
+# minor tag it publishes under. Everything else upgrades freely.
 RUN echo "refresh key: ${PKG_REFRESH}" \
+    && apt-mark hold postgresql-16 postgresql-client-16 \
     && apt-get update && apt-get upgrade -y \
     && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-16-pgvector \
+    && apt-mark unhold postgresql-16 postgresql-client-16 \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.17
+++ b/Dockerfile.17
@@ -9,9 +9,15 @@ FROM postgres:${POSTGRES_VERSION}
 # pending-security-fix set moved, so this layer re-runs exactly when there
 # is something to pick up — and stays byte-cached (stable digest) otherwise.
 ARG PKG_REFRESH=none
+# apt-mark hold: the OS upgrade must never touch the packages that define
+# the bundled Postgres minor — PGDG always carries the major's newest minor,
+# so an unheld upgrade can make the image bundle a newer server than the
+# minor tag it publishes under. Everything else upgrades freely.
 RUN echo "refresh key: ${PKG_REFRESH}" \
+    && apt-mark hold postgresql-17 postgresql-client-17 \
     && apt-get update && apt-get upgrade -y \
     && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-17-pgvector \
+    && apt-mark unhold postgresql-17 postgresql-client-17 \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password

--- a/Dockerfile.18
+++ b/Dockerfile.18
@@ -9,9 +9,15 @@ FROM postgres:${POSTGRES_VERSION}
 # pending-security-fix set moved, so this layer re-runs exactly when there
 # is something to pick up — and stays byte-cached (stable digest) otherwise.
 ARG PKG_REFRESH=none
+# apt-mark hold: the OS upgrade must never touch the packages that define
+# the bundled Postgres minor — PGDG always carries the major's newest minor,
+# so an unheld upgrade can make the image bundle a newer server than the
+# minor tag it publishes under. Everything else upgrades freely.
 RUN echo "refresh key: ${PKG_REFRESH}" \
+    && apt-mark hold postgresql-18 postgresql-client-18 \
     && apt-get update && apt-get upgrade -y \
     && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-18-pgvector \
+    && apt-mark unhold postgresql-18 postgresql-client-18 \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow the postgres user to execute certain commands as root without a password


### PR DESCRIPTION
Follow-up to #117, same class as railwayapp-templates/postgres-ha#102: the content gate's `apt-get upgrade -y` can replace the **server packages themselves** (PGDG always carries the major's newest minor), making the image bundle a newer Postgres than the minor tag it publishes under.

This repo only builds each major's newest minor, so today the window is just the race between a PGDG release and the upstream base re-mint (current images verified clean: `:17` bundles 17.10 = newest). But with the hold the bundled server provably stays the resolved minor — and it's mandatory groundwork if pinned-minor backfill (postgres-ha#100) ever lands here.

`apt-mark hold postgresql-<major> postgresql-client-<major>` around the upgrade, unheld after install; everything else (glibc, openssl, libpq, pgbackrest deps) upgrades freely.