### PR TITLE
fix(upgrade-job): self-diagnosing quiesce failure + one in-job retry on fast death

### DIFF
--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -472,6 +472,31 @@ t_recovers_unclean_shutdown() {
   stop_pg unclean2-pg
 }
 
+# The quiesce start's failure line must be SELF-DIAGNOSING: die()'s one line
+# is the only output that survives into the platform's progress record (the
+# job log dies with its container), so a postmaster that DIES during
+# recovery must be reported as a crash carrying the server's own last error
+# — never the misleading "within Ns" timeout wording — and a fast death
+# earns exactly one in-job retry first. Emptying pg_wal makes recovery PANIC
+# immediately ("could not locate a valid checkpoint record"): deterministic
+# fast death, both attempts.
+t_quiesce_crash_reports_server_error() {
+  local vol="upg-e2e-quiesce-crash"
+  fresh_volume "$vol" || return 1
+  run_pg quiesce-pg "$vol" "$FROM_IMAGE" || return 1
+  wait_for_pg quiesce-pg || { fail_dump quiesce quiesce-pg; return 1; }
+  psql_must quiesce-pg "CREATE TABLE quiesce_canary (id int)" || return 1
+  kill_pg quiesce-pg
+  in_volume "$vol" "rm -f ${PGDATA_IN_VOLUME}/pg_wal/0*" || return 1
+
+  run_job "$vol" check
+  assert_eq "$JOB_RC" 3 "check dies on a crash-dead quiesce" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_contains "$JOB_OUT" "retrying once" "fast death earned one in-job retry" || return 1
+  assert_contains "$JOB_OUT" "failed to start for crash recovery" "crash wording, not timeout wording" || return 1
+  assert_contains "$JOB_OUT" "last server error:" "server's own error line surfaced in the die() line" || return 1
+}
+
+
 # A second concurrent job on the same volume is refused (activity-retry race).
 t_refuses_concurrent_job() {
   local vol="upg-e2e-concurrent"
@@ -1641,6 +1666,7 @@ ALL_TESTS=(
   t_check_blocker_pre16_types
   t_refuses_wrong_major
   t_recovers_unclean_shutdown
+  t_quiesce_crash_reports_server_error
   t_refuses_concurrent_job
   t_upgrade_happy_path
   t_upgrade_idempotent

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -392,10 +392,29 @@ ensure_clean_shutdown() {
   # a WAL-replay failure is exactly the moment the FATAL lines matter, and
   # discarding them leaves the job log with nothing but a generic message.
   local quiesce_log="/tmp/pg-quiesce.log"
-  rm -f "$quiesce_log"
-  as_postgres "$OLD_BINDIR/pg_ctl" -D "$PGDATA" -w -t "$UPGRADE_QUIESCE_TIMEOUT_SECONDS" -l "$quiesce_log" \
-    -o "-c listen_addresses='' -k /tmp" start >/dev/null 2>&1 \
-    || { print_quiesce_log "$quiesce_log"; die 3 "the old server could not start to complete crash recovery within ${UPGRADE_QUIESCE_TIMEOUT_SECONDS}s (server log above; override with UPGRADE_QUIESCE_TIMEOUT_SECONDS)"; }
+  # A start that dies FAST (well under the -t deadline) has repeatedly shown
+  # up as a transient of the just-attached volume/container rather than a
+  # real WAL-replay failure, and an interrupted recovery persists no progress
+  # (see above) — so one bounded in-job retry is safe and cheap. A start that
+  # burned the whole deadline gets no retry: the second attempt would replay
+  # the same WAL from scratch into the same deadline.
+  local quiesce_started elapsed attempt
+  for attempt in 1 2; do
+    rm -f "$quiesce_log"
+    quiesce_started="$(date +%s)"
+    if as_postgres "$OLD_BINDIR/pg_ctl" -D "$PGDATA" -w -t "$UPGRADE_QUIESCE_TIMEOUT_SECONDS" -l "$quiesce_log" \
+      -o "-c listen_addresses='' -k /tmp" start >/dev/null 2>&1; then
+      break
+    fi
+    elapsed=$(( $(date +%s) - quiesce_started ))
+    print_quiesce_log "$quiesce_log"
+    if [ "$attempt" -eq 1 ] && [ "$elapsed" -lt $(( UPGRADE_QUIESCE_TIMEOUT_SECONDS / 2 )) ]; then
+      log "old server start for crash recovery failed fast (${elapsed}s) — retrying once (server log above)"
+      sleep 5
+      continue
+    fi
+    die 3 "$(quiesce_start_failure_reason "$quiesce_log" "$quiesce_started")"
+  done
   as_postgres "$OLD_BINDIR/pg_ctl" -D "$PGDATA" -w -t "$UPGRADE_QUIESCE_TIMEOUT_SECONDS" -m fast stop >/dev/null 2>&1 \
     || { print_quiesce_log "$quiesce_log"; die 3 "the old server did not shut down cleanly after recovery within ${UPGRADE_QUIESCE_TIMEOUT_SECONDS}s (server log above)"; }
 
@@ -416,6 +435,30 @@ print_quiesce_log() {
   # RAILWAY_UPGRADE_RESULT: sentinel and forge a result line.
   tail -100 "$1" | sed 's/^/  server: /'
   echo "----- end of old server log -----"
+}
+
+# One self-diagnosing line for a failed quiesce start. pg_ctl -w exits the
+# same way whether the postmaster DIED during recovery or recovery was merely
+# still running at the -t deadline — and the die() line below is the ONLY
+# part of this job's output that survives into the upgrade/rehearsal progress
+# record (the full log dies with the job's container), so that line must
+# carry the distinction plus the server's own last fatal line. pg_ctl's
+# readiness probes leave benign "FATAL: the database system is starting up"
+# entries in the server log for the whole recovery — those never count as
+# the failure reason. die() JSON-encodes the message (jq --arg), so embedded
+# server-log bytes can't forge a result line; length still bounded here to
+# keep the blocker readable.
+quiesce_start_failure_reason() {
+  local quiesce_log="$1" started="$2"
+  local elapsed=$(( $(date +%s) - started ))
+  local reason
+  reason="$(grep -a -E "(PANIC|FATAL):" "$quiesce_log" 2>/dev/null \
+    | grep -v "the database system is starting up" | tail -1 | cut -c1-300)"
+  if [ -z "$reason" ] && [ "$elapsed" -ge $(( UPGRADE_QUIESCE_TIMEOUT_SECONDS - 2 )) ]; then
+    echo "the old server did not finish crash recovery within ${UPGRADE_QUIESCE_TIMEOUT_SECONDS}s (still recovering after ${elapsed}s — large WAL backlog or slow disk; override with UPGRADE_QUIESCE_TIMEOUT_SECONDS; server log above)"
+  else
+    echo "the old server failed to start for crash recovery after ${elapsed}s${reason:+ — last server error: ${reason}} (server log above)"
+  fi
 }
 
 # Reverse pg_upgrade's disable of the old cluster. pg_upgrade renames


### PR DESCRIPTION
## What

The rehearsal battery's only flaky flow fails as `upgradeWouldSucceed=false (blockers: the old server could not start to complete crash recovery within 600s ...)` — but the failing attempts die in seconds, not 600s: the message is the same for a postmaster that DIED during recovery and a genuine deadline, and the real server error lives only in the job container's log, which is gone by the time anyone looks (the rehearsal tears its disposable service down).

## Changes

1. **Self-diagnosing failure line** — `quiesce_start_failure_reason()`: a genuine deadline reads *did not finish crash recovery within Ns (still recovering after Xs)*; a postmaster death reads *failed to start for crash recovery after Xs — last server error: \<last PANIC/FATAL from the server log\>*. pg_ctl -w's readiness probes leave benign `FATAL: the database system is starting up` lines during recovery — excluded from the reason. `die()` already jq-encodes the message, so embedded server-log bytes can't forge the `RAILWAY_UPGRADE_RESULT:` sentinel; the reason is also length-bounded (300 chars).
2. **One in-job retry on fast death** — a start that died under half the deadline gets exactly one retry after 5s. An interrupted recovery persists no progress (already documented in this file), so the retry is safe; a transient of the just-attached volume/container now converts to a pass instead of a failed rehearsal attempt. A start that burned the whole deadline is never retried (same WAL, same deadline).
3. **New e2e** — `t_quiesce_crash_reports_server_error`: kill -9 the server, empty `pg_wal/` (deterministic `could not locate a valid checkpoint record` PANIC), run `check`; asserts exit 3, the one retry, the crash wording, and the surfaced server error.

## Test evidence

Local `test/e2e-upgrade.sh` (16→17): `t_quiesce_crash_reports_server_error` PASS, `t_recovers_unclean_shutdown` PASS, `t_check_pass` PASS.

## Rollout note

The e2e battery's retry markers match the old string; railwayapp/test-postgres-major-upgrade gets the two new marker strings (companion PR) — merge that one first so no window exists where the battery stops retrying on this class.