### PR TITLE
feat(wrapper): self-heal post-upgrade config and collation drift — no operator in the loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,9 +480,18 @@ files at the volume root as `.pre-upgrade-<from>-postgresql.conf` /
 re-applied one GUC at a time via `ALTER SYSTEM` — a GUC the new major
 removed fails only its own statement (logged), never the boot; GUCs the
 image itself manages (archiving/recovery machinery, connection paths, SSL
-file paths) are never re-applied. `postgresql.conf` itself is initdb +
-entrypoint output, not a user surface, so only its stash remains as
-reference.
+file paths) are never re-applied, and neither are the preload GUCs
+(`shared_preload_libraries` & co.) or `dynamic_library_path`: `ALTER SYSTEM`
+validates those only syntactically — the libraries load at postmaster or
+connection start — so re-applying a value naming a library the new major's
+image doesn't ship would pass the statement and then refuse every subsequent
+boot, the exact failure not carrying the file exists to avoid (they stay in
+the stash for manual review, and the image manages `pg_stat_statements`
+preloading itself). A statement the server *rejects* still counts as a
+verdict; only settings that never reached the server (connection lost
+mid-restore, psql exit 2) keep the flag for a retry on the next boot.
+`postgresql.conf` itself is initdb + entrypoint output, not a user surface,
+so only its stash remains as reference.
 
 #### Disk reclaim and rollback window
 
@@ -519,10 +528,28 @@ upgrade window, so the database serves immediately either way:
   per index: PG13 added `pg_depend.refobjversion`, PG14 reverted it): the
   database default's `datcollversion` and each named collation's
   `collversion` against their `*_actual_version()`.
-- Only the indexes depending on a stale collation are rebuilt, with
-  `REINDEX INDEX CONCURRENTLY` (system catalogs excluded — they cannot be
-  reindexed concurrently and ship on C-locale name columns). Leftover
-  invalid `*_ccnew` indexes from an interrupted attempt are dropped first.
+- The recorded stamps can't always be trusted, and where they can't the
+  suspect set is **widened instead of compared**: pg_upgrade from a pre-15
+  source has no `datcollversion` to carry, so the new database is stamped
+  with the *current* library's version and "not stale" there means nothing —
+  every collation-dependent index is treated as suspect. And initdb-created
+  (predefined) collations are re-stamped current by the new cluster's initdb
+  even from 15+ sources — pg_dump only carries user-created ones — so their
+  staleness is inferred per *provider*: any preserved stamp (the database
+  default's, or a user-created collation's) proving that library changed
+  marks every predefined collation of that provider suspect too. The one
+  undetectable residue: a 15+ upgrade where a provider's library changed but
+  no preserved stamp of that provider exists anywhere *and* an index uses
+  only its predefined collations.
+- Only the indexes depending on a suspect collation are rebuilt, with
+  `REINDEX INDEX CONCURRENTLY` — except indexes backing exclusion
+  constraints, which PostgreSQL refuses to rebuild concurrently and are
+  rare enough to take the short non-concurrent lock instead. System
+  catalogs are excluded (they cannot be reindexed concurrently and ship on
+  C-locale name columns), as are other sessions' `pg_temp` schemas;
+  partitioned parents are skipped in favor of their leaves (a parent
+  rebuild would redo every leaf a second time). Leftover invalid `*_ccnew`
+  indexes from an interrupted attempt are dropped first.
 - The version stamps are refreshed only **after** the rebuilds succeed —
   never the reverse. While `needsReindex` is up, the boot-time blind
   collation-version refresh stands down (refreshing stamps without

--- a/README.md
+++ b/README.md
@@ -475,10 +475,14 @@ removed, and one unrecognized parameter there refuses the whole boot. The
 user's tuning must not silently evaporate either, so the job stashes both
 files at the volume root as `.pre-upgrade-<from>-postgresql.conf` /
 `.pre-upgrade-<from>-postgresql.auto.conf` (they outlive the old data dir's
-24 h reclaim) and records `needsConfigReview: true` in the completed marker —
-surfacing "re-apply your `ALTER SYSTEM` settings" is the dashboard's job,
-because the alternative is the user discovering it via a post-upgrade
-`max_connections` regression.
+24 h reclaim) and records `needsConfigReview: true` in the completed marker.
+`wrapper.sh` then self-heals it on the next boot: the stashed `auto.conf` is
+re-applied one GUC at a time via `ALTER SYSTEM` — a GUC the new major
+removed fails only its own statement (logged), never the boot; GUCs the
+image itself manages (archiving/recovery machinery, connection paths, SSL
+file paths) are never re-applied. `postgresql.conf` itself is initdb +
+entrypoint output, not a user surface, so only its stash remains as
+reference.
 
 #### Disk reclaim and rollback window
 
@@ -502,17 +506,31 @@ another `${PGDATA}.old-*` name to get it out of the way — the background
 reclaim above matches that whole glob and would delete it once the grace
 period passes; move it outside the prefix entirely.
 
-#### Collation caveat (known follow-up)
+#### Collation self-heal
 
 `pg_upgrade` preserves index files verbatim, but indexes on collatable
-columns (text/varchar btrees) are only valid for the glibc that built them,
-and the target image's glibc may differ from whatever built the source
-cluster. The marker records `needsReindex: true` on every upgrade — the
-image deliberately does **not** auto-`REINDEX` (rebuilding every text index
-on an arbitrarily large database inside the upgrade window is the wrong
-default). Surfacing that flag and driving the reindex is the dashboard's
-follow-up; `wrapper.sh`'s collation-version refresh only silences the
-version-mismatch warnings, it does not rebuild indexes.
+columns (text/varchar btrees) are only valid for the collation library that
+built them, and the target image's glibc may differ from whatever built the
+source cluster. The marker records `needsReindex: true` on every upgrade and
+`wrapper.sh` self-heals it in the background on the next boot — outside the
+upgrade window, so the database serves immediately either way:
+
+- Staleness is detected **per collation** (no supported PostgreSQL tracks it
+  per index: PG13 added `pg_depend.refobjversion`, PG14 reverted it): the
+  database default's `datcollversion` and each named collation's
+  `collversion` against their `*_actual_version()`.
+- Only the indexes depending on a stale collation are rebuilt, with
+  `REINDEX INDEX CONCURRENTLY` (system catalogs excluded — they cannot be
+  reindexed concurrently and ship on C-locale name columns). Leftover
+  invalid `*_ccnew` indexes from an interrupted attempt are dropped first.
+- The version stamps are refreshed only **after** the rebuilds succeed —
+  never the reverse. While `needsReindex` is up, the boot-time blind
+  collation-version refresh stands down (refreshing stamps without
+  rebuilding would silently declare stale indexes current, which is exactly
+  the wart this replaces).
+- Same library on both sides (the common case) means an empty stale set and
+  the flag clears with zero work; any failure keeps the flag and the next
+  boot retries.
 
 ### Archive re-anchoring
 

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -1261,6 +1261,94 @@ t_recover_refuses_past_commit_point() {
     || { echo "  refusal mutated the volume"; return 1; }
 }
 
+# The wrapper self-heals BOTH post-upgrade config concerns without an
+# operator: ALTER SYSTEM settings come back one GUC at a time (a GUC the new
+# major removed fails only its own statement; image-managed GUCs are never
+# re-applied), and the database restarts clean afterwards.
+t_config_restore_self_heals() {
+  local vol="upg-e2e-confheal"
+  fresh_volume "$vol" || return 1
+  run_pg confheal-pg "$vol" "$FROM_IMAGE" || return 1
+  wait_for_pg confheal-pg || { fail_dump confheal confheal-pg; return 1; }
+  psql_must confheal-pg "ALTER SYSTEM SET work_mem = '7654kB'" || return 1
+  psql_must confheal-pg "ALTER SYSTEM SET archive_command = 'should-never-carry'" || return 1
+  if [ "$FROM_VERSION" -le 16 ] && [ "$TO_VERSION" -ge 17 ]; then
+    # Removed in 17 — exercises the per-GUC rejection path.
+    psql_must confheal-pg "ALTER SYSTEM SET old_snapshot_threshold = '10min'" || return 1
+  fi
+  stop_pg confheal-pg
+
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "upgrade" || { echo "$JOB_OUT" | tail -20; return 1; }
+
+  run_pg confheal2-pg "$vol" "$TO_IMAGE" || return 1
+  wait_for_pg confheal2-pg || { fail_dump confheal2 confheal2-pg; return 1; }
+  local deadline=$(($(date +%s) + 120))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    [ "$(marker_field "$vol" needsConfigReview)" = "false" ] && break
+    sleep 5
+  done
+  assert_eq "$(marker_field "$vol" needsConfigReview)" "false" "config review self-healed" || { fail_dump confheal2 confheal2-pg; return 1; }
+  assert_eq "$(psql_in confheal2-pg 'SHOW work_mem')" "7654kB" "user tuning re-applied" || return 1
+  local logs
+  logs=$(docker logs confheal2-pg 2>&1)
+  assert_contains "$logs" "archive_command: image-managed" "image-managed GUC never re-applied" || return 1
+  if [ "$FROM_VERSION" -le 16 ] && [ "$TO_VERSION" -ge 17 ]; then
+    assert_contains "$logs" "old_snapshot_threshold: not re-applied" "removed GUC rejected per-statement, boot unharmed" || return 1
+  fi
+  # The restored auto.conf must not refuse the NEXT boot either.
+  docker restart confheal2-pg >/dev/null
+  wait_for_pg confheal2-pg || { fail_dump confheal2-restart confheal2-pg; return 1; }
+  assert_eq "$(psql_in confheal2-pg 'SHOW work_mem')" "7654kB" "tuning survives restart" || return 1
+  stop_pg confheal2-pg
+}
+
+# The wrapper self-heals collation drift: per-collation staleness detection
+# (datcollversion / collversion), REINDEX CONCURRENTLY of exactly the
+# dependent indexes, and only then the version-stamp refresh. Same library
+# across the test images = the zero-work path; a faked datcollversion forces
+# the rebuild path deterministically.
+t_reindex_self_heals() {
+  local vol="upg-e2e-reindexheal"
+  fresh_volume "$vol" || return 1
+  run_pg rxheal-pg "$vol" "$FROM_IMAGE" || return 1
+  wait_for_pg rxheal-pg || { fail_dump rxheal rxheal-pg; return 1; }
+  psql_must rxheal-pg "CREATE TABLE ct(a text); INSERT INTO ct SELECT g::text FROM generate_series(1,500) g; CREATE INDEX ct_a_idx ON ct(a)" || return 1
+  stop_pg rxheal-pg
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "upgrade" || { echo "$JOB_OUT" | tail -20; return 1; }
+
+  run_pg rxheal2-pg "$vol" "$TO_IMAGE" || return 1
+  wait_for_pg rxheal2-pg || { fail_dump rxheal2 rxheal2-pg; return 1; }
+  local deadline=$(($(date +%s) + 120))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    [ "$(marker_field "$vol" needsReindex)" = "false" ] && break
+    sleep 5
+  done
+  assert_eq "$(marker_field "$vol" needsReindex)" "false" "reindex flag self-cleared" || { fail_dump rxheal2 rxheal2-pg; return 1; }
+  assert_contains "$(docker logs rxheal2-pg 2>&1)" "no reindex needed" "zero-work path logged" || return 1
+
+  # Force the stale shape: fake the recorded default-collation version,
+  # re-arm the flag, restart — the fork must rebuild ct_a_idx, and only
+  # then refresh the stamp back to current.
+  psql_must rxheal2-pg "SET allow_system_table_mods = on; UPDATE pg_database SET datcollversion = '0.fake' WHERE datname = current_database()" || return 1
+  in_volume "$vol" "jq '.needsReindex = true' $MARKER_PATH > /tmp/m && cat /tmp/m > $MARKER_PATH" || return 1
+  docker restart rxheal2-pg >/dev/null
+  wait_for_pg rxheal2-pg || { fail_dump rxheal2-restart rxheal2-pg; return 1; }
+  deadline=$(($(date +%s) + 180))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    [ "$(marker_field "$vol" needsReindex)" = "false" ] && break
+    sleep 5
+  done
+  assert_eq "$(marker_field "$vol" needsReindex)" "false" "forced reindex completed" || { fail_dump rxheal2b rxheal2-pg; return 1; }
+  local logs
+  logs=$(docker logs rxheal2-pg 2>&1)
+  assert_contains "$logs" "reindexing" "stale-dependent index actually rebuilt" || return 1
+  assert_eq "$(psql_in rxheal2-pg 'SELECT (datcollversion IS NOT DISTINCT FROM pg_database_collation_actual_version(oid))::int FROM pg_database WHERE datname = current_database()')" "1" "version stamp refreshed only after the rebuild" || return 1
+  assert_eq "$(psql_in rxheal2-pg "SELECT count(*) FROM ct WHERE a = '250'")" "1" "index answers queries" || return 1
+  stop_pg rxheal2-pg
+}
+
 # pgdata.old-<from> is the rollback body and pins every pre-upgrade inode
 # (--link hardlinks); it must survive normal boots and be reclaimed in the
 # background once the upgraded database has been up past the grace period,
@@ -1749,6 +1837,8 @@ ALL_TESTS=(
   t_manifest_mode
   t_ssl_survives_upgrade
   t_analyze_staged
+  t_config_restore_self_heals
+  t_reindex_self_heals
   t_old_image_on_upgraded_data
   t_mismatch_boot_failstop
   t_boot_refused_mid_upgrade

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -1272,6 +1272,10 @@ t_config_restore_self_heals() {
   wait_for_pg confheal-pg || { fail_dump confheal confheal-pg; return 1; }
   psql_must confheal-pg "ALTER SYSTEM SET work_mem = '7654kB'" || return 1
   psql_must confheal-pg "ALTER SYSTEM SET archive_command = 'should-never-carry'" || return 1
+  # Boot-validated, statement-tolerant: ALTER SYSTEM accepts this even when
+  # the target image doesn't ship a named library — the refusal only comes
+  # at the NEXT postmaster start. The restore must never re-apply it.
+  psql_must confheal-pg "ALTER SYSTEM SET shared_preload_libraries = 'pg_stat_statements'" || return 1
   if [ "$FROM_VERSION" -le 16 ] && [ "$TO_VERSION" -ge 17 ]; then
     # Removed in 17 — exercises the per-GUC rejection path.
     psql_must confheal-pg "ALTER SYSTEM SET old_snapshot_threshold = '10min'" || return 1
@@ -1293,6 +1297,7 @@ t_config_restore_self_heals() {
   local logs
   logs=$(docker logs confheal2-pg 2>&1)
   assert_contains "$logs" "archive_command: image-managed" "image-managed GUC never re-applied" || return 1
+  assert_contains "$logs" "shared_preload_libraries: image-managed" "boot-validated preload GUC never re-applied" || return 1
   if [ "$FROM_VERSION" -le 16 ] && [ "$TO_VERSION" -ge 17 ]; then
     assert_contains "$logs" "old_snapshot_threshold: not re-applied" "removed GUC rejected per-statement, boot unharmed" || return 1
   fi
@@ -1303,17 +1308,67 @@ t_config_restore_self_heals() {
   stop_pg confheal2-pg
 }
 
+# A stash whose EVERY line is a GUC the new major removed is a full set of
+# server verdicts, not a connectivity failure — the flag must clear instead
+# of retrying forever. (A real boot always writes max_connections into
+# auto.conf, so this shape has to be constructed by rewriting the stash
+# after the upgrade — it models a volume whose stash predates the wrapper's
+# auto.conf writes, or a hand-pruned stash.)
+t_config_restore_all_rejected() {
+  if [ "$FROM_VERSION" -gt 16 ] || [ "$TO_VERSION" -lt 17 ]; then
+    echo "  (skipped: needs a GUC removed between $FROM_VERSION and $TO_VERSION; old_snapshot_threshold covers <=16 -> >=17)"
+    return 0
+  fi
+  local vol="upg-e2e-confrej"
+  fresh_volume "$vol" || return 1
+  run_pg confrej-pg "$vol" "$FROM_IMAGE" || return 1
+  wait_for_pg confrej-pg || { fail_dump confrej confrej-pg; return 1; }
+  stop_pg confrej-pg
+
+  run_job "$vol" upgrade
+  assert_eq "$JOB_RC" 0 "upgrade" || { echo "$JOB_OUT" | tail -20; return 1; }
+  in_volume "$vol" "printf \"old_snapshot_threshold = '10min'\\n\" > /var/lib/postgresql/data/.pre-upgrade-${FROM_VERSION}-postgresql.auto.conf" || return 1
+
+  run_pg confrej2-pg "$vol" "$TO_IMAGE" || return 1
+  wait_for_pg confrej2-pg || { fail_dump confrej2 confrej2-pg; return 1; }
+  local deadline=$(($(date +%s) + 120))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    [ "$(marker_field "$vol" needsConfigReview)" = "false" ] && break
+    sleep 5
+  done
+  assert_eq "$(marker_field "$vol" needsConfigReview)" "false" "all-rejected stash still completes the review" || { fail_dump confrej2 confrej2-pg; return 1; }
+  local logs
+  logs=$(docker logs confrej2-pg 2>&1)
+  assert_contains "$logs" "old_snapshot_threshold: not re-applied" "removed GUC rejected per-statement" || return 1
+  assert_contains "$logs" "0 applied, 0 image-managed, 1 rejected" "rejected-only tally, no bogus connectivity retry" || return 1
+  stop_pg confrej2-pg
+}
+
 # The wrapper self-heals collation drift: per-collation staleness detection
 # (datcollversion / collversion), REINDEX CONCURRENTLY of exactly the
 # dependent indexes, and only then the version-stamp refresh. Same library
-# across the test images = the zero-work path; a faked datcollversion forces
-# the rebuild path deterministically.
+# across the test images = the zero-work path (pre-15 sources have no
+# baseline and rebuild everything instead); a faked datcollversion plus a
+# faked named-collation version forces the rebuild path deterministically,
+# across the awkward shapes: an exclusion-constraint index (no CONCURRENTLY
+# support), quote-needing schema/index/collation names, and a partitioned
+# index (leaves rebuilt, parent skipped).
 t_reindex_self_heals() {
   local vol="upg-e2e-reindexheal"
   fresh_volume "$vol" || return 1
   run_pg rxheal-pg "$vol" "$FROM_IMAGE" || return 1
   wait_for_pg rxheal-pg || { fail_dump rxheal rxheal-pg; return 1; }
   psql_must rxheal-pg "CREATE TABLE ct(a text); INSERT INTO ct SELECT g::text FROM generate_series(1,500) g; CREATE INDEX ct_a_idx ON ct(a)" || return 1
+  # Exclusion-constraint index on a collatable column: REINDEX CONCURRENTLY
+  # refuses these outright, so the fork must fall back to the short
+  # non-concurrent rebuild instead of failing the database forever.
+  psql_must rxheal-pg "CREATE EXTENSION btree_gist; CREATE TABLE ex(r text, EXCLUDE USING gist (r WITH =)); INSERT INTO ex VALUES ('ea'), ('eb')" || return 1
+  # Quote-needing names end-to-end (schema, index, named collation): these
+  # break on any shell word-splitting or double-quoting of identifiers.
+  psql_must rxheal-pg "CREATE SCHEMA \"Weird Schema\"; CREATE COLLATION \"Weird Schema\".\"my coll\" (provider = icu, locale = 'en-US'); CREATE TABLE \"Weird Schema\".\"w t\"(a text COLLATE \"Weird Schema\".\"my coll\"); INSERT INTO \"Weird Schema\".\"w t\" VALUES ('x1'), ('x2'); CREATE INDEX \"w idx\" ON \"Weird Schema\".\"w t\"(a)" || return 1
+  # Partitioned index: only the leaves have storage; naming the parent would
+  # rebuild every leaf a second time.
+  psql_must rxheal-pg "CREATE TABLE pt(a text) PARTITION BY LIST (a); CREATE TABLE pt1 PARTITION OF pt FOR VALUES IN ('x','y'); INSERT INTO pt VALUES ('x'),('y'); CREATE INDEX pt_a_idx ON pt(a)" || return 1
   stop_pg rxheal-pg
   run_job "$vol" upgrade
   assert_eq "$JOB_RC" 0 "upgrade" || { echo "$JOB_OUT" | tail -20; return 1; }
@@ -1326,12 +1381,29 @@ t_reindex_self_heals() {
     sleep 5
   done
   assert_eq "$(marker_field "$vol" needsReindex)" "false" "reindex flag self-cleared" || { fail_dump rxheal2 rxheal2-pg; return 1; }
-  assert_contains "$(docker logs rxheal2-pg 2>&1)" "no reindex needed" "zero-work path logged" || return 1
+  local logs
+  logs=$(docker logs rxheal2-pg 2>&1)
+  if [ "$FROM_VERSION" -lt 15 ]; then
+    # Pre-15 sources carry no datcollversion baseline: pg_upgrade stamps the
+    # new database current, so "not stale" proves nothing — the fork must
+    # say so and rebuild everything rather than declare a zero-work heal.
+    assert_contains "$logs" "treated as suspect" "pre-15 source: baseline-unknown path taken" || return 1
+    assert_contains "$logs" "reindexing" "pre-15 source: indexes actually rebuilt" || return 1
+  elif ! echo "$logs" | grep -Eq "no reindex needed|reindexed [0-9]+ collation-dependent"; then
+    # Same base distro on both images means zero work; a genuinely different
+    # glibc/ICU between them makes a real rebuild the correct outcome too.
+    echo "  expected the zero-work or completed-rebuild log after first boot"
+    echo "  actual (tail): $(echo "$logs" | tail -5)"
+    return 1
+  fi
 
-  # Force the stale shape: fake the recorded default-collation version,
-  # re-arm the flag, restart — the fork must rebuild ct_a_idx, and only
-  # then refresh the stamp back to current.
+  # Force the stale shape: fake the recorded default-collation version AND
+  # the named collation's version, re-arm the flag, restart — the fork must
+  # rebuild the dependent indexes (concurrently, non-concurrently for the
+  # exclusion index, leaves-only for the partitioned one) and only then
+  # refresh the stamps back to current.
   psql_must rxheal2-pg "SET allow_system_table_mods = on; UPDATE pg_database SET datcollversion = '0.fake' WHERE datname = current_database()" || return 1
+  psql_must rxheal2-pg "SET allow_system_table_mods = on; UPDATE pg_collation SET collversion = '0.fake' WHERE collname = 'my coll'" || return 1
   in_volume "$vol" "jq '.needsReindex = true' $MARKER_PATH > /tmp/m && cat /tmp/m > $MARKER_PATH" || return 1
   docker restart rxheal2-pg >/dev/null
   wait_for_pg rxheal2-pg || { fail_dump rxheal2-restart rxheal2-pg; return 1; }
@@ -1341,11 +1413,16 @@ t_reindex_self_heals() {
     sleep 5
   done
   assert_eq "$(marker_field "$vol" needsReindex)" "false" "forced reindex completed" || { fail_dump rxheal2b rxheal2-pg; return 1; }
-  local logs
   logs=$(docker logs rxheal2-pg 2>&1)
   assert_contains "$logs" "reindexing" "stale-dependent index actually rebuilt" || return 1
-  assert_eq "$(psql_in rxheal2-pg 'SELECT (datcollversion IS NOT DISTINCT FROM pg_database_collation_actual_version(oid))::int FROM pg_database WHERE datname = current_database()')" "1" "version stamp refreshed only after the rebuild" || return 1
+  assert_contains "$logs" "non-concurrently (exclusion constraint" "exclusion index took the non-concurrent path" || return 1
+  assert_contains "$logs" '"Weird Schema"."w idx"' "quote-needing index survived identifier plumbing" || return 1
+  assert_contains "$logs" "pt1_a_idx" "partition leaf index rebuilt" || return 1
+  assert_not_contains "$logs" "public.pt_a_idx " "partitioned parent skipped (leaves carry the storage)" || return 1
+  assert_eq "$(psql_in rxheal2-pg 'SELECT (datcollversion IS NOT DISTINCT FROM pg_database_collation_actual_version(oid))::int FROM pg_database WHERE datname = current_database()')" "1" "default version stamp refreshed only after the rebuild" || return 1
+  assert_eq "$(psql_in rxheal2-pg "SELECT (collversion IS NOT DISTINCT FROM pg_collation_actual_version(oid))::int FROM pg_collation WHERE collname = 'my coll'")" "1" "named collation stamp refreshed (quoted schema + name)" || return 1
   assert_eq "$(psql_in rxheal2-pg "SELECT count(*) FROM ct WHERE a = '250'")" "1" "index answers queries" || return 1
+  assert_eq "$(psql_in rxheal2-pg "SELECT count(*) FROM \"Weird Schema\".\"w t\" WHERE a = 'x1'")" "1" "quoted-collation index answers queries" || return 1
   stop_pg rxheal2-pg
 }
 
@@ -1838,6 +1915,7 @@ ALL_TESTS=(
   t_ssl_survives_upgrade
   t_analyze_staged
   t_config_restore_self_heals
+  t_config_restore_all_rejected
   t_reindex_self_heals
   t_old_image_on_upgraded_data
   t_mismatch_boot_failstop

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -759,9 +759,10 @@ carry_cluster_config() {
 # 16, …), and an unrecognized parameter in those files refuses the whole
 # boot. The user's tuning must not silently evaporate either, so keep
 # reference copies at the volume root — they outlive the old dir's reclaim —
-# and the completed marker records needsConfigReview so the dashboard can
-# surface "re-apply your ALTER SYSTEM settings" instead of the user
-# discovering it via a post-upgrade max_connections regression.
+# and the completed marker records needsConfigReview; the runtime wrapper
+# then re-applies the stashed auto.conf itself on first boot, one GUC at a
+# time (a GUC the new major removed fails only its own statement, logged),
+# so the user's tuning comes back without anyone in the loop.
 stash_old_config() {
   local src="$1" f
   for f in postgresql.conf postgresql.auto.conf; do
@@ -827,9 +828,11 @@ finish_swap() {
   # collatable columns (text/varchar btree) is only valid for the glibc that
   # built it — and the source cluster may have run on an older base image.
   # We can't read the OLD runtime image's glibc from here, so record the flag
-  # unconditionally and let the operator/dashboard drive the REINDEX; an
-  # automatic REINDEX of an arbitrarily large database inside the upgrade
-  # window is the wrong default (documented follow-up in the README).
+  # unconditionally; the runtime wrapper self-heals it on first boot — it
+  # enumerates collation-version-stale indexes from the catalog (PG15+
+  # records per-index collation versions) and reindexes exactly that set,
+  # CONCURRENTLY, in the background: zero work when the library didn't
+  # change, no operator in the loop when it did.
   # needsConfigReview: postgresql{,.auto}.conf were not carried (see
   # stash_old_config) — the dashboard surfaces "re-apply your ALTER SYSTEM
   # settings" off this flag, pointing at the stashed reference copies.

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -829,13 +829,19 @@ finish_swap() {
   # built it — and the source cluster may have run on an older base image.
   # We can't read the OLD runtime image's glibc from here, so record the flag
   # unconditionally; the runtime wrapper self-heals it on first boot — it
-  # enumerates collation-version-stale indexes from the catalog (PG15+
-  # records per-index collation versions) and reindexes exactly that set,
-  # CONCURRENTLY, in the background: zero work when the library didn't
-  # change, no operator in the loop when it did.
+  # detects staleness per COLLATION (no supported PostgreSQL tracks it per
+  # index: PG13 added pg_depend.refobjversion, PG14 reverted it), maps
+  # suspect collations to their dependent indexes, and reindexes exactly
+  # that set, CONCURRENTLY, in the background: zero work when the library
+  # didn't change, no operator in the loop when it did. Pre-15 sources have
+  # no recorded baseline to compare (datcollversion is PG15+, and pg_upgrade
+  # re-stamps initdb-created collations), so the wrapper treats every
+  # collation-dependent index as suspect there instead of declaring them
+  # current.
   # needsConfigReview: postgresql{,.auto}.conf were not carried (see
-  # stash_old_config) — the dashboard surfaces "re-apply your ALTER SYSTEM
-  # settings" off this flag, pointing at the stashed reference copies.
+  # stash_old_config) — the runtime wrapper re-applies the stashed auto.conf
+  # itself, one GUC at a time; the stashed reference copies stay at the
+  # volume root.
   write_marker "$(jq -nc \
     --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" --arg old "$(basename "$OLD_KEEP_DIR")" \
     '{phase: "completed", from: $from, to: $to, oldDataDir: $old, needsAnalyze: true, needsReindex: true, needsConfigReview: true, completedAt: (now | todate)}')"

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1793,10 +1793,18 @@ fork_post_upgrade_analyze() {
 # belong to the PITR machinery (a leftover ALTER SYSTEM archive_command is
 # a known footgun), and connection paths / SSL file paths belong to the
 # entrypoint (a stale ssl_cert_file would refuse the next boot outright).
+# The preload GUCs and dynamic_library_path are skipped for a subtler
+# reason: ALTER SYSTEM validates them only syntactically — the libraries
+# load at postmaster start (shared_) or connection start (session_/local_),
+# so re-applying a value that names a library the new major's image doesn't
+# ship would pass here and then refuse every subsequent boot or connection,
+# which is the exact disaster class not carrying the file avoids. The image
+# also actively manages shared_preload_libraries itself (pg_stat_statements,
+# see ensure_pg_stat_statements above).
 # postgresql.conf itself is not re-applied: on this image it is initdb +
 # entrypoint output, not a user surface — its stash stays as reference.
 # One-shot across restarts via the marker's needsConfigReview flag.
-CONFIG_RESTORE_SKIP_GUCS="archive_mode archive_command archive_timeout restore_command recovery_target recovery_target_name recovery_target_time recovery_target_xid recovery_target_lsn recovery_target_inclusive recovery_target_timeline recovery_target_action primary_conninfo primary_slot_name listen_addresses port unix_socket_directories data_directory hba_file ident_file external_pid_file ssl ssl_cert_file ssl_key_file ssl_ca_file ssl_crl_file"
+CONFIG_RESTORE_SKIP_GUCS="archive_mode archive_command archive_timeout restore_command recovery_target recovery_target_name recovery_target_time recovery_target_xid recovery_target_lsn recovery_target_inclusive recovery_target_timeline recovery_target_action primary_conninfo primary_slot_name listen_addresses port unix_socket_directories data_directory hba_file ident_file external_pid_file ssl ssl_cert_file ssl_key_file ssl_ca_file ssl_crl_file shared_preload_libraries session_preload_libraries local_preload_libraries dynamic_library_path"
 
 fork_post_upgrade_config_restore() {
   [ -f "$UPGRADE_MARKER_FILE" ] || return 0
@@ -1814,7 +1822,7 @@ fork_post_upgrade_config_restore() {
     for _ in $(seq 1 120); do
       if pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null; then
         echo "post-upgrade: re-applying ALTER SYSTEM settings from $(basename "$stash")"
-        applied=0 skipped=0 rejected=0
+        applied=0 skipped=0 rejected=0 unreachable=0
         while IFS= read -r line; do
           case "$line" in ''|'#'*) continue ;; esac
           key="${line%%=*}"; key="$(printf '%s' "$key" | tr -d '[:space:]')"
@@ -1829,18 +1837,29 @@ fork_post_upgrade_config_restore() {
               echo "post-upgrade:   $key: image-managed, not re-applied"
               skipped=$((skipped + 1)); continue ;;
           esac
-          if out=$(psql -h /var/run/postgresql -p 5432 -U "${POSTGRES_USER:-postgres}" -d postgres -v ON_ERROR_STOP=1               -c "ALTER SYSTEM SET \"$key\" = $value" 2>&1); then
+          rc=0
+          out=$(psql -h /var/run/postgresql -p 5432 -U "${POSTGRES_USER:-postgres}" -d postgres -v ON_ERROR_STOP=1 \
+            -c "ALTER SYSTEM SET \"$key\" = $value" 2>&1 </dev/null) || rc=$?
+          if [ "$rc" -eq 0 ]; then
             applied=$((applied + 1))
+          elif [ "$rc" -eq 2 ]; then
+            # psql exit 2 = the connection could not be established or went
+            # bad — infrastructure, not a verdict on the GUC. Any other
+            # nonzero is the server rejecting this statement, which is the
+            # expected shape for a GUC the new major removed. (A stash whose
+            # every line is a removed GUC must still clear the flag — "all
+            # rejected" alone is NOT evidence of a connectivity problem.)
+            echo "post-upgrade:   $key: could not reach postgres ($(printf '%s' "$out" | tail -1))"
+            unreachable=$((unreachable + 1))
           else
             echo "post-upgrade:   $key: not re-applied ($(printf '%s' "$out" | tail -1))"
             rejected=$((rejected + 1))
           fi
         done < "$stash"
-        if [ "$applied" -eq 0 ] && [ "$skipped" -eq 0 ] && [ "$rejected" -gt 0 ]; then
-          # Every single statement failed — that is a connectivity/auth
-          # problem, not the expected removed-GUC rejections. Keep the flag
-          # so the next boot retries.
-          echo "post-upgrade: ALTER SYSTEM restore could not run; will retry on next boot"
+        if [ "$unreachable" -gt 0 ]; then
+          # Some settings never got a server verdict; keep the flag so the
+          # next boot retries (re-applying is idempotent).
+          echo "post-upgrade: ALTER SYSTEM restore could not reach postgres for ${unreachable} setting(s); will retry on next boot"
           exit 0
         fi
         psql -h /var/run/postgresql -p 5432 -U "${POSTGRES_USER:-postgres}" -d postgres -Atc "SELECT pg_reload_conf()" >/dev/null 2>&1 || true
@@ -1860,25 +1879,88 @@ fork_post_upgrade_config_restore() {
 # pg_depend.refobjversion, PG14 reverted it); what IS tracked is
 # per-collation: the database default's datcollversion (PG15+) and each
 # named collation's collversion. So: detect staleness per collation, map
-# stale collations to the indexes that depend on them (pg_index.indcollation),
+# suspect collations to the indexes that depend on them (pg_index.indcollation),
 # REINDEX exactly that set CONCURRENTLY in the background, and only then
 # refresh the version stamps — never the reverse. When no collation is stale
-# (the common case) this flips the flag with zero work. One-shot across
-# restarts via the marker's needsReindex flag; any failure keeps the flag so
-# the next boot retries. While this flag is up, fork_collation_refresh's
-# blind version refresh stands down — refreshing stamps without rebuilding
-# is exactly the wart this replaces.
+# (the common case) this flips the flag with zero work.
+#
+# Two places where the recorded stamps CANNOT be trusted, so the suspect set
+# is widened instead of comparing:
+# - Pre-15 sources have no datcollversion at all: pg_upgrade stamps the new
+#   database with the CURRENT library's version, so "not stale" there means
+#   nothing. With no baseline, every versioned collation is suspect.
+# - initdb-created (predefined, oid < 16384) collations are re-created by
+#   the new cluster's initdb with current stamps — pg_dump only carries
+#   user-created ones — so their staleness is inferred per PROVIDER: if any
+#   preserved stamp of a provider (the database default's, or a user-created
+#   collation's) proves that library changed, every predefined collation of
+#   that provider is suspect too.
+#
+# One-shot across restarts via the marker's needsReindex flag; any failure
+# keeps the flag so the next boot retries. While this flag is up,
+# fork_collation_refresh's blind version refresh stands down — refreshing
+# stamps without rebuilding is exactly the wart this replaces.
 fork_post_upgrade_reindex() {
   [ -f "$UPGRADE_MARKER_FILE" ] || return 0
   [ "$(jq -r '.needsReindex // false' "$UPGRADE_MARKER_FILE" 2>/dev/null)" = "true" ] || return 0
+  local rx_from_major rx_baseline_unknown
+  rx_from_major="$(jq -r '.from // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null)"
+  rx_baseline_unknown=0
+  if [ -n "$rx_from_major" ] && [ "$rx_from_major" -lt 15 ] 2>/dev/null; then
+    rx_baseline_unknown=1
+  fi
   (
     # Same connection shape as fork_post_upgrade_analyze: the cluster's
     # actual superuser over the local socket — a custom-POSTGRES_USER
     # cluster has no 'postgres' role at all.
     _rx_psql() { psql -h /var/run/postgresql -p 5432 -U "${POSTGRES_USER:-postgres}" -v ON_ERROR_STOP=1 "$@"; }
-    # Indexes whose indcollation vector contains a given collation oid.
-    _rx_indexes_for_coll() {
-      _rx_psql -d "$1" -Atc "SELECT DISTINCT format('%I.%I', n.nspname, c.relname) FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid JOIN pg_namespace n ON n.oid = c.relnamespace, unnest(string_to_array(i.indcollation::text, ' ')::oid[]) u(collid) WHERE u.collid = $2 AND n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema')"
+    # One pass per database: build the suspect collation set (stale stamps,
+    # plus the widenings described above), then every index depending on it.
+    # Output lines are "<is_exclusion> <schema-qualified name>": exclusion-
+    # constraint indexes cannot be rebuilt CONCURRENTLY (REINDEX raises an
+    # error when one is named directly), so they take the non-concurrent
+    # path. relkind 'i' only — a partitioned parent ('I') has no storage and
+    # naming it would rebuild every leaf a second time. pg_temp schemas are
+    # other sessions' business; system catalogs can't be reindexed
+    # concurrently and ship on C-locale name columns anyway.
+    _rx_suspect_indexes() {
+      _rx_psql -d "$1" -Atc "
+        WITH stale_user AS (
+          SELECT oid, collprovider FROM pg_collation
+          WHERE oid >= 16384 AND collversion IS NOT NULL
+            AND collversion IS DISTINCT FROM pg_collation_actual_version(oid)
+        ), dflt AS (
+          SELECT datlocprovider AS p,
+                 (datcollversion IS NOT NULL AND datcollversion IS DISTINCT FROM pg_database_collation_actual_version(oid)) AS stale,
+                 (pg_database_collation_actual_version(oid) IS NOT NULL) AS versioned
+          FROM pg_database WHERE datname = current_database()
+        ), stale_providers AS (
+          SELECT collprovider AS p FROM stale_user
+          UNION SELECT p FROM dflt WHERE stale
+        ), suspect AS (
+          SELECT oid FROM stale_user
+          UNION SELECT oid FROM pg_collation
+            WHERE $rx_baseline_unknown = 1 AND oid >= 16384
+              AND pg_collation_actual_version(oid) IS NOT NULL
+          UNION SELECT c.oid FROM pg_collation c
+            WHERE c.oid < 16384 AND c.collname <> 'default'
+              AND pg_collation_actual_version(c.oid) IS NOT NULL
+              AND ($rx_baseline_unknown = 1 OR c.collprovider IN (SELECT p FROM stale_providers))
+          UNION SELECT c.oid FROM pg_collation c, dflt d
+            WHERE c.collname = 'default'
+              AND (d.stale OR ($rx_baseline_unknown = 1 AND d.versioned))
+        )
+        SELECT DISTINCT (EXISTS (SELECT 1 FROM pg_constraint x WHERE x.conindid = i.indexrelid AND x.contype = 'x'))::int
+               || ' ' || format('%I.%I', n.nspname, c.relname)
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indexrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace,
+             unnest(string_to_array(i.indcollation::text, ' ')::oid[]) u(collid)
+        WHERE u.collid IN (SELECT oid FROM suspect)
+          AND c.relkind = 'i'
+          AND n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema')
+          AND n.nspname NOT LIKE 'pg_temp%'
+          AND n.nspname NOT LIKE 'pg_toast_temp%'"
     }
     i=0
     while ! pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null; do
@@ -1886,67 +1968,81 @@ fork_post_upgrade_reindex() {
     done
     pg_major=$(cat "$PGDATA/PG_VERSION" 2>/dev/null || echo "0")
     if [ "$pg_major" -lt 15 ] 2>/dev/null; then
-      # No collation-version tracking at all before 15 — nothing to compare
-      # against; leave the flag for a future major to resolve.
+      # Defensive only: the upgrade job's supported range (14-18) can never
+      # land BELOW 15, and pre-15 has no version tracking to drive this.
       exit 0
+    fi
+    if [ "$rx_baseline_unknown" = "1" ]; then
+      echo "post-upgrade: upgraded from PG${rx_from_major} — no collation-version baseline survives pg_upgrade from a pre-15 source, so every collation-dependent index is treated as suspect"
     fi
     dbs=$(_rx_psql -d postgres -Atc "SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate" 2>/dev/null) || {
       echo "post-upgrade: reindex check could not list databases; will retry on next boot"
       exit 0
     }
     total_reindexed=0 failed=0
-    for db in $dbs; do
+    while IFS= read -r db; do
+      [ -n "$db" ] || continue
       # Leftovers of a crashed prior CONCURRENTLY attempt are invalid
       # *_ccnew indexes; drop them before retrying.
       _rx_psql -d "$db" -Atc "SELECT format('%I.%I', n.nspname, c.relname) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace JOIN pg_index i ON i.indexrelid = c.oid WHERE NOT i.indisvalid AND c.relname ~ '_ccnew[0-9]*$'" 2>/dev/null \
         | while IFS= read -r junk; do
             [ -n "$junk" ] || continue
-            _rx_psql -d "$db" -c "DROP INDEX CONCURRENTLY IF EXISTS $junk" >/dev/null 2>&1 || true
+            _rx_psql -d "$db" -c "DROP INDEX CONCURRENTLY IF EXISTS $junk" >/dev/null 2>&1 </dev/null || true
           done
 
       db_failed=0
-      default_stale=$(_rx_psql -d "$db" -Atc "SELECT (datcollversion IS DISTINCT FROM pg_database_collation_actual_version(oid))::int FROM pg_database WHERE datname = current_database() AND datcollversion IS NOT NULL" 2>/dev/null) || { failed=$((failed+1)); continue; }
-      stale_named=$(_rx_psql -d "$db" -Atc "SELECT oid FROM pg_collation WHERE collversion IS NOT NULL AND collversion IS DISTINCT FROM pg_collation_actual_version(oid)" 2>/dev/null) || { failed=$((failed+1)); continue; }
+      # Stamp-stale sets drive the REFRESH step below — only stamps that
+      # really are behind get refreshed (the widened suspects above already
+      # carry current stamps, initdb/createdb just wrote them).
+      default_stale=$(_rx_psql -d "$db" -Atc "SELECT (datcollversion IS DISTINCT FROM pg_database_collation_actual_version(oid))::int FROM pg_database WHERE datname = current_database() AND datcollversion IS NOT NULL" 2>/dev/null) || { echo "post-upgrade: $db: collation staleness check failed; will retry on next boot"; failed=$((failed+1)); continue; }
+      stale_named=$(_rx_psql -d "$db" -Atc "SELECT oid FROM pg_collation WHERE collversion IS NOT NULL AND collversion IS DISTINCT FROM pg_collation_actual_version(oid)" 2>/dev/null) || { echo "post-upgrade: $db: collation staleness check failed; will retry on next boot"; failed=$((failed+1)); continue; }
+      suspect_indexes=$(_rx_suspect_indexes "$db" 2>/dev/null) || { echo "post-upgrade: $db: suspect-index enumeration failed; will retry on next boot"; failed=$((failed+1)); continue; }
 
-      stale_oids="$stale_named"
-      if [ "$default_stale" = "1" ]; then
-        default_oid=$(_rx_psql -d "$db" -Atc "SELECT oid FROM pg_collation WHERE collname = 'default'" 2>/dev/null)
-        stale_oids="$stale_oids $default_oid"
-      fi
-
-      for coll_oid in $stale_oids; do
-        [ -n "$coll_oid" ] || continue
-        for idx in $(_rx_indexes_for_coll "$db" "$coll_oid"); do
-          [ -n "$idx" ] || continue
+      while IFS=' ' read -r is_excl idx; do
+        [ -n "$idx" ] || continue
+        if [ "$is_excl" = "1" ]; then
+          echo "post-upgrade: reindexing $db.$idx non-concurrently (exclusion constraint; collation version changed)"
+          rx_cmd="REINDEX INDEX $idx"
+        else
           echo "post-upgrade: reindexing $db.$idx (collation version changed)"
-          if _rx_psql -d "$db" -c "REINDEX INDEX CONCURRENTLY $idx" >/dev/null 2>&1; then
-            total_reindexed=$((total_reindexed + 1))
-          else
-            echo "post-upgrade:   $db.$idx: reindex failed; will retry on next boot"
-            db_failed=1
-          fi
-        done
-      done
+          rx_cmd="REINDEX INDEX CONCURRENTLY $idx"
+        fi
+        if rx_out=$(_rx_psql -d "$db" -c "$rx_cmd" 2>&1 </dev/null); then
+          total_reindexed=$((total_reindexed + 1))
+        else
+          echo "post-upgrade:   $db.$idx: reindex failed; will retry on next boot ($(printf '%s' "$rx_out" | tail -1))"
+          db_failed=1
+        fi
+      done <<EOF_SUSPECT_INDEXES
+$suspect_indexes
+EOF_SUSPECT_INDEXES
 
       if [ "$db_failed" -eq 0 ]; then
         # Rebuilds done — NOW the version stamps may say current.
+        # regcollation renders a schema-qualified, quoted-as-needed name.
         for coll_oid in $stale_named; do
           [ -n "$coll_oid" ] || continue
-          _rx_psql -d "$db" -c "DO \$\$ DECLARE n text; BEGIN SELECT format('%I.%I', collnamespace::regnamespace, collname) INTO n FROM pg_collation WHERE oid = $coll_oid; EXECUTE format('ALTER COLLATION %s REFRESH VERSION', n); END \$\$" >/dev/null 2>&1 || true
+          _rx_psql -d "$db" -c "DO \$\$ BEGIN EXECUTE format('ALTER COLLATION %s REFRESH VERSION', ${coll_oid}::regcollation); END \$\$" >/dev/null 2>&1 || true
         done
         if [ "$default_stale" = "1" ]; then
-          _rx_psql -d postgres -c "ALTER DATABASE \"$db\" REFRESH COLLATION VERSION" >/dev/null 2>&1 || true
+          _rx_psql -d "$db" -c "DO \$\$ BEGIN EXECUTE format('ALTER DATABASE %I REFRESH COLLATION VERSION', current_database()); END \$\$" >/dev/null 2>&1 || true
         fi
       else
         failed=$((failed + 1))
       fi
-    done
+    done <<EOF_DBS
+$dbs
+EOF_DBS
     if [ "$failed" -gt 0 ]; then
       exit 0
     fi
     update_upgrade_marker '.needsReindex = false' || true
     if [ "$total_reindexed" -eq 0 ]; then
-      echo "post-upgrade: collation library unchanged — no reindex needed"
+      if [ "$rx_baseline_unknown" = "1" ]; then
+        echo "post-upgrade: no collation-dependent indexes to rebuild"
+      else
+        echo "post-upgrade: collation library unchanged — no reindex needed"
+      fi
     else
       echo "post-upgrade: reindexed ${total_reindexed} collation-dependent index(es)"
     fi

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1582,6 +1582,13 @@ fork_pgbackrest_backup_watcher() {
 # the database volume was initialized with the old version — postgres emits a WARNING on every
 # connection until refreshed, which is harmless but noisy.
 fork_collation_refresh() {
+  # While a post-upgrade reindex is pending, refreshing version stamps
+  # WITHOUT rebuilding would declare stale indexes current and blind the
+  # reindex fork's detection — it owns the refresh until it completes.
+  if [ -f "$UPGRADE_MARKER_FILE" ] && [ "$(jq -r '.needsReindex // false' "$UPGRADE_MARKER_FILE" 2>/dev/null)" = "true" ]; then
+    echo "collation-refresh: deferred — the post-upgrade reindex owns collation versions until it completes"
+    return 0
+  fi
   (
     local i=0
     while ! gosu postgres pg_isready -q 2>/dev/null; do
@@ -1776,6 +1783,176 @@ fork_post_upgrade_analyze() {
   ) &
 }
 
+# After a major upgrade, ALTER SYSTEM settings are deliberately NOT carried
+# into the new cluster (either file can hold a GUC the target major removed,
+# and an unrecognized parameter in postgresql.auto.conf refuses the whole
+# boot). Self-heal instead of asking the operator: re-apply the stashed
+# auto.conf one GUC at a time via ALTER SYSTEM — a setting the new major
+# rejects fails only ITS OWN statement (logged, skipped), never the boot.
+# Image-managed GUCs are never re-applied: archiving/recovery settings
+# belong to the PITR machinery (a leftover ALTER SYSTEM archive_command is
+# a known footgun), and connection paths / SSL file paths belong to the
+# entrypoint (a stale ssl_cert_file would refuse the next boot outright).
+# postgresql.conf itself is not re-applied: on this image it is initdb +
+# entrypoint output, not a user surface — its stash stays as reference.
+# One-shot across restarts via the marker's needsConfigReview flag.
+CONFIG_RESTORE_SKIP_GUCS="archive_mode archive_command archive_timeout restore_command recovery_target recovery_target_name recovery_target_time recovery_target_xid recovery_target_lsn recovery_target_inclusive recovery_target_timeline recovery_target_action primary_conninfo primary_slot_name listen_addresses port unix_socket_directories data_directory hba_file ident_file external_pid_file ssl ssl_cert_file ssl_key_file ssl_ca_file ssl_crl_file"
+
+fork_post_upgrade_config_restore() {
+  [ -f "$UPGRADE_MARKER_FILE" ] || return 0
+  [ "$(jq -r '.needsConfigReview // false' "$UPGRADE_MARKER_FILE" 2>/dev/null)" = "true" ] || return 0
+  local from_major stash
+  from_major="$(jq -r '.from // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null)"
+  stash="$EXPECTED_VOLUME_MOUNT_PATH/.pre-upgrade-${from_major}-postgresql.auto.conf"
+  if [ -z "$from_major" ] || [ ! -f "$stash" ]; then
+    # No ALTER SYSTEM settings existed before the upgrade (or the stash is
+    # gone): the review is trivially complete.
+    update_upgrade_marker '.needsConfigReview = false' || true
+    return 0
+  fi
+  (
+    for _ in $(seq 1 120); do
+      if pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null; then
+        echo "post-upgrade: re-applying ALTER SYSTEM settings from $(basename "$stash")"
+        applied=0 skipped=0 rejected=0
+        while IFS= read -r line; do
+          case "$line" in ''|'#'*) continue ;; esac
+          key="${line%%=*}"; key="$(printf '%s' "$key" | tr -d '[:space:]')"
+          value="${line#*=}"
+          # Trim leading whitespace only — auto.conf's value quoting IS SQL
+          # literal quoting, so the raw right-hand side drops into
+          # ALTER SYSTEM verbatim.
+          value="$(printf '%s' "$value" | sed 's/^[[:space:]]*//')"
+          [ -n "$key" ] || continue
+          case " $CONFIG_RESTORE_SKIP_GUCS " in
+            *" $key "*)
+              echo "post-upgrade:   $key: image-managed, not re-applied"
+              skipped=$((skipped + 1)); continue ;;
+          esac
+          if out=$(psql -h /var/run/postgresql -p 5432 -U "${POSTGRES_USER:-postgres}" -d postgres -v ON_ERROR_STOP=1               -c "ALTER SYSTEM SET \"$key\" = $value" 2>&1); then
+            applied=$((applied + 1))
+          else
+            echo "post-upgrade:   $key: not re-applied ($(printf '%s' "$out" | tail -1))"
+            rejected=$((rejected + 1))
+          fi
+        done < "$stash"
+        if [ "$applied" -eq 0 ] && [ "$skipped" -eq 0 ] && [ "$rejected" -gt 0 ]; then
+          # Every single statement failed — that is a connectivity/auth
+          # problem, not the expected removed-GUC rejections. Keep the flag
+          # so the next boot retries.
+          echo "post-upgrade: ALTER SYSTEM restore could not run; will retry on next boot"
+          exit 0
+        fi
+        psql -h /var/run/postgresql -p 5432 -U "${POSTGRES_USER:-postgres}" -d postgres -Atc "SELECT pg_reload_conf()" >/dev/null 2>&1 || true
+        update_upgrade_marker '.needsConfigReview = false' || true
+        echo "post-upgrade: ALTER SYSTEM restore complete (${applied} applied, ${skipped} image-managed, ${rejected} rejected by the new major; restart-scoped settings apply on the next restart)"
+        exit 0
+      fi
+      sleep 5
+    done
+  ) &
+}
+
+# pg_upgrade preserves index FILES verbatim, but an index on collatable
+# columns is only valid for the collation library that built it — and the
+# upgrade can change the base image under the data. Per-INDEX collation
+# versions are not tracked by any supported PostgreSQL (PG13 added
+# pg_depend.refobjversion, PG14 reverted it); what IS tracked is
+# per-collation: the database default's datcollversion (PG15+) and each
+# named collation's collversion. So: detect staleness per collation, map
+# stale collations to the indexes that depend on them (pg_index.indcollation),
+# REINDEX exactly that set CONCURRENTLY in the background, and only then
+# refresh the version stamps — never the reverse. When no collation is stale
+# (the common case) this flips the flag with zero work. One-shot across
+# restarts via the marker's needsReindex flag; any failure keeps the flag so
+# the next boot retries. While this flag is up, fork_collation_refresh's
+# blind version refresh stands down — refreshing stamps without rebuilding
+# is exactly the wart this replaces.
+fork_post_upgrade_reindex() {
+  [ -f "$UPGRADE_MARKER_FILE" ] || return 0
+  [ "$(jq -r '.needsReindex // false' "$UPGRADE_MARKER_FILE" 2>/dev/null)" = "true" ] || return 0
+  (
+    # Same connection shape as fork_post_upgrade_analyze: the cluster's
+    # actual superuser over the local socket — a custom-POSTGRES_USER
+    # cluster has no 'postgres' role at all.
+    _rx_psql() { psql -h /var/run/postgresql -p 5432 -U "${POSTGRES_USER:-postgres}" -v ON_ERROR_STOP=1 "$@"; }
+    # Indexes whose indcollation vector contains a given collation oid.
+    _rx_indexes_for_coll() {
+      _rx_psql -d "$1" -Atc "SELECT DISTINCT format('%I.%I', n.nspname, c.relname) FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid JOIN pg_namespace n ON n.oid = c.relnamespace, unnest(string_to_array(i.indcollation::text, ' ')::oid[]) u(collid) WHERE u.collid = $2 AND n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema')"
+    }
+    i=0
+    while ! pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null; do
+      sleep 5; i=$((i+1)); [ "$i" -ge 120 ] && exit 0
+    done
+    pg_major=$(cat "$PGDATA/PG_VERSION" 2>/dev/null || echo "0")
+    if [ "$pg_major" -lt 15 ] 2>/dev/null; then
+      # No collation-version tracking at all before 15 — nothing to compare
+      # against; leave the flag for a future major to resolve.
+      exit 0
+    fi
+    dbs=$(_rx_psql -d postgres -Atc "SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate" 2>/dev/null) || {
+      echo "post-upgrade: reindex check could not list databases; will retry on next boot"
+      exit 0
+    }
+    total_reindexed=0 failed=0
+    for db in $dbs; do
+      # Leftovers of a crashed prior CONCURRENTLY attempt are invalid
+      # *_ccnew indexes; drop them before retrying.
+      _rx_psql -d "$db" -Atc "SELECT format('%I.%I', n.nspname, c.relname) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace JOIN pg_index i ON i.indexrelid = c.oid WHERE NOT i.indisvalid AND c.relname ~ '_ccnew[0-9]*$'" 2>/dev/null \
+        | while IFS= read -r junk; do
+            [ -n "$junk" ] || continue
+            _rx_psql -d "$db" -c "DROP INDEX CONCURRENTLY IF EXISTS $junk" >/dev/null 2>&1 || true
+          done
+
+      db_failed=0
+      default_stale=$(_rx_psql -d "$db" -Atc "SELECT (datcollversion IS DISTINCT FROM pg_database_collation_actual_version(oid))::int FROM pg_database WHERE datname = current_database() AND datcollversion IS NOT NULL" 2>/dev/null) || { failed=$((failed+1)); continue; }
+      stale_named=$(_rx_psql -d "$db" -Atc "SELECT oid FROM pg_collation WHERE collversion IS NOT NULL AND collversion IS DISTINCT FROM pg_collation_actual_version(oid)" 2>/dev/null) || { failed=$((failed+1)); continue; }
+
+      stale_oids="$stale_named"
+      if [ "$default_stale" = "1" ]; then
+        default_oid=$(_rx_psql -d "$db" -Atc "SELECT oid FROM pg_collation WHERE collname = 'default'" 2>/dev/null)
+        stale_oids="$stale_oids $default_oid"
+      fi
+
+      for coll_oid in $stale_oids; do
+        [ -n "$coll_oid" ] || continue
+        for idx in $(_rx_indexes_for_coll "$db" "$coll_oid"); do
+          [ -n "$idx" ] || continue
+          echo "post-upgrade: reindexing $db.$idx (collation version changed)"
+          if _rx_psql -d "$db" -c "REINDEX INDEX CONCURRENTLY $idx" >/dev/null 2>&1; then
+            total_reindexed=$((total_reindexed + 1))
+          else
+            echo "post-upgrade:   $db.$idx: reindex failed; will retry on next boot"
+            db_failed=1
+          fi
+        done
+      done
+
+      if [ "$db_failed" -eq 0 ]; then
+        # Rebuilds done — NOW the version stamps may say current.
+        for coll_oid in $stale_named; do
+          [ -n "$coll_oid" ] || continue
+          _rx_psql -d "$db" -c "DO \$\$ DECLARE n text; BEGIN SELECT format('%I.%I', collnamespace::regnamespace, collname) INTO n FROM pg_collation WHERE oid = $coll_oid; EXECUTE format('ALTER COLLATION %s REFRESH VERSION', n); END \$\$" >/dev/null 2>&1 || true
+        done
+        if [ "$default_stale" = "1" ]; then
+          _rx_psql -d postgres -c "ALTER DATABASE \"$db\" REFRESH COLLATION VERSION" >/dev/null 2>&1 || true
+        fi
+      else
+        failed=$((failed + 1))
+      fi
+    done
+    if [ "$failed" -gt 0 ]; then
+      exit 0
+    fi
+    update_upgrade_marker '.needsReindex = false' || true
+    if [ "$total_reindexed" -eq 0 ]; then
+      echo "post-upgrade: collation library unchanged — no reindex needed"
+    else
+      echo "post-upgrade: reindexed ${total_reindexed} collation-dependent index(es)"
+    fi
+  ) &
+}
+
 # After a completed upgrade the previous cluster stays at ${PGDATA}.old-<from>
 # as the rollback body. pg_upgrade --link hardlinked the data files, so the
 # kept directory pins every pre-upgrade inode: space freed inside the upgraded
@@ -1861,6 +2038,8 @@ bootstrap_pgbackrest_stanza
 fork_pgbackrest_backup_watcher
 fork_collation_refresh
 fork_post_upgrade_analyze
+fork_post_upgrade_config_restore
+fork_post_upgrade_reindex
 fork_old_datadir_reclaim
 
 # H1 (audit): we considered `exec docker-entrypoint.sh` and a


### PR DESCRIPTION
Paulo's ruling on the post-upgrade follow-ups: the image self-heals EVERYTHING — both the stashed ALTER SYSTEM settings and the reindex. Surfacing guidance to the user (the approach in mono#36311, now closed) was the wrong design.

## Config restore (`needsConfigReview`)

On the next boot the wrapper re-applies the stashed `auto.conf` **one GUC at a time** via ALTER SYSTEM — a GUC the new major removed fails only its own statement (logged), never the boot, which is exactly why the file couldn't be carried verbatim in the first place. Never re-applied:

- **Image-managed GUCs** — archiving/recovery machinery, connection paths, SSL file paths (a leftover `archive_command` is a known footgun; a stale `ssl_cert_file` would refuse the next boot).
- **Boot-validated GUCs** — `shared_preload_libraries` & co. and `dynamic_library_path`. ALTER SYSTEM accepts these *syntactically*; the libraries only load at postmaster/connection start, so re-applying a value naming a library the new major's image doesn't ship (pgvector packaging famously lags new majors) would pass the statement and then refuse every subsequent boot — the exact disaster class not carrying the file exists to prevent. They stay in the stash for manual review, and the wrapper already manages `pg_stat_statements` preloading itself.

Retry gating is by **verdict, not tally**: psql exit 2 (connection lost/never reached the server) keeps the flag for the next boot; any server rejection is a final per-GUC verdict. A stash whose every line is a removed GUC clears the flag instead of retrying forever.

## Collation reindex (`needsReindex`)

**No supported PostgreSQL tracks collation versions per index** — PG13 added `pg_depend.refobjversion`, PG14 reverted it (verified empirically against PG17). So detection is per COLLATION: `datcollversion` + each named collation's `collversion` vs their `*_actual_version()`. Stale collations map to dependent indexes via `pg_index.indcollation`; exactly that set is rebuilt with `REINDEX INDEX CONCURRENTLY`, and the version stamps are refreshed **only after** the rebuilds. Same library on both sides — the common case — clears the flag with zero work.

Two places the recorded stamps **cannot be trusted**, where the suspect set is widened instead of compared (silently declaring unverifiable indexes "healed" would be worse than the dashboard flag this replaces):

- **Pre-15 sources have no `datcollversion` to carry** — pg_upgrade stamps the new database with the *current* library's version, so "not stale" proves nothing. From a 14 source, every collation-dependent index is treated as suspect and rebuilt.
- **initdb-created (predefined) collations are re-stamped current by the new cluster's initdb** — pg_dump only carries user-created ones (known upstream hole since 2019). Their staleness is inferred per *provider*: any preserved stamp (the database default's, or a user-created collation's) proving that library changed marks every predefined collation of that provider suspect too.

Rebuild mechanics hardened: exclusion-constraint indexes take the short non-concurrent path (PostgreSQL refuses `REINDEX CONCURRENTLY` on them — erroring forever was the alternative); partitioned parents are skipped in favor of their leaves (naming the parent would rebuild every leaf twice); `pg_temp` schemas are excluded; identifier plumbing is word-split-safe end to end (a `"Weird Schema"."w idx"` survives), and stamp refresh goes through `regcollation` / `current_database()` so quote-needing names refresh correctly. System catalogs stay excluded (can't be reindexed concurrently; C-locale name columns). Leftover invalid `*_ccnew` from an interrupted attempt dropped first.

This also closes a pre-existing wart the README admitted: the boot-time blind collation-version refresh silenced warnings WITHOUT rebuilding. It now stands down while `needsReindex` is up; the reindex fork owns the refresh.

## Tests (16→17 local, 5/5; reindex leg also verified 14→17 for the baseline-unknown path)

- `t_config_restore_self_heals`: `work_mem` re-applied and surviving a further restart; `archive_command` skipped as image-managed; `shared_preload_libraries` skipped as boot-validated; `old_snapshot_threshold` (removed in 17) rejected per-statement with the boot unharmed; flag flips.
- `t_config_restore_all_rejected`: a stash whose only line is a removed GUC — full set of server verdicts, flag clears (`0 applied, 0 image-managed, 1 rejected`), no bogus connectivity retry loop.
- `t_reindex_self_heals`: zero-work path (or honest rebuild on a pre-15 source); then forced-stale `datcollversion` **and** a faked named-ICU-collation version + re-armed flag + restart prove the rebuild runs across the awkward shapes — exclusion-constraint index non-concurrently, quote-needing schema/index/collation names, partition leaves without the parent — and both stamps are refreshed only after it.
- `t_upgrade_happy_path`, `t_analyze_staged`: unregressed.

Note: touches wrapper.sh/README alongside #121/#122/#124's upgrade-job.sh — no file overlap with those, merges clean in any order.
