### PR TITLE
rename the boot-time volume lock so it stops reading as upgrade evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,12 +432,22 @@ restore. `wrapper.sh` refuses to boot while a non-completed marker exists, and
 refuses any image whose major differs from the on-disk `PG_VERSION` — so no
 mismatched boot can touch the data.
 
-Both sides also hold a `flock` on the volume-root
-`.railway-major-upgrade.lock`: the job exclusively for its run, the runtime
-container shared for its lifetime. A job dispatched against a live database
-refuses instead of corrupting the cluster, and a database deployed while a
-job is mid-flight refuses to boot — in-image backstops for the
-orchestrator's own exclusion.
+Both sides also hold a `flock` on the volume-root `.railway-volume.lock`:
+the job exclusively for its run, the runtime container shared for its
+lifetime. A job dispatched against a live database refuses instead of
+corrupting the cluster, and a database deployed while a job is mid-flight
+refuses to boot — in-image backstops for the orchestrator's own exclusion.
+
+The lock lived at `.railway-major-upgrade.lock` until the rename: a name
+that reads as an event marker, on a file every boot creates, kept being
+cited during data-loss forensics as evidence that an automatic major
+upgrade had run. Post-rename builds still lock the legacy path — the
+runtime whenever the file exists, the job creating it — so mixed-build
+runtime/job pairings keep excluding each other; both files now also carry
+a self-describing note instead of being empty. The legacy file is never
+deleted (unlinking an flock rendezvous splits racers across inodes) and is
+never created by a post-rename boot, so on new volumes it only ever
+appears where an upgrade job actually ran.
 
 The job tolerates the platform's ungraceful container stop: it clears a stale
 `postmaster.pid` and, when `pg_control` says the cluster was not shut down

--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -508,13 +508,47 @@ t_refuses_concurrent_job() {
   # Hold the lock from a sleeper container, then try a real job.
   docker run -d --name lockholder --label postgres-upgrade-e2e=1 \
     -v "$vol:/var/lib/postgresql/data" --entrypoint /bin/sh "$JOB_IMAGE" \
-    -c "exec 9>/var/lib/postgresql/data/.railway-major-upgrade.lock; flock 9; sleep 60" >/dev/null
+    -c "exec 9>/var/lib/postgresql/data/.railway-volume.lock; flock 9; sleep 60" >/dev/null
   sleep 2
   run_job "$vol" upgrade
   local rc="$JOB_RC" out="$JOB_OUT"
   docker rm -f lockholder >/dev/null 2>&1
   assert_eq "$rc" 2 "second job refused" || { echo "$out" | tail -10; return 1; }
   assert_contains "$out" "holds the upgrade lock" "lock message" || return 1
+}
+
+# The rename's transition contract: builds from before it rendezvous on the
+# legacy .railway-major-upgrade.lock, and both directions must still exclude.
+# A pre-rename runtime (shared holder on the legacy path) refuses the job,
+# and a pre-rename job (exclusive holder on the legacy path) refuses a boot.
+t_legacy_lock_still_excludes() {
+  local vol="upg-e2e-legacylock"
+  seed_from_cluster "$vol" || return 1
+
+  # Direction 1: old runtime alive → new job refused. Old wrapper holds the
+  # legacy path SHARED for its container's lifetime; simulate exactly that.
+  docker run -d --name legacy-rt-holder --label postgres-upgrade-e2e=1 \
+    -v "$vol:/var/lib/postgresql/data" --entrypoint /bin/sh "$JOB_IMAGE" \
+    -c "exec 9>>/var/lib/postgresql/data/.railway-major-upgrade.lock; flock -s 9; sleep 60" >/dev/null
+  sleep 2
+  run_job "$vol" upgrade
+  local rc="$JOB_RC" out="$JOB_OUT"
+  docker rm -f legacy-rt-holder >/dev/null 2>&1
+  assert_eq "$rc" 2 "job refused while a pre-rename runtime holds the legacy lock" \
+    || { echo "$out" | tail -10; return 1; }
+  assert_contains "$out" "holds the upgrade lock" "legacy lock message" || return 1
+
+  # Direction 2: old job mid-flight → new runtime refuses to boot. Old jobs
+  # hold the legacy path EXCLUSIVELY; the wrapper contends on it whenever the
+  # file exists (it does here — direction 1 created it).
+  docker run -d --name legacy-job-holder --label postgres-upgrade-e2e=1 \
+    -v "$vol:/var/lib/postgresql/data" --entrypoint /bin/sh "$JOB_IMAGE" \
+    -c "exec 9>>/var/lib/postgresql/data/.railway-major-upgrade.lock; flock 9; sleep 60" >/dev/null
+  sleep 2
+  rc=0
+  expect_boot_refusal "$vol" "$FROM_IMAGE" "upgrade job is currently running" || rc=1
+  docker rm -f legacy-job-holder >/dev/null 2>&1
+  return "$rc"
 }
 
 # The whole point: upgrade succeeds, marker completes, the TO image boots,
@@ -1065,7 +1099,7 @@ t_runtime_refused_while_job_locked() {
   seed_from_cluster "$vol" || return 1
   docker run -d --name rt-lockholder --label postgres-upgrade-e2e=1 \
     -v "$vol:/var/lib/postgresql/data" --entrypoint /bin/sh "$JOB_IMAGE" \
-    -c "exec 9>/var/lib/postgresql/data/.railway-major-upgrade.lock; flock 9; sleep 60" >/dev/null
+    -c "exec 9>/var/lib/postgresql/data/.railway-volume.lock; flock 9; sleep 60" >/dev/null
   sleep 2
   local rc=0
   expect_boot_refusal "$vol" "$FROM_IMAGE" "upgrade job is currently running" || rc=1
@@ -1789,6 +1823,7 @@ ALL_TESTS=(
   t_foreign_pair_upgraded_marker_refused
   t_job_refused_while_runtime_live
   t_runtime_refused_while_job_locked
+  t_legacy_lock_still_excludes
   t_recovery_shapes_refused
   t_marker_lost_after_pg_upgrade_resumes
   t_crash_mid_link_rolls_back_and_reruns

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -353,11 +353,16 @@ take_job_lock() {
     "Advisory flock rendezvous between the Postgres container and Railway maintenance jobs." \
     "Created on every boot; its presence is not a record of any upgrade or other event." \
     >>"$JOB_LOCK_FILE" 2>/dev/null || true
-  if ! { exec 10>>"$LEGACY_JOB_LOCK_FILE"; } 2>/dev/null; then
+  # fd 7, not 10+: bash reserves fds >= 10 to save/restore the shell's own
+  # fds around redirections (e.g. this brace group's 2>/dev/null), and that
+  # bookkeeping closes a user-opened fd 10 on the way out — flock then sees
+  # EBADF and every job run dies here. Single-digit fds are never touched
+  # by it.
+  if ! { exec 7>>"$LEGACY_JOB_LOCK_FILE"; } 2>/dev/null; then
     log "could not open $LEGACY_JOB_LOCK_FILE; continuing without the legacy upgrade lock"
     return 0
   fi
-  if ! flock -n 10; then
+  if ! flock -n 7; then
     die 2 "the volume is in use — another upgrade job, or a still-running database container, holds the upgrade lock"
   fi
 }

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -309,7 +309,11 @@ check_mount() {
   fi
 }
 
-JOB_LOCK_FILE="$VOLUME_ROOT/.railway-major-upgrade.lock"
+JOB_LOCK_FILE="$VOLUME_ROOT/.railway-volume.lock"
+# Pre-rename path (see wrapper.sh): runtimes built before the rename hold
+# THIS file shared for their container's lifetime and know nothing of the
+# new name, so the job locks both.
+LEGACY_JOB_LOCK_FILE="$VOLUME_ROOT/.railway-major-upgrade.lock"
 
 # Exclusive flock on the volume-root lock file, held for this job's lifetime.
 # The runtime image (wrapper.sh) holds the SAME file with a SHARED flock for
@@ -323,6 +327,12 @@ JOB_LOCK_FILE="$VOLUME_ROOT/.railway-major-upgrade.lock"
 # incumbent before this container starts) remains the first line of defense;
 # this is the in-image backstop that turns a workflow bug into a refusal
 # instead of a corrupted volume.
+#
+# The legacy path is CREATED here, not if-exists-probed: the create-open
+# converges every racer on one inode, so even a pre-rename runtime booting
+# concurrently contends on the same lock with no check-then-create window.
+# (Unlike the wrapper, the job runs only during a real upgrade — a
+# major-upgrade-named file on an upgraded volume is true evidence.)
 take_job_lock() {
   command -v flock >/dev/null 2>&1 \
     || { log "flock not available; continuing without the upgrade lock"; return 0; }
@@ -337,6 +347,17 @@ take_job_lock() {
     return 0
   fi
   if ! flock -n 9; then
+    die 2 "the volume is in use — another upgrade job, or a still-running database container, holds the upgrade lock"
+  fi
+  [ -s "$JOB_LOCK_FILE" ] || printf '%s\n' \
+    "Advisory flock rendezvous between the Postgres container and Railway maintenance jobs." \
+    "Created on every boot; its presence is not a record of any upgrade or other event." \
+    >>"$JOB_LOCK_FILE" 2>/dev/null || true
+  if ! { exec 10>>"$LEGACY_JOB_LOCK_FILE"; } 2>/dev/null; then
+    log "could not open $LEGACY_JOB_LOCK_FILE; continuing without the legacy upgrade lock"
+    return 0
+  fi
+  if ! flock -n 10; then
     die 2 "the volume is in use — another upgrade job, or a still-running database container, holds the upgrade lock"
   fi
 }

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -91,9 +91,14 @@ if command -v flock >/dev/null 2>&1 && [ -d "$EXPECTED_VOLUME_MOUNT_PATH" ] \
   # only: old volumes already carry the file (every old boot created it);
   # a volume that never booted an old build has no old-build peer to
   # exclude, and never creating it here is the point of the rename.
+  # fd 7, not 10+: bash reserves fds >= 10 to save/restore the shell's own
+  # fds around redirections (e.g. this brace group's 2>/dev/null), and that
+  # bookkeeping closes a user-opened fd 10 on the way out — flock then sees
+  # EBADF and every boot on a legacy-carrying volume refuses. Single-digit
+  # fds are never touched by it.
   if [ -f "$LEGACY_UPGRADE_LOCK_FILE" ]; then
-    if { exec 10>>"$LEGACY_UPGRADE_LOCK_FILE"; } 2>/dev/null; then
-      if ! flock -n -s 10; then
+    if { exec 7>>"$LEGACY_UPGRADE_LOCK_FILE"; } 2>/dev/null; then
+      if ! flock -n -s 7; then
         echo "A major version upgrade job is currently running against this volume."
         echo "The database must not start until it finishes; retry the deploy once the upgrade completes."
         exit 1

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -48,8 +48,18 @@ fi
 # creating the lock file inside an empty PGDATA would make docker-entrypoint
 # skip initdb (it checks `ls -A`), and that layout can't take an in-place
 # upgrade anyway (no sibling slot on the volume for the new data dir).
+#
+# The file was named .railway-major-upgrade.lock until the rename below:
+# a name that reads as an event marker, plus a ctime refreshed by whichever
+# boot first recreated it, kept being cited during data-loss forensics as
+# evidence that an automatic major upgrade had run — when every boot of
+# every volume creates it. The lock now lives at a neutral name and carries
+# a self-describing note; the legacy path is still locked (below) whenever
+# it exists, so mixed-build runtime/job pairings keep excluding each other,
+# but it is never created here again.
 # -----------------------------------------------------------------------------
-UPGRADE_LOCK_FILE="$EXPECTED_VOLUME_MOUNT_PATH/.railway-major-upgrade.lock"
+UPGRADE_LOCK_FILE="$EXPECTED_VOLUME_MOUNT_PATH/.railway-volume.lock"
+LEGACY_UPGRADE_LOCK_FILE="$EXPECTED_VOLUME_MOUNT_PATH/.railway-major-upgrade.lock"
 if command -v flock >/dev/null 2>&1 && [ -d "$EXPECTED_VOLUME_MOUNT_PATH" ] \
   && ! { [ "$PGDATA" = "$EXPECTED_VOLUME_MOUNT_PATH" ] && [ ! -f "$PGDATA/PG_VERSION" ]; }; then
   # The 2>/dev/null MUST be scoped by the brace group, never put on the exec
@@ -65,8 +75,36 @@ if command -v flock >/dev/null 2>&1 && [ -d "$EXPECTED_VOLUME_MOUNT_PATH" ] \
       echo "The database must not start until it finishes; retry the deploy once the upgrade completes."
       exit 1
     fi
+    # Self-describing, written once while the lock is held: bare lock files
+    # keep getting read as event markers during forensics on a dead volume.
+    [ -s "$UPGRADE_LOCK_FILE" ] || printf '%s\n' \
+      "Advisory flock rendezvous between the Postgres container and Railway maintenance jobs." \
+      "Created on every boot; its presence is not a record of any upgrade or other event." \
+      >>"$UPGRADE_LOCK_FILE" 2>/dev/null || true
   else
     echo "wrapper: could not open $UPGRADE_LOCK_FILE; continuing without the upgrade lock" >&2
+  fi
+  # Transition: builds from before the rename rendezvous on the legacy path,
+  # so contend there too whenever the file exists — an upgrade job from an
+  # earlier build must still refuse to run against this live database, and
+  # this boot must still refuse while such a job is mid-flight. if-exists
+  # only: old volumes already carry the file (every old boot created it);
+  # a volume that never booted an old build has no old-build peer to
+  # exclude, and never creating it here is the point of the rename.
+  if [ -f "$LEGACY_UPGRADE_LOCK_FILE" ]; then
+    if { exec 10>>"$LEGACY_UPGRADE_LOCK_FILE"; } 2>/dev/null; then
+      if ! flock -n -s 10; then
+        echo "A major version upgrade job is currently running against this volume."
+        echo "The database must not start until it finishes; retry the deploy once the upgrade completes."
+        exit 1
+      fi
+      [ -s "$LEGACY_UPGRADE_LOCK_FILE" ] || printf '%s\n' \
+        "Legacy name of .railway-volume.lock (see that file). Older image builds create this" \
+        "file on EVERY boot; its presence is not evidence that a major version upgrade ran." \
+        >>"$LEGACY_UPGRADE_LOCK_FILE" 2>/dev/null || true
+    else
+      echo "wrapper: could not open $LEGACY_UPGRADE_LOCK_FILE; continuing without the legacy upgrade lock" >&2
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Problem

`.railway-major-upgrade.lock` is an advisory flock rendezvous the wrapper creates on **every boot of every volume** (shared) and the upgrade job locks exclusively for its run. The name reads as an event marker: during data-loss forensics users keep citing its presence + timestamp as proof that an automatic major upgrade ran on their volume, and support has now had to debunk exactly that reading twice.

## Change

- Lock moves to `.railway-volume.lock`; both files get a one-time self-describing note written into them (they were 0 bytes — a bare lock file invites misreads).
- **Transition keeps every mixed-build pairing mutually exclusive:**
  - wrapper: creates+shared-locks the new path as before, and also shared-locks the **legacy path whenever it exists** — never creating it again (that's the point of the rename).
  - upgrade-job: exclusively locks **both** paths, creating the legacy one — create-open converges every racer on one inode, closing the check-then-create window an if-exists probe would leave. On upgraded volumes the legacy name becomes *true* evidence: it only appears where a job actually ran.
  - the legacy file is never unlinked (deleting an flock rendezvous splits racers across inodes).

| pairing | rendezvous |
|---|---|
| new job vs old runtime | legacy path (old boots created it) |
| old job vs new runtime | legacy path (if-exists lock; file predates any such job) |
| new vs new | new path |
| old vs old | legacy path (unchanged) |

The only unguarded pairing is a pre-rename **job** against a volume that never booted a pre-rename runtime — which cannot arise, since job images are resolved by tag at dispatch time.

## Tests

The two lockholder e2e tests move to the new path; new `t_legacy_lock_still_excludes` covers both legacy directions (pre-rename runtime blocks the job; pre-rename job blocks a boot).

Companion PR to follow in postgres-ha (its runtime takes the same shared lock in `major_upgrade.rs`); the dual-lock transition makes merge order irrelevant.