### PR TITLE
feat(upgrade-job): recover mode — roll-back only, for the workflow's auto-availability arm

### DIFF
--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -1161,6 +1161,81 @@ t_crash_mid_link_rolls_back_and_reruns() {
   stop_pg midlink-pg
 }
 
+# recover mode is the workflow's automatic-availability arm: a job that died
+# BEFORE the commit point must be reversible to a bootable FROM-major volume
+# with no human involved and no upgrade redo. Reconstruct the same mid-link
+# crash shape as t_crash_mid_link_rolls_back_and_reruns, but resolve it with
+# recover instead of re-running the upgrade.
+t_recover_returns_midlink_crash_to_bootable() {
+  local vol="upg-e2e-recover"
+  seed_from_cluster "$vol" || return 1
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "initial upgrade" || { echo "$JOB_OUT" | tail -20; return 1; }
+  in_volume "$vol" "
+    set -e
+    cd /var/lib/postgresql/data
+    rm -rf pgdata
+    mv pgdata.old-${FROM_VERSION} pgdata
+    mkdir -p pgdata.upgrade-${TO_VERSION}
+    echo ${TO_VERSION} > pgdata.upgrade-${TO_VERSION}/PG_VERSION
+    chown -R postgres:postgres pgdata.upgrade-${TO_VERSION}
+    rm -f $MARKER_PATH
+  " || return 1
+  in_volume "$vol" "test -f ${PGDATA_IN_VOLUME}/global/pg_control.old && test ! -f ${PGDATA_IN_VOLUME}/global/pg_control" \
+    || { echo "  premise broken: reconstructed old cluster is not in the disabled shape"; return 1; }
+
+  run_job "$vol" recover
+  assert_eq "$JOB_RC" 0 "recover exit code" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_contains "$JOB_OUT" "restored global/pg_control" "the disable was reversed" || return 1
+  assert_contains "$JOB_OUT" '"mode":"recover"' "machine-readable recover result" || return 1
+  in_volume "$vol" "test ! -e ${PGDATA_IN_VOLUME}.upgrade-${TO_VERSION}" \
+    || { echo "  partial target dir survived recover"; return 1; }
+  assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "data major is FROM after recover" || return 1
+
+  run_pg recover-pg "$vol" "$FROM_IMAGE" || return 1
+  wait_for_pg recover-pg || { fail_dump recover recover-pg; return 1; }
+  assert_eq "$(psql_in recover-pg 'SELECT count(*) FROM upgrade_canary')" "1000" "data intact after recover" || return 1
+  stop_pg recover-pg
+
+  # Idempotent: a second recover on the now-healthy FROM volume is a no-op
+  # success, which is what the workflow's retry semantics need.
+  run_job "$vol" recover
+  assert_eq "$JOB_RC" 0 "recover is idempotent on a healthy FROM volume" || { echo "$JOB_OUT" | tail -10; return 1; }
+}
+
+# recover must never roll BACKWARD over a committed upgrade: at or past the
+# commit point (upgraded marker, or the finished-run disk shape with the
+# completion sentinel) it refuses toward upgrade mode's roll-forward.
+t_recover_refuses_past_commit_point() {
+  local vol="upg-e2e-recover-refuse"
+  seed_from_cluster "$vol" || return 1
+
+  # Shape 1: phase=upgraded marker (the durable commit point).
+  in_volume "$vol" "printf '%s' '{\"phase\":\"upgraded\",\"from\":\"${FROM_VERSION}\",\"to\":\"${TO_VERSION}\"}' > $MARKER_PATH" || return 1
+  run_job "$vol" recover
+  assert_eq "$JOB_RC" 2 "refused on an upgraded marker" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_contains "$JOB_OUT" "roll FORWARD" "points at upgrade mode" || return 1
+  in_volume "$vol" "rm -f $MARKER_PATH" || return 1
+
+  # Shape 2: no marker, but the finished-run disk shape (pg_control.old +
+  # completion sentinel in a TO-major target dir) — a lost marker write.
+  in_volume "$vol" "
+    set -e
+    cd /var/lib/postgresql/data
+    mv pgdata/global/pg_control pgdata/global/pg_control.old
+    mkdir -p pgdata.upgrade-${TO_VERSION}
+    echo ${TO_VERSION} > pgdata.upgrade-${TO_VERSION}/PG_VERSION
+    touch pgdata.upgrade-${TO_VERSION}/.railway_pg_upgrade_complete
+    chown -R postgres:postgres pgdata.upgrade-${TO_VERSION}
+  " || return 1
+  run_job "$vol" recover
+  assert_eq "$JOB_RC" 2 "refused on the finished-run disk shape" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_contains "$JOB_OUT" "run upgrade mode to finish the swap" "points at upgrade mode" || return 1
+  # And the refusal touched nothing: the shape is still resolvable forward.
+  in_volume "$vol" "test -f ${PGDATA_IN_VOLUME}/global/pg_control.old && test -f ${PGDATA_IN_VOLUME}.upgrade-${TO_VERSION}/.railway_pg_upgrade_complete" \
+    || { echo "  refusal mutated the volume"; return 1; }
+}
+
 # pgdata.old-<from> is the rollback body and pins every pre-upgrade inode
 # (--link hardlinks); it must survive normal boots and be reclaimed in the
 # background once the upgraded database has been up past the grace period,
@@ -1665,6 +1740,8 @@ ALL_TESTS=(
   t_recovery_shapes_refused
   t_marker_lost_after_pg_upgrade_resumes
   t_crash_mid_link_rolls_back_and_reruns
+  t_recover_returns_midlink_crash_to_bootable
+  t_recover_refuses_past_commit_point
   t_old_datadir_reclaimed
   t_trailing_slash_pgdata
   t_upgrade_survives_root_owned_volume_root

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -29,6 +29,16 @@
 #              the workflow to decide roll-back vs roll-forward on resume.
 #   manifest — print the extensions available on the TARGET major as JSON.
 #              Feeds the dashboard preflight's extension check.
+#   recover  — roll-back ONLY, never redoes the upgrade: return a volume
+#              whose job died BEFORE the commit point (no marker) to a
+#              bootable FROM-major state — reverse pg_upgrade's pg_control
+#              disable if present, drop the partial target dir — so the
+#              workflow can restart the old image automatically instead of
+#              leaving the database down until a human clicks revert.
+#              Refuses (exit 2) anything at or past the commit point
+#              (upgraded/completed marker, or the finished-run disk shape):
+#              those roll FORWARD via upgrade mode. Idempotent — a volume
+#              already bootable on FROM is a success no-op.
 #
 # Marker contract (volume root, .railway-major-upgrade.json):
 #   absent               — nothing committed; any failure rolls back. One
@@ -209,10 +219,10 @@ if [ -z "$MODE" ]; then
   if [ "$#" -gt 0 ]; then
     for _arg in "$@"; do
       case "$_arg" in
-        check | upgrade | status | manifest) MODE="$_arg" ;;
+        check | upgrade | status | manifest | recover) MODE="$_arg" ;;
       esac
     done
-    [ -n "$MODE" ] || die 2 "no recognized mode among arguments: $* (expected one of: check, upgrade, status, manifest)"
+    [ -n "$MODE" ] || die 2 "no recognized mode among arguments: $* (expected one of: check, upgrade, status, manifest, recover)"
   fi
 fi
 MODE="${MODE:-upgrade}"
@@ -789,6 +799,78 @@ finish_swap() {
   exit 0
 }
 
+# Roll-back only — the workflow's automatic-availability arm for a job that
+# died BEFORE the commit point. Returns the volume to a bootable FROM-major
+# state and never redoes the upgrade (that is a fresh decision for the
+# workflow/user, not a side effect of recovery). Anything at or past the
+# commit point is refused toward upgrade mode's roll-forward: recover must
+# never discard a committed upgrade.
+mode_recover() {
+  check_mount
+  take_job_lock
+
+  refuse_unreadable_marker
+  local marker_phase marker_from marker_to
+  marker_phase="$(read_marker_field phase)"
+  marker_from="$(read_marker_field from)"
+  marker_to="$(read_marker_field to)"
+  case "$marker_phase" in
+    upgraded)
+      die 2 "marker phase 'upgraded' (${marker_from:-?} -> ${marker_to:-?}) — the commit point has passed; run upgrade mode to roll FORWARD instead (recover never discards a committed upgrade)"
+      ;;
+    completed)
+      # A completed marker of a PREVIOUS pair over FROM-major data is
+      # history, not state (same reading as upgrade mode); a completed
+      # SAME-pair marker over TO-major data means the upgrade finished —
+      # there is nothing to recover from.
+      if [ "$(data_major)" = "$TO_MAJOR" ]; then
+        die 2 "marker records a completed ${marker_from:-?} -> ${marker_to:-?} upgrade and the data directory is $TO_MAJOR — the upgrade finished; nothing to recover"
+      fi
+      ;;
+    "") ;;
+    *)
+      die 2 "marker phase '$marker_phase' is not this job's to resolve — refusing to recover over another writer's in-flight state"
+      ;;
+  esac
+
+  # Same disk-shape reading as upgrade mode's marker-less branch: the
+  # completion sentinel proves a FINISHED run whose marker write was lost —
+  # roll forward via upgrade mode, never backward. pg_control.old without it
+  # proves only that pg_upgrade DISABLED the old cluster before crashing
+  # mid-link; reversing the rename is safe (the target cluster has never
+  # been started, and linking never modifies the old cluster's files).
+  if [ -f "$PGDATA/global/pg_control.old" ]; then
+    if [ -f "$NEW_DATA_DIR/.railway_pg_upgrade_complete" ] \
+      && [ "$(cat "$NEW_DATA_DIR/PG_VERSION" 2>/dev/null)" = "$TO_MAJOR" ]; then
+      die 2 "the disk shape shows a FINISHED pg_upgrade (completion sentinel in the $TO_MAJOR dir) — run upgrade mode to finish the swap; recover never discards a finished upgrade"
+    fi
+    log "pg_control.old present without a completion sentinel — pg_upgrade crashed mid-link; restoring the old cluster's pg_control"
+    restore_disabled_pg_control
+  fi
+
+  # Drop the partial target dir so nothing half-linked lingers and a later
+  # fresh attempt starts clean. Its pg_upgrade logs are printed first — this
+  # is the last copy of WHY the run died. Removing hardlinks never touches
+  # the old cluster's files.
+  local cleaned_target="false"
+  if [ -d "$NEW_DATA_DIR" ]; then
+    print_check_details "$NEW_DATA_DIR"
+    rm -rf "$NEW_DATA_DIR"
+    cleaned_target="true"
+  fi
+
+  # The one promise this mode makes: the volume is bootable on FROM again.
+  local major
+  major="$(data_major)"
+  if [ "$major" != "$FROM_MAJOR" ]; then
+    die 3 "volume is not bootable on $FROM_MAJOR after recovery (data major: '${major:-unreadable}') — restore the pre-upgrade backup"
+  fi
+
+  result "$(jq -nc --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" --argjson cleaned "$cleaned_target" \
+    '{ok: true, mode: "recover", from: $from, to: $to, dataMajor: $from, cleanedTargetDir: $cleaned}')"
+  exit 0
+}
+
 mode_upgrade() {
   check_mount
   take_job_lock
@@ -955,5 +1037,6 @@ case "$MODE" in
   upgrade) mode_upgrade ;;
   status) mode_status ;;
   manifest) mode_manifest ;;
-  *) die 2 "unknown mode '$MODE' (expected check|upgrade|status|manifest)" ;;
+  recover) mode_recover ;;
+  *) die 2 "unknown mode '$MODE' (expected check|upgrade|status|manifest|recover)" ;;
 esac


### PR DESCRIPTION
Companion to railwayapp/mono#36309 (auto-recover of an ambiguous job death). New job mode:

- **recover** — after the workflow's CONFIRMED container sweep, return a volume whose job died BEFORE the commit point to a bootable FROM-major state: reverse pg_upgrade's `pg_control` disable (safe strictly pre-commit — linking never modifies the old cluster's files and the target cluster never started), drop the partial target dir (its pg_upgrade logs printed first — the last copy of why the run died), verify `PG_VERSION` = FROM.
- **Never forward, never redo**: an `upgraded`/`completed` marker, or the finished-run disk shape (completion sentinel in a TO-major target dir), is refused (exit 2) toward upgrade mode's roll-forward — recover can never discard a committed upgrade.
- **Idempotent** on an already-bootable FROM volume (workflow retry semantics).

## Tests

- `t_recover_returns_midlink_crash_to_bootable`: reconstructs the same mid-link crash shape as `t_crash_mid_link_rolls_back_and_reruns`, resolves it with recover → exit 0, `pg_control` restored, partial dir gone, FROM image boots with the canary intact, second recover no-ops.
- `t_recover_refuses_past_commit_point`: upgraded-marker and finished-run-shape both refused with pointers at upgrade mode, volume untouched by the refusal.
- 2/2 PASS locally (16→17); `t_crash_mid_link_rolls_back_and_reruns` still passes.

## Ordering

Safe in any order vs mono#36309: a fleet job image without this mode exits 2 on `recover`, which the workflow treats as recover-unavailable → today's FAILED + restore-guidance floor. Note: touches the same files as #121 (quiesce self-diagnosis) — whichever merges second needs a trivial conflict resolution in the mode list/ALL_TESTS.