### PR TITLE
feat(upgrade-job): free-space precondition + 14→17 multi-hop CI cell

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,7 +80,10 @@ jobs:
   # regression-tested anywhere in CI — pg_upgrade's own behavior here isn't
   # a clean "any pre-16 source" rule (14→15 fires neither check; see the
   # test's own docblock), so this cell is a pair confirmed to trigger both,
-  # not a stand-in for every pre-16 pair. The
+  # not a stand-in for every pre-16 pair. 14→17 is the multi-major-jump
+  # representative: build-and-push publishes all 10 forward pairs and the
+  # product's eligibility gate allows non-adjacent targets, but until this
+  # cell no multi-hop pair had ever been executed anywhere. The
   # harness builds its own images (FROM, TO, and the dual-binary job image),
   # so no buildx step is needed here.
   e2e-upgrade:
@@ -94,6 +97,7 @@ jobs:
           - { from: 16, to: 17 }
           - { from: 17, to: 18 }
           - { from: 15, to: 16 }
+          - { from: 14, to: 17 }
 
     steps:
       - name: Checkout sources

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -254,8 +254,12 @@ kill_pg() {
 # Sets JOB_OUT and JOB_RC.
 run_job() {
   local vol="$1" mode="${2:-upgrade}"
+  shift 2 2>/dev/null || true
+  # Trailing args are extra docker-run options (e.g. -e OVERRIDE=x),
+  # inserted before the image like any docker option must be.
   JOB_OUT=$(docker run --rm --label postgres-upgrade-e2e=1 \
     -e "PGDATA=$PGDATA_IN_VOLUME" \
+    "$@" \
     -v "$vol:/var/lib/postgresql/data" \
     "$JOB_IMAGE" "$mode" 2>&1)
   JOB_RC=$?
@@ -1186,6 +1190,27 @@ t_crash_mid_link_rolls_back_and_reruns() {
   stop_pg midlink-pg
 }
 
+# Running out of space MID-LINK leaves the half-linked shape recover mode
+# exists to clean up — both modes refuse up front instead. Docker named
+# volumes report the HOST filesystem's free space, so the deterministic way
+# to exercise the refusal is an absurd floor override; the default floor's
+# pass-path is exercised by every other test in this file.
+t_free_space_precondition_refuses() {
+  local vol="upg-e2e-freespace"
+  seed_from_cluster "$vol" || return 1
+
+  run_job "$vol" check -e "UPGRADE_MIN_FREE_MB=999999999"
+  assert_eq "$JOB_RC" 2 "check refused below the free-space floor" || { echo "$JOB_OUT" | tail -10; return 1; }
+  assert_contains "$JOB_OUT" "free up space or grow the volume" "actionable free-space message" || return 1
+
+  run_job "$vol" upgrade -e "UPGRADE_MIN_FREE_MB=999999999"
+  assert_eq "$JOB_RC" 2 "upgrade refused below the free-space floor" || { echo "$JOB_OUT" | tail -10; return 1; }
+  # Refused before any mutation: the volume still boots FROM and re-checks green.
+  assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "volume untouched by the refusal" || return 1
+  run_job "$vol" check
+  assert_eq "$JOB_RC" 0 "check green again at the default floor" || { echo "$JOB_OUT" | tail -10; return 1; }
+}
+
 # recover mode is the workflow's automatic-availability arm: a job that died
 # BEFORE the commit point must be reversible to a bootable FROM-major volume
 # with no human involved and no upgrade redo. Reconstruct the same mid-link
@@ -1739,6 +1764,7 @@ ALL_TESTS=(
   t_check_pass
   t_check_blocker
   t_check_blocker_pre16_types
+  t_free_space_precondition_refuses
   t_refuses_wrong_major
   t_recovers_unclean_shutdown
   t_quiesce_crash_reports_server_error

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -102,6 +102,15 @@ unset PGPORT
 # same unclean state we started from.
 UPGRADE_QUIESCE_TIMEOUT_SECONDS="${UPGRADE_QUIESCE_TIMEOUT_SECONDS:-600}"
 
+# pg_upgrade --link needs little space (hard links + fresh catalogs), but
+# "little" is not "none": the target cluster's initdb, pg_upgrade's dump/
+# restore work files, and its output dir all land on this same volume, and
+# running out MID-LINK leaves exactly the half-linked shape recover mode
+# exists to clean up. Refuse up front instead. The floor is deliberately
+# modest — a --link upgrade of any data size fits comfortably in it — and
+# overridable for pathological volumes.
+UPGRADE_MIN_FREE_MB="${UPGRADE_MIN_FREE_MB:-512}"
+
 EXPECTED_VOLUME_MOUNT_PATH="/var/lib/postgresql/data"
 VOLUME_ROOT="$EXPECTED_VOLUME_MOUNT_PATH"
 # The dispatcher must pass the SERVICE's own PGDATA to this container. The
@@ -599,6 +608,24 @@ run_pg_upgrade() {
 # init_new_cluster's history). Prove the slot is creatable the same way the
 # real run will create it, then remove the probe. Uses a distinct suffix so
 # it can never collide with (or destroy) a real in-flight upgrade directory.
+# Free-space precondition for both modes: a green check must mean the real
+# run will not die on a condition check could have seen (same rule as
+# probe_sibling_slot). An unreadable df is logged and skipped, never fatal —
+# the check exists to catch a nearly-full volume, not to add a new way for
+# a healthy one to fail.
+check_free_space() {
+  local avail_kb avail_mb
+  avail_kb=$(df -Pk "$VOLUME_ROOT" 2>/dev/null | awk 'NR==2 {print $4}')
+  if [ -z "${avail_kb:-}" ]; then
+    log "could not read free space on $VOLUME_ROOT; continuing without the free-space check"
+    return 0
+  fi
+  avail_mb=$(( avail_kb / 1024 ))
+  if [ "$avail_mb" -lt "$UPGRADE_MIN_FREE_MB" ]; then
+    die 2 "only ${avail_mb} MiB free on the volume (need at least ${UPGRADE_MIN_FREE_MB} MiB for the new cluster's catalogs and pg_upgrade's work files) — free up space or grow the volume, then re-run (override with UPGRADE_MIN_FREE_MB)"
+  fi
+}
+
 probe_sibling_slot() {
   local probe="${NEW_DATA_DIR}.preflight"
   rm -rf "$probe" 2>/dev/null
@@ -695,6 +722,7 @@ mode_check() {
   # Before the quiesce, so an unwritable volume root gets the precise
   # refusal instead of a generic quiesce failure.
   probe_sibling_slot
+  check_free_space
   # Quiesces an unclean cluster (WAL replay + clean shutdown — what the next
   # normal boot would do); see the header for why check is only strictly
   # read-only on a cleanly-shut-down volume.
@@ -1023,6 +1051,7 @@ mode_upgrade() {
   fi
   clear_stale_pidfile
   refuse_recovery_shapes
+  check_free_space
   ensure_clean_shutdown
   init_new_cluster "$NEW_DATA_DIR"
 


### PR DESCRIPTION
Closes two items from the 2026-08-21 test-coverage sweep at their root:

## Free-space precondition (sweep item c)

`pg_upgrade --link` needs little space, but 'little' is not 'none': the target cluster's initdb, pg_upgrade's dump/restore work files, and its output dir all land on the same volume — and running out MID-LINK leaves exactly the half-linked shape recover mode exists to clean up. Both `check` and `upgrade` now refuse up front (`die 2`, actionable message) when free space is below a modest floor (`UPGRADE_MIN_FREE_MB`, default 512 MiB, overridable). An unreadable `df` logs and skips — the check catches a nearly-full volume, it never adds a new way for a healthy one to fail.

Test: `t_free_space_precondition_refuses` — refusal in both modes at an absurd floor override (docker named volumes report the HOST filesystem, so the override is the deterministic lever), volume untouched by the refusal, check green again at the default floor. `run_job` gained trailing-docker-option pass-through for the override.

## Multi-hop CI cell (sweep item b)

`build-and-push` publishes all 10 forward pairs (14–18) and the product's eligibility gate allows non-adjacent targets — but **no multi-major jump had ever been executed anywhere**, in any repo. `14→17` joins the e2e matrix as the multi-hop representative.

**Evidence**: the FULL suite passes locally on 14→17 — **54/54**, including the reg*/aclitem pre-16 blockers, the new quiesce/recover tests, and this PR's free-space test.

**CI-cost note**: this adds a 4th ~25-min parallel cell to every PR's E2E. If that's too rich, the alternative is dropping the cell and running the pair via the live battery's existing `E2E_FROM_MAJOR`/`E2E_TARGET_MAJOR` override on a schedule — reviewer's call.