### PR TITLE
fix: overlap-safe runtime volume lock + nonzero exit on unasked clean shutdown

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -375,6 +375,11 @@ t_runtime_lock_blocks_overlapping_boot() {
   # next once-per-minute lock-file recheck.
   local name=t-rtlock-${PG_VERSION}
   local vol=${name}-vol
+  # Asserts on wrapper.sh behavior — never trust a pre-existing tag.
+  if ! rebuild_image; then
+    ko "${FUNCNAME[0]}" "could not rebuild $IMAGE"
+    return
+  fi
   new_volume "$vol"
   docker rm -f "$name" "${name}-b" >/dev/null 2>&1 || true
   docker run -d --name "$name" --label postgres-ssl-e2e=1 --network "$NET" \
@@ -400,11 +405,23 @@ t_runtime_lock_blocks_overlapping_boot() {
     fail_dump t_runtime_lock_blocks_overlapping_boot "${name}-b"
     return
   fi
+  # Pin the ordering, not just the park: the "released the volume" line is
+  # printed only when the flock -w wait returns, so seeing it BEFORE the
+  # first container dies means a broken wait that returned immediately —
+  # which the "starting PostgreSQL" grep alone could miss (postgres takes
+  # longer than the grep to log its first line).
+  if docker logs "${name}-b" 2>&1 | grep -q "previous container released the volume"; then
+    ko t_runtime_lock_blocks_overlapping_boot "second container exited the lock wait while the first still held the volume"
+    fail_dump t_runtime_lock_blocks_overlapping_boot "${name}-b"
+    return
+  fi
 
   # Kill the first container outright — SIGKILL included, the kernel must
   # release the flock — and the second boot should proceed to a healthy
   # postgres.
   docker rm -f "$name" >/dev/null
+  wait_for_log_line "${name}-b" "previous container released the volume" 60 \
+    || { ko t_runtime_lock_blocks_overlapping_boot "second container never logged the lock release after the first died"; fail_dump t_runtime_lock_blocks_overlapping_boot "${name}-b"; return; }
   wait_for_pg "${name}-b" || { ko t_runtime_lock_blocks_overlapping_boot "second container did not start after the first released the volume"; fail_dump t_runtime_lock_blocks_overlapping_boot "${name}-b"; return; }
 
   ok t_runtime_lock_blocks_overlapping_boot
@@ -420,6 +437,11 @@ t_unasked_clean_exit_is_nonzero() {
   # down until a human redeploys.
   local name=t-unasked-exit-${PG_VERSION}
   local vol=${name}-vol
+  # Asserts on wrapper.sh behavior — never trust a pre-existing tag.
+  if ! rebuild_image; then
+    ko "${FUNCNAME[0]}" "could not rebuild $IMAGE"
+    return
+  fi
   new_volume "$vol"
   docker rm -f "$name" >/dev/null 2>&1 || true
   docker run -d --name "$name" --label postgres-ssl-e2e=1 --network "$NET" \
@@ -466,6 +488,11 @@ t_requested_stop_still_exits_zero() {
   # keep the container's exit 0 — a stop must never look like a crash.
   local name=t-asked-exit-${PG_VERSION}
   local vol=${name}-vol
+  # Asserts on wrapper.sh behavior — never trust a pre-existing tag.
+  if ! rebuild_image; then
+    ko "${FUNCNAME[0]}" "could not rebuild $IMAGE"
+    return
+  fi
   new_volume "$vol"
   docker rm -f "$name" >/dev/null 2>&1 || true
   docker run -d --name "$name" --label postgres-ssl-e2e=1 --network "$NET" \

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -366,6 +366,153 @@ t_vanilla_boot() {
   docker volume rm "$vol" >/dev/null
 }
 
+t_runtime_lock_blocks_overlapping_boot() {
+  # Two containers on the same volume: the second must not touch the data
+  # directory or start postgres until every process of the first is gone.
+  # This is the redeploy-overlap shape: a new container booting while the
+  # old postmaster is still shutting down ends with the old postmaster's
+  # exit unlinking the NEW postmaster.pid, and postgres kills itself on its
+  # next once-per-minute lock-file recheck.
+  local name=t-rtlock-${PG_VERSION}
+  local vol=${name}-vol
+  new_volume "$vol"
+  docker rm -f "$name" "${name}-b" >/dev/null 2>&1 || true
+  docker run -d --name "$name" --label postgres-ssl-e2e=1 --network "$NET" \
+    -e POSTGRES_PASSWORD=test \
+    -e PGDATA=/var/lib/postgresql/data/pgdata \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$IMAGE" >/dev/null
+  # See t_requested_stop_still_exits_zero: outwait the initdb temp server.
+  wait_for_log_line "$name" "init process complete" 120 \
+    || { ko t_runtime_lock_blocks_overlapping_boot "initdb did not complete"; fail_dump t_runtime_lock_blocks_overlapping_boot "$name"; return; }
+  wait_for_pg "$name" || { ko t_runtime_lock_blocks_overlapping_boot "first container did not start"; fail_dump t_runtime_lock_blocks_overlapping_boot "$name"; return; }
+
+  # Overlapping boot on the same volume must park on the runtime lock.
+  docker run -d --name "${name}-b" --label postgres-ssl-e2e=1 --network "$NET" \
+    -e POSTGRES_PASSWORD=test \
+    -e PGDATA=/var/lib/postgresql/data/pgdata \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$IMAGE" >/dev/null
+  wait_for_log_line "${name}-b" "another postgres container still holds this volume" 30 \
+    || { ko t_runtime_lock_blocks_overlapping_boot "second container did not report waiting on the runtime lock"; fail_dump t_runtime_lock_blocks_overlapping_boot "${name}-b"; return; }
+  if docker logs "${name}-b" 2>&1 | grep -q "starting PostgreSQL"; then
+    ko t_runtime_lock_blocks_overlapping_boot "second container started postgres while the first still held the volume"
+    fail_dump t_runtime_lock_blocks_overlapping_boot "${name}-b"
+    return
+  fi
+
+  # Kill the first container outright — SIGKILL included, the kernel must
+  # release the flock — and the second boot should proceed to a healthy
+  # postgres.
+  docker rm -f "$name" >/dev/null
+  wait_for_pg "${name}-b" || { ko t_runtime_lock_blocks_overlapping_boot "second container did not start after the first released the volume"; fail_dump t_runtime_lock_blocks_overlapping_boot "${name}-b"; return; }
+
+  ok t_runtime_lock_blocks_overlapping_boot
+  docker rm -f "${name}-b" >/dev/null
+  docker volume rm "$vol" >/dev/null
+}
+
+t_unasked_clean_exit_is_nonzero() {
+  # A postgres that shuts down CLEANLY without anyone asking (here: its
+  # postmaster.pid is unlinked and its once-per-minute lock-file recheck
+  # fires an immediate shutdown) must not leave the container exit 0 — an
+  # ON_FAILURE restart policy treats 0 as success and the database stays
+  # down until a human redeploys.
+  local name=t-unasked-exit-${PG_VERSION}
+  local vol=${name}-vol
+  new_volume "$vol"
+  docker rm -f "$name" >/dev/null 2>&1 || true
+  docker run -d --name "$name" --label postgres-ssl-e2e=1 --network "$NET" \
+    -e POSTGRES_PASSWORD=test \
+    -e PGDATA=/var/lib/postgresql/data/pgdata \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$IMAGE" >/dev/null
+  # See t_requested_stop_still_exits_zero: outwait the initdb temp server.
+  wait_for_log_line "$name" "init process complete" 120 \
+    || { ko t_unasked_clean_exit_is_nonzero "initdb did not complete"; fail_dump t_unasked_clean_exit_is_nonzero "$name"; return; }
+  wait_for_pg "$name" || { ko t_unasked_clean_exit_is_nonzero "postgres did not start"; fail_dump t_unasked_clean_exit_is_nonzero "$name"; return; }
+
+  docker exec "$name" bash -c 'rm -f "$PGDATA/postmaster.pid"'
+
+  # The recheck runs once per minute; give it that plus shutdown slack.
+  local deadline=$(($(date +%s) + 100)) status=""
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    status=$(docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || echo "")
+    [ "$status" = "exited" ] && break
+    sleep 2
+  done
+  if [ "$status" != "exited" ]; then
+    ko t_unasked_clean_exit_is_nonzero "container did not exit after postgres self-shutdown"
+    fail_dump t_unasked_clean_exit_is_nonzero "$name"
+    return
+  fi
+
+  local exit_code
+  exit_code=$(docker inspect -f '{{.State.ExitCode}}' "$name")
+  assert_eq "$exit_code" "1" "container exit code after unasked clean postgres exit" \
+    || { ko t_unasked_clean_exit_is_nonzero ""; fail_dump t_unasked_clean_exit_is_nonzero "$name"; return; }
+  wait_for_log_line "$name" "no stop was requested" 10 \
+    || { ko t_unasked_clean_exit_is_nonzero "missing unasked-exit log line"; fail_dump t_unasked_clean_exit_is_nonzero "$name"; return; }
+
+  ok t_unasked_clean_exit_is_nonzero
+  docker rm -f "$name" >/dev/null
+  docker volume rm "$vol" >/dev/null
+}
+
+t_requested_stop_still_exits_zero() {
+  # The counterpart to t_unasked_clean_exit_is_nonzero: when the runtime
+  # DID ask us to stop (Railway's VM runtime delivers SIGTERM to every
+  # process in the container, wrapper included), a clean postgres exit must
+  # keep the container's exit 0 — a stop must never look like a crash.
+  local name=t-asked-exit-${PG_VERSION}
+  local vol=${name}-vol
+  new_volume "$vol"
+  docker rm -f "$name" >/dev/null 2>&1 || true
+  docker run -d --name "$name" --label postgres-ssl-e2e=1 --network "$NET" \
+    -e POSTGRES_PASSWORD=test \
+    -e PGDATA=/var/lib/postgresql/data/pgdata \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$IMAGE" >/dev/null
+  # First boot on a fresh volume: pg_isready answers the initdb TEMP
+  # postmaster too, so wait for the entrypoint to hand off to the final
+  # server before signaling anything.
+  wait_for_log_line "$name" "init process complete" 120 \
+    || { ko t_requested_stop_still_exits_zero "initdb did not complete"; fail_dump t_requested_stop_still_exits_zero "$name"; return; }
+  wait_for_pg "$name" || { ko t_requested_stop_still_exits_zero "postgres did not start"; fail_dump t_requested_stop_still_exits_zero "$name"; return; }
+
+  # Simulate the runtime's stop: TERM to the wrapper (PID 1), then a clean
+  # postgres shutdown. The wrapper's trap only records the request; the
+  # shutdown itself is postgres's own.
+  docker exec "$name" kill -TERM 1
+  docker exec -u postgres "$name" bash -c 'pg_ctl stop -D "$PGDATA" -m fast -w'
+
+  local deadline=$(($(date +%s) + 30)) status=""
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    status=$(docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || echo "")
+    [ "$status" = "exited" ] && break
+    sleep 1
+  done
+  if [ "$status" != "exited" ]; then
+    ko t_requested_stop_still_exits_zero "container did not exit after requested stop"
+    fail_dump t_requested_stop_still_exits_zero "$name"
+    return
+  fi
+
+  local exit_code
+  exit_code=$(docker inspect -f '{{.State.ExitCode}}' "$name")
+  assert_eq "$exit_code" "0" "container exit code after requested stop" \
+    || { ko t_requested_stop_still_exits_zero ""; fail_dump t_requested_stop_still_exits_zero "$name"; return; }
+  if docker logs "$name" 2>&1 | grep -q "no stop was requested"; then
+    ko t_requested_stop_still_exits_zero "requested stop was misclassified as unasked"
+    fail_dump t_requested_stop_still_exits_zero "$name"
+    return
+  fi
+
+  ok t_requested_stop_still_exits_zero
+  docker rm -f "$name" >/dev/null
+  docker volume rm "$vol" >/dev/null
+}
+
 t_collation_refresh_no_permission_error() {
   # Regression: fork_collation_refresh's mktemp ran as root (mode 0600,
   # root-owned) while the gosu postgres psql call read it as the postgres
@@ -4531,6 +4678,9 @@ t_invalid_bucket_sentinel_cleared_on_disable() {
 
 ALL_TESTS=(
   t_vanilla_boot
+  t_runtime_lock_blocks_overlapping_boot
+  t_unasked_clean_exit_is_nonzero
+  t_requested_stop_still_exits_zero
   t_collation_refresh_no_permission_error
   t_invalid_bucket_skips_archive
   t_archiving_boot

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -71,6 +71,48 @@ if command -v flock >/dev/null 2>&1 && [ -d "$EXPECTED_VOLUME_MOUNT_PATH" ] \
 fi
 
 # -----------------------------------------------------------------------------
+# Runtime lock: at most one postgres container touches this volume at a time.
+# Held EXCLUSIVELY (fd 9) for the container's lifetime, same shell-as-PID-1
+# mechanics as the upgrade lock above — the kernel releases it only when the
+# last process holding the open description exits, so "lock free" really
+# means every process of the previous container is gone, however that
+# container ended (graceful stop, SIGKILL, OOM).
+#
+# Why: a redeploy can leave the old and new containers briefly overlapping
+# on the shared volume. The stale-postmaster.pid removal below cannot see
+# the old container's postgres (different PID namespace), and worse, a
+# still-shutting-down old postmaster unlinks postmaster.pid on its way out
+# — deleting the file the NEW postgres just wrote. Postgres treats a missing
+# lock file as fatal on its once-per-minute recheck and shuts itself down.
+# Waiting on the previous holder before touching the data directory closes
+# both directions of that race.
+#
+# Fail-stop on timeout: refusing to boot (the restart policy retries) beats
+# starting a second postmaster against a volume the previous one may still
+# be using. Same legacy-layout skip as the upgrade lock: never create files
+# inside an empty PGDATA-at-the-volume-root, or docker-entrypoint skips
+# initdb.
+# -----------------------------------------------------------------------------
+RUNTIME_LOCK_FILE="$EXPECTED_VOLUME_MOUNT_PATH/.railway-postgres-runtime.lock"
+RUNTIME_LOCK_WAIT_SECONDS="${RUNTIME_LOCK_WAIT_SECONDS:-300}"
+if command -v flock >/dev/null 2>&1 && [ -d "$EXPECTED_VOLUME_MOUNT_PATH" ] \
+  && ! { [ "$PGDATA" = "$EXPECTED_VOLUME_MOUNT_PATH" ] && [ ! -f "$PGDATA/PG_VERSION" ]; }; then
+  # Brace-group-scoped stderr for the same reason as the upgrade lock above.
+  if { exec 9>>"$RUNTIME_LOCK_FILE"; } 2>/dev/null; then
+    if ! flock -n -x 9; then
+      echo "wrapper: another postgres container still holds this volume (overlapping deploy); waiting up to ${RUNTIME_LOCK_WAIT_SECONDS}s for it to shut down"
+      if ! flock -w "$RUNTIME_LOCK_WAIT_SECONDS" -x 9; then
+        echo "wrapper: previous container did not release the volume within ${RUNTIME_LOCK_WAIT_SECONDS}s; refusing to start postgres on a volume another postmaster may still be using"
+        exit 1
+      fi
+      echo "wrapper: previous container released the volume; continuing boot"
+    fi
+  else
+    echo "wrapper: could not open $RUNTIME_LOCK_FILE; continuing without the runtime lock" >&2
+  fi
+fi
+
+# -----------------------------------------------------------------------------
 # Major-version guards. Both are fail-stop and loud, and both run before
 # anything touches the data directory, so a mismatched boot can never corrupt
 # data or initdb over a half-swapped upgrade.
@@ -194,6 +236,14 @@ POSTGRES_CONF_FILE="$PGDATA/postgresql.conf"
 # guarantees only one wrapper.sh per container instance. Avoids the
 # need for a graceful-shutdown handoff that re-parents children onto
 # postmaster (postmaster panics with SIGCHLD on unknown children).
+#
+# "No postgres running" additionally covers OTHER containers on this
+# volume once the runtime lock (fd 9, above) is held: any previous
+# container running this image keeps that lock until its last process
+# exits, so reaching this line means no lock-honoring postmaster can
+# still be alive on the volume. A previous container from an image
+# WITHOUT the lock can still overlap; the unasked-clean-exit shaping at
+# the bottom of this file is what recovers that case.
 if [ -f "$PGDATA/postmaster.pid" ]; then
   echo "wrapper: removing stale $PGDATA/postmaster.pid (no postgres running at container start)"
   rm -f "$PGDATA/postmaster.pid" 2>/dev/null || true
@@ -1817,4 +1867,28 @@ fork_old_datadir_reclaim
 # subprocesses. Falling back to the simple foreground invocation
 # preserves the e2e suite's existing behavior on docker stop / docker
 # restart.
-/usr/local/bin/docker-entrypoint.sh "$@"
+#
+# The traps below deliberately do NOT forward signals or restructure the
+# foreground invocation (that is the pattern CI rejected). They only
+# record that a stop was requested: bash runs a trap after the foreground
+# child returns, so by the time the exit-code shaping below executes the
+# flag reflects whether the runtime asked us to stop. That distinction is
+# what lets a postgres that dies CLEANLY BUT UNASKED — e.g. it shut itself
+# down because something unlinked its postmaster.pid — exit this container
+# nonzero so an ON_FAILURE restart policy can bring the database back,
+# instead of the container reporting exit 0 and staying down forever.
+STOP_REQUESTED=0
+trap 'STOP_REQUESTED=1' TERM INT
+
+ENTRYPOINT_EXIT=0
+/usr/local/bin/docker-entrypoint.sh "$@" || ENTRYPOINT_EXIT=$?
+
+if [ "$ENTRYPOINT_EXIT" -ne 0 ]; then
+  # Failure exit codes already make the restart policy act; pass through.
+  exit "$ENTRYPOINT_EXIT"
+fi
+if [ "$STOP_REQUESTED" = "1" ]; then
+  exit 0
+fi
+echo "wrapper: postgres exited cleanly but no stop was requested; exiting nonzero so the restart policy can recover the database"
+exit 1

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -95,6 +95,17 @@ fi
 # -----------------------------------------------------------------------------
 RUNTIME_LOCK_FILE="$EXPECTED_VOLUME_MOUNT_PATH/.railway-postgres-runtime.lock"
 RUNTIME_LOCK_WAIT_SECONDS="${RUNTIME_LOCK_WAIT_SECONDS:-300}"
+# Must be a whole number of seconds: `flock -w` rejects anything else with a
+# usage error, whose non-zero exit is indistinguishable from a hold timeout
+# below — so a typo'd override would surface as "previous container did not
+# release the volume" and instant-fail every boot DURING a real overlap,
+# exactly when the wait matters. Fall back loudly instead.
+case "$RUNTIME_LOCK_WAIT_SECONDS" in
+  ''|*[!0-9]*)
+    echo "wrapper: RUNTIME_LOCK_WAIT_SECONDS='${RUNTIME_LOCK_WAIT_SECONDS}' is not a whole number of seconds; using 300" >&2
+    RUNTIME_LOCK_WAIT_SECONDS=300
+    ;;
+esac
 if command -v flock >/dev/null 2>&1 && [ -d "$EXPECTED_VOLUME_MOUNT_PATH" ] \
   && ! { [ "$PGDATA" = "$EXPECTED_VOLUME_MOUNT_PATH" ] && [ ! -f "$PGDATA/PG_VERSION" ]; }; then
   # Brace-group-scoped stderr for the same reason as the upgrade lock above.
@@ -1877,6 +1888,15 @@ fork_old_datadir_reclaim
 # down because something unlinked its postmaster.pid — exit this container
 # nonzero so an ON_FAILURE restart policy can bring the database back,
 # instead of the container reporting exit 0 and staying down forever.
+#
+# The flag is a one-shot latch: a TERM/INT that never culminates in a stop
+# (an operator poking PID 1, a platform stop that gets cancelled) still
+# reclassifies a LATER unasked clean exit as requested, exit 0, no restart.
+# Accepted: bash defers trap execution until the foreground child returns,
+# so signal-delivery time cannot be recorded and a recency check is not
+# implementable in this design — and on Railway a TERM broadcast is always
+# followed by container removal, so a latched flag never coexists with a
+# live postgres for long.
 STOP_REQUESTED=0
 trap 'STOP_REQUESTED=1' TERM INT
 


### PR DESCRIPTION
## What

Two wrapper hardenings against redeploy overlap on the shared volume:

1. **Runtime volume lock.** The wrapper holds an exclusive `flock` (fd 9) on `.railway-postgres-runtime.lock` at the volume root for the container's lifetime — same shell-as-PID-1 mechanics as the existing major-upgrade lock. A booting container waits for the previous holder's **last process** to exit (default 300s, `RUNTIME_LOCK_WAIT_SECONDS` overrides) before removing a stale `postmaster.pid` or starting postgres, and fail-stops loudly on timeout so a restart policy retries the boot instead of risking two postmasters on one volume. The kernel releases the flock however the previous container ended (graceful stop, SIGKILL, OOM).

2. **Exit-code shaping for unasked clean shutdowns.** TERM/INT traps record that a stop was requested — they do not forward signals or restructure the foreground `docker-entrypoint.sh` invocation (the trap+wait/exec patterns previously rejected by CI stay rejected). If postgres exits cleanly **without** a recorded stop request, the wrapper now exits `1` with a loud log line, so an `ON_FAILURE` restart policy recovers the database in seconds.

## Why

If an old container is still shutting down when a new one boots on the same volume:

- The boot-time stale-`postmaster.pid` removal cannot see the old container's live postgres (different PID namespace).
- Worse, the old postmaster's graceful shutdown unlinks `postmaster.pid` on its way out — deleting the file the **new** postgres just wrote. On its once-per-minute lock-file recheck the new postgres logs `performing immediate shutdown because data directory lock file is invalid` and shuts down — **cleanly, exit 0** — so an `ON_FAILURE` restart policy never fires and the database stays down until a human redeploys.

Reproduced end-to-end: delete `postmaster.pid` under a running container of the current image → postgres self-kills at the next recheck → container exits `0` and nothing restarts it.

The lock closes both directions of the race for lock-aware images; the exit shaping recovers the remaining first-rollout window where the *old* container predates the lock.

## Notes

- Legacy PGDATA-at-the-volume-root first-init skips the lock (same guard and reasoning as the upgrade lock: a file in an empty PGDATA would make docker-entrypoint skip initdb). Modern layout (PGDATA under `<volume>/pgdata`) takes the lock from the very first boot.
- Behavior change worth naming: a manual in-container `pg_ctl stop` now results in a container restart rather than a silently stopped-but-"running" service. Stopping a Railway database is a platform operation, not an in-container one.

## Testing

`PG_VERSION=18 ./test/e2e.sh t_runtime_lock_blocks_overlapping_boot t_unasked_clean_exit_is_nonzero t_requested_stop_still_exits_zero` — 3/3 pass:

- `t_runtime_lock_blocks_overlapping_boot`: second container on the same volume parks on the lock ("another postgres container still holds this volume"), starts no postgres while the first is alive, and boots to healthy after the first is SIGKILLed.
- `t_unasked_clean_exit_is_nonzero`: unlinking `postmaster.pid` under a live postgres ends with container exit code `1` and the unasked-exit log line.
- `t_requested_stop_still_exits_zero`: TERM to the wrapper + clean postgres stop exits `0` and is not misclassified.