### PR TITLE
fix: post-audit hardening — validity-keyed cert regen, warn-not-exit knobs, generation-gated self-heal

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,29 @@ upgrade window, so the database serves immediately either way:
 - Same library on both sides (the common case) means an empty stale set and
   the flag clears with zero work; any failure keeps the flag and the next
   boot retries.
+- `POST_UPGRADE_REINDEX_DISABLED=1` opts out of the automatic reindex
+  entirely: every rebuild **and** every stamp refresh is skipped (refreshing
+  without rebuilding would mask the staleness), `needsReindex` stays set,
+  and the skip is logged. Default behavior is unchanged when unset.
+
+Scope and caveats for both post-upgrade self-heals (this reindex and the
+`ALTER SYSTEM` restore above):
+
+- They act only on markers written by the current upgrade job, which records
+  a `stashedAutoConf` field. A legacy marker (no such field) predates the
+  self-heal and its flags belong to the dashboard-driven flow — the wrapper
+  logs that it found one, skips, and leaves the flags set. Retroactively
+  adopting an old marker would replay a months-old `auto.conf` stash over
+  re-tuning done since, and (for ≥15 sources) trust collation stamps the old
+  boot-time blind refresh already overwrote.
+- "No operator in the loop" is a property of this **standalone** image:
+  postgres-ha cluster members boot a different image without these forks,
+  so on HA volumes the flags never self-clear and the dashboard-driven flow
+  resolves them.
+- The self-heal covers upgrades only. A plain image rebuild that ships a
+  newer glibc/ICU **without** a major upgrade leaves no marker, and on such
+  boots `wrapper.sh`'s collation-version refresh still only silences the
+  version-mismatch warnings — it does not rebuild indexes.
 
 ### Archive re-anchoring
 

--- a/init-ssl.sh
+++ b/init-ssl.sh
@@ -17,26 +17,37 @@ SSL_V3_EXT="$SSL_DIR/v3.ext"
 
 POSTGRES_CONF_FILE="$PGDATA/postgresql.conf"
 
-# A malformed day count must fail loudly, not degrade silently: bash
-# arithmetic would turn a typo into a nonsense value and openssl into a
-# cert that expires at birth, and SSL_CERT_DAYS=0 issues a certificate
-# that is expired the moment it is written.
-SSL_CERT_DAYS_VALUE="${SSL_CERT_DAYS:-820}"
-case "$SSL_CERT_DAYS_VALUE" in
-  ''|0|*[!0-9]*)
-    echo "init-ssl: SSL_CERT_DAYS='${SSL_CERT_DAYS}' is not a positive integer; refusing to issue certificates with it" >&2
-    exit 1
-    ;;
-esac
-
 # Idempotency: docker-entrypoint-initdb.d runs on first init only, but a
 # re-execution (manual run, unusual entrypoint ordering) must not rotate a
 # CA that clients have pinned into their trust stores — that is an outage.
-# Regenerate only when the set is absent or incomplete, and say so.
-if [ -f "$SSL_ROOT_CRT" ] && [ -f "$SSL_SERVER_CRT" ] && [ -f "$SSL_SERVER_KEY" ]; then
-  echo "init-ssl: certificates already present in $SSL_DIR; keeping them"
+# Keep is keyed on VALIDITY, never mere existence: wrapper.sh re-runs this
+# script precisely to REPLACE certs that are not x509v3 (no SAN) or that
+# expire within 30 days, so an existence-only keep would turn both of those
+# heals into no-ops. Keep only a complete set whose server.crt passes the
+# SAME two tests wrapper.sh uses to decide a re-run is needed (checkend
+# 2592000 = 30 days; DNS:localhost in the text output as the v3/SAN probe),
+# so the two can never disagree; anything else regenerates.
+if [ -f "$SSL_ROOT_CRT" ] && [ -f "$SSL_SERVER_CRT" ] && [ -f "$SSL_SERVER_KEY" ] \
+  && openssl x509 -checkend 2592000 -noout -in "$SSL_SERVER_CRT" >/dev/null 2>&1 \
+  && openssl x509 -noout -text -in "$SSL_SERVER_CRT" 2>/dev/null | grep -q "DNS:localhost"; then
+  echo "init-ssl: valid certificates already present in $SSL_DIR; keeping them"
 else
-  echo "init-ssl: certificate set incomplete or absent in $SSL_DIR; generating"
+  echo "init-ssl: certificates absent, incomplete, expiring within 30 days, or missing the x509v3 SAN in $SSL_DIR; generating"
+
+# A malformed day count must not stop the database: this script runs under
+# wrapper.sh's set -e on every renewal (the checkend re-run above), so an
+# exit here would crash-loop a healthy database the day its certificate
+# crosses the 30-day window. Bash arithmetic would turn a typo into a
+# nonsense value and openssl into a cert that expires at birth (and
+# SSL_CERT_DAYS=0 is expired the moment it is written) — so WARN loudly and
+# fall back to the default instead.
+SSL_CERT_DAYS_VALUE="${SSL_CERT_DAYS:-820}"
+case "$SSL_CERT_DAYS_VALUE" in
+  ''|0|*[!0-9]*)
+    echo "init-ssl: SSL_CERT_DAYS='${SSL_CERT_DAYS}' is not a positive integer; using 820 (a bad value must never stop certificate issuance)" >&2
+    SSL_CERT_DAYS_VALUE=820
+    ;;
+esac
 
 # Use sudo to create the directory as root
 sudo mkdir -p "$SSL_DIR"

--- a/pgbackrest-archive-push-wrapper.sh
+++ b/pgbackrest-archive-push-wrapper.sh
@@ -94,12 +94,28 @@ PGWAL_THRESHOLD_MB="${WAL_DROP_THRESHOLD_MB:-5120}"
 # A malformed numeric knob must never degrade silently: bash arithmetic
 # evaluates non-numeric strings to 0, and a 0 threshold here means "drop
 # WAL on ANY archive failure" — a typo like 5gb would silently truncate
-# PITR. Refuse to run with it instead; Postgres retries archive_command
-# and the log line is unmissable.
+# PITR. But refusing to run is worse: this script IS archive_command, so an
+# exit here fails every invocation forever, Postgres retains WAL, and the
+# disk fills with the anti-disk-fill escape hatch disabled. Log loudly and
+# fall back to the same volume-proportional threshold wrapper.sh's
+# compute_volume_thresholds would have exported absent the override —
+# min(5 GiB, ~50% of volume), floor 128 MiB; 5 GiB when the volume size is
+# unreadable. Archiving keeps working; only the destructive drop stays
+# gated, on a sane threshold.
 case "$PGWAL_THRESHOLD_MB" in
   ''|*[!0-9]*)
-    echo "pgbackrest-wrapper: WAL_DROP_THRESHOLD_MB='${WAL_DROP_THRESHOLD_MB}' is not a non-negative integer; refusing to run (bash arithmetic would evaluate it as 0 and drop WAL on any failure)" >&2
-    exit 1
+    FALLBACK_THRESHOLD_MB=5120
+    VOLUME_TOTAL_KIB=$(df -Pk "${RAILWAY_VOLUME_MOUNT_PATH:-/var/lib/postgresql/data}" 2>/dev/null | awk 'NR==2 { print $2 }')
+    case "$VOLUME_TOTAL_KIB" in
+      ''|*[!0-9]*) : ;;
+      *)
+        FALLBACK_THRESHOLD_MB=$(( VOLUME_TOTAL_KIB / 1024 / 2 ))
+        [ "$FALLBACK_THRESHOLD_MB" -gt 5120 ] && FALLBACK_THRESHOLD_MB=5120
+        [ "$FALLBACK_THRESHOLD_MB" -lt 128 ] && FALLBACK_THRESHOLD_MB=128
+        ;;
+    esac
+    echo "pgbackrest-wrapper: WAL_DROP_THRESHOLD_MB='${WAL_DROP_THRESHOLD_MB}' is not a non-negative integer; using the computed default ${FALLBACK_THRESHOLD_MB} MiB instead (bash arithmetic would evaluate it as 0 and drop WAL on any failure; refusing to run would fail every archive_command and fill the disk)" >&2
+    PGWAL_THRESHOLD_MB="$FALLBACK_THRESHOLD_MB"
     ;;
 esac
 PGWAL_THRESHOLD_BYTES=$(( PGWAL_THRESHOLD_MB * 1024 * 1024 ))

--- a/pgbackrest-backup-watcher.sh
+++ b/pgbackrest-backup-watcher.sh
@@ -127,35 +127,46 @@ FULL_RETRY_BACKOFF_SECONDS="${WAL_BACKUP_FULL_RETRY_BACKOFF_SECONDS:-600}"
 # trips and drops segments.
 WAL_LAG_GAP_THRESHOLD_SEGMENTS="${WAL_LAG_GAP_THRESHOLD_SEGMENTS:-32}"
 
+# A malformed numeric knob must never degrade silently: bash arithmetic
+# evaluates non-numeric strings to 0, and 0 here means "periodic fulls
+# disabled" — a typo like 168h would silently stop the weekly full and
+# erode PITR windows. But exiting is worse: there is NO supervisor
+# (wrapper.sh forks a single watcher, no respawn — deliberate, see
+# fork_pgbackrest_backup_watcher), so a refusal at startup silently
+# disables the initial backup, gap recovery, LSN-lag detection, and the
+# WAL heartbeat until the next deploy. WARN loudly and fall back to the
+# knob's documented default instead — the watcher must keep running.
+sanitize_uint() {
+  # $1 = env var name (for the log line), $2 = variable to repair, $3 = default
+  local value="${!2}"
+  case "$value" in
+    ''|*[!0-9]*)
+      echo "pgbackrest-watcher: $1='$value' is not a non-negative integer; using the default ($3) — a bad knob must never stop the watcher" >&2
+      printf -v "$2" '%s' "$3"
+      ;;
+  esac
+}
+sanitize_uint WAL_BACKUP_POLL_INTERVAL_SECONDS POLL_INTERVAL_SECONDS 60
+sanitize_uint WAL_BACKUP_GAP_RECOVERY_BACKOFF_SECONDS GAP_RECOVERY_BACKOFF_SECONDS 600
+sanitize_uint WAL_BACKUP_FULL_INTERVAL_HOURS FULL_INTERVAL_HOURS 168
+sanitize_uint WAL_BACKUP_DIFF_INTERVAL_HOURS DIFF_INTERVAL_HOURS 24
+sanitize_uint WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS CATALOG_VERIFY_INTERVAL_SECONDS 3600
+sanitize_uint WAL_BACKUP_FULL_RETRY_BACKOFF_SECONDS FULL_RETRY_BACKOFF_SECONDS 600
+sanitize_uint WAL_LAG_GAP_THRESHOLD_SEGMENTS WAL_LAG_GAP_THRESHOLD_SEGMENTS 32
+
 # Resolved cadence in seconds. WAL_BACKUP_FULL_INTERVAL_SECONDS overrides
 # the hours setting — bash arithmetic precludes fractional hours, so the
 # e2e harness needs a second-level knob to exercise retention rollover
 # inside a single test cycle. 0 means "no periodic full" (gap-recovery
 # and NEEDS_INITIAL_BACKUP still fire); any positive value sets the
 # cadence. Defaults to FULL_INTERVAL_HOURS * 3600 when unset, preserving
-# existing prod behavior.
+# existing prod behavior. Computed only AFTER the hours knobs are
+# sanitized above — an arithmetic expansion over a malformed hours value
+# would abort the assignment and leave the variable unset under set -u.
 FULL_INTERVAL_SECONDS="${WAL_BACKUP_FULL_INTERVAL_SECONDS:-$((FULL_INTERVAL_HOURS * 3600))}"
 DIFF_INTERVAL_SECONDS="${WAL_BACKUP_DIFF_INTERVAL_SECONDS:-$((DIFF_INTERVAL_HOURS * 3600))}"
-
-# A malformed numeric knob must never degrade silently: bash arithmetic
-# evaluates non-numeric strings to 0, and 0 here means "periodic fulls
-# disabled" — a typo like 168h would silently stop the weekly full and
-# erode PITR windows. Refuse to run with it; the supervisor restarts the
-# watcher and the log line is unmissable.
-require_uint() {
-  # $1 = env var name, $2 = resolved value
-  case "$2" in
-    ''|*[!0-9]*)
-      echo "pgbackrest-watcher: $1='$2' is not a non-negative integer; refusing to run (bash would evaluate it as 0)" >&2
-      exit 1
-      ;;
-  esac
-}
-require_uint WAL_BACKUP_FULL_INTERVAL_HOURS "$FULL_INTERVAL_HOURS"
-require_uint WAL_BACKUP_DIFF_INTERVAL_HOURS "$DIFF_INTERVAL_HOURS"
-require_uint WAL_BACKUP_FULL_INTERVAL_SECONDS "$FULL_INTERVAL_SECONDS"
-require_uint WAL_BACKUP_DIFF_INTERVAL_SECONDS "$DIFF_INTERVAL_SECONDS"
-require_uint WAL_BACKUP_CATALOG_VERIFY_INTERVAL_SECONDS "$CATALOG_VERIFY_INTERVAL_SECONDS"
+sanitize_uint WAL_BACKUP_FULL_INTERVAL_SECONDS FULL_INTERVAL_SECONDS "$((FULL_INTERVAL_HOURS * 3600))"
+sanitize_uint WAL_BACKUP_DIFF_INTERVAL_SECONDS DIFF_INTERVAL_SECONDS "$((DIFF_INTERVAL_HOURS * 3600))"
 
 log() { echo "pgbackrest-watcher: $*"; }
 

--- a/pgbackrest-init.sh
+++ b/pgbackrest-init.sh
@@ -53,15 +53,17 @@ mkdir -p "$PGDATA/conf.d"
 chmod 0750 "$PGDATA/conf.d"
 
 archive_timeout="${POSTGRES_ARCHIVE_TIMEOUT:-60}"
-# archive_timeout=0 turns the WAL hand-off off entirely — the RPO bound
-# this knob exists to set. A malformed value must fail the init loudly
-# instead of degrading to whatever bash makes of it.
-case "$archive_timeout" in
-  ''|0|*[!0-9]*)
-    echo "pgbackrest: POSTGRES_ARCHIVE_TIMEOUT='${POSTGRES_ARCHIVE_TIMEOUT}' is not a positive integer; refusing to write an archive config with it" >&2
-    exit 1
-    ;;
-esac
+# Accept everything Postgres itself accepts for this GUC: a bare integer or
+# an integer with a time unit ('5min', '1h', …), including 0 — a legitimate
+# value that turns the forced segment switch off. On anything else WARN and
+# default to 60: exiting here fails the whole initdb under set -e, killing a
+# fresh service over a knob typo — and only on the fresh-init path, since
+# wrapper.sh's existing-DB reapply has no such gate (refused once, accepted
+# on restart is the wrong shape for a validation to have).
+if ! printf '%s' "$archive_timeout" | grep -qE '^[0-9]+(ms|s|min|h|d)?$'; then
+  echo "pgbackrest: POSTGRES_ARCHIVE_TIMEOUT='${POSTGRES_ARCHIVE_TIMEOUT}' is not a valid archive_timeout (integer with optional ms/s/min/h/d unit); using 60" >&2
+  archive_timeout=60
+fi
 # track_commit_timestamp lets pg_last_committed_xact() return the wall-clock
 # time of the last commit. The PITR picker uses that as its upper bound:
 # `recovery_target_time` only matches commit record timestamps, so on an idle

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -888,8 +888,12 @@ finish_swap() {
   # stash_old_config) — the runtime wrapper re-applies the stashed auto.conf
   # itself, one GUC at a time; the stashed reference copies stay at the
   # volume root.
+  # --argjson (not --arg) so stashedAutoConf lands as a real JSON boolean;
+  # STASHED_AUTOCONF only ever holds the literal "true"/"false". Markers
+  # already written with the legacy string form exist on volumes, so every
+  # reader (wrapper.sh) accepts both shapes.
   write_marker "$(jq -nc \
-    --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" --arg old "$(basename "$OLD_KEEP_DIR")" --arg stashed "$STASHED_AUTOCONF" \
+    --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" --arg old "$(basename "$OLD_KEEP_DIR")" --argjson stashed "$STASHED_AUTOCONF" \
     '{phase: "completed", from: $from, to: $to, oldDataDir: $old, stashedAutoConf: $stashed, needsAnalyze: true, needsReindex: true, needsConfigReview: true, completedAt: (now | todate)}')"
   log "upgrade $FROM_MAJOR -> $TO_MAJOR complete"
   result "$(jq -nc --arg from "$FROM_MAJOR" --arg to "$TO_MAJOR" \

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1800,15 +1800,26 @@ fork_post_upgrade_analyze() {
 # ship would pass here and then refuse every subsequent boot or connection,
 # which is the exact disaster class not carrying the file avoids. The image
 # also actively manages shared_preload_libraries itself (pg_stat_statements,
-# see ensure_pg_stat_statements above).
+# see add_pg_stat_statements above).
 # postgresql.conf itself is not re-applied: on this image it is initdb +
 # entrypoint output, not a user surface — its stash stays as reference.
 # One-shot across restarts via the marker's needsConfigReview flag.
-CONFIG_RESTORE_SKIP_GUCS="archive_mode archive_command archive_timeout restore_command recovery_target recovery_target_name recovery_target_time recovery_target_xid recovery_target_lsn recovery_target_inclusive recovery_target_timeline recovery_target_action primary_conninfo primary_slot_name listen_addresses port unix_socket_directories data_directory hba_file ident_file external_pid_file ssl ssl_cert_file ssl_key_file ssl_ca_file ssl_crl_file shared_preload_libraries session_preload_libraries local_preload_libraries dynamic_library_path"
+CONFIG_RESTORE_SKIP_GUCS="archive_mode archive_command archive_timeout archive_library archive_cleanup_command restore_command recovery_end_command recovery_target recovery_target_name recovery_target_time recovery_target_xid recovery_target_lsn recovery_target_inclusive recovery_target_timeline recovery_target_action primary_conninfo primary_slot_name listen_addresses port unix_socket_directories data_directory hba_file ident_file external_pid_file ssl ssl_cert_file ssl_key_file ssl_ca_file ssl_crl_file shared_preload_libraries session_preload_libraries local_preload_libraries dynamic_library_path"
 
 fork_post_upgrade_config_restore() {
   [ -f "$UPGRADE_MARKER_FILE" ] || return 0
   [ "$(jq -r '.needsConfigReview // false' "$UPGRADE_MARKER_FILE" 2>/dev/null)" = "true" ] || return 0
+  # Generation gate: only markers written by the new-generation upgrade job
+  # (the one that stashes auto.conf and records stashedAutoConf) hand their
+  # flags to this fork. A legacy marker's needsConfigReview predates the
+  # self-heal and belongs to the dashboard-driven flow — on such a volume
+  # the stash (when one exists at all) can be months old, and replaying it
+  # would overwrite every ALTER SYSTEM re-tune the user has done since.
+  # Skip AND keep the flag; never retroactively adopt another flow's state.
+  if [ "$(jq 'has("stashedAutoConf")' "$UPGRADE_MARKER_FILE" 2>/dev/null)" != "true" ]; then
+    echo "post-upgrade: legacy upgrade marker (no stashedAutoConf field) — config-restore self-heal skipped; needsConfigReview stays set for the dashboard-driven flow"
+    return 0
+  fi
   local from_major stash
   from_major="$(jq -r '.from // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null)"
   stash="$EXPECTED_VOLUME_MOUNT_PATH/.pre-upgrade-${from_major}-postgresql.auto.conf"
@@ -1817,14 +1828,18 @@ fork_post_upgrade_config_restore() {
     # (stashedAutoConf). Missing-but-expected means the stash copy failed
     # at upgrade time — clearing the flag here would silently drop the
     # user's ALTER SYSTEM tuning; keep the flag and say so instead.
-    expect_stash="$(jq -r '.stashedAutoConf // "absent"' "$UPGRADE_MARKER_FILE" 2>/dev/null)"
+    # Plain `.stashedAutoConf` (never `// absent`): jq's `//` treats a
+    # literal false as absent, and the field is a real boolean on markers
+    # written since the --argjson fix while older volumes still carry the
+    # legacy string form — jq -r renders both as "true"/"false".
+    expect_stash="$(jq -r '.stashedAutoConf' "$UPGRADE_MARKER_FILE" 2>/dev/null)"
     if [ "$expect_stash" = "true" ]; then
       echo "post-upgrade: the upgrade marker expects a stashed postgresql.auto.conf, but $stash is missing; keeping needsConfigReview set — recover the stash (a copy survives in the kept old data dir) or clear the flag manually" >&2
       return 0
     fi
-    # No ALTER SYSTEM settings existed before the upgrade (or a
-    # pre-stashedAutoConf marker with the stash gone): the review is
-    # trivially complete.
+    # No ALTER SYSTEM settings existed before the upgrade (the generation
+    # gate above guarantees the marker carries stashedAutoConf, so a stash
+    # was never written): the review is trivially complete.
     update_upgrade_marker '.needsConfigReview = false' || true
     return 0
   fi
@@ -1842,6 +1857,14 @@ fork_post_upgrade_config_restore() {
           # ALTER SYSTEM verbatim.
           value="$(printf '%s' "$value" | sed 's/^[[:space:]]*//')"
           [ -n "$key" ] || continue
+          # wal_level is special-cased rather than skip-listed: on a
+          # non-archiving image restoring it is harmless, but with archiving
+          # enabled a stashed 'minimal' would refuse the next boot
+          # (archive_mode=on requires wal_level >= replica).
+          if [ "$key" = "wal_level" ] && [ -n "${WAL_ARCHIVE_BUCKET:-}" ]; then
+            echo "post-upgrade:   wal_level: not re-applied (archiving is enabled on this image; a stashed value below 'replica' would refuse the next boot)"
+            skipped=$((skipped + 1)); continue
+          fi
           case " $CONFIG_RESTORE_SKIP_GUCS " in
             *" $key "*)
               echo "post-upgrade:   $key: image-managed, not re-applied"
@@ -1913,6 +1936,27 @@ fork_post_upgrade_config_restore() {
 fork_post_upgrade_reindex() {
   [ -f "$UPGRADE_MARKER_FILE" ] || return 0
   [ "$(jq -r '.needsReindex // false' "$UPGRADE_MARKER_FILE" 2>/dev/null)" = "true" ] || return 0
+  # Generation gate, same as fork_post_upgrade_config_restore: a legacy
+  # marker (no stashedAutoConf field) predates this self-heal, and on those
+  # volumes the flag belongs to the dashboard-driven flow. Worse than mere
+  # ownership: for source >= 15 the old blind fork_collation_refresh already
+  # re-stamped the collation versions on the first post-upgrade boot, so the
+  # detector below would read "collation library unchanged" (false) and
+  # clear the flag with zero rebuilds — permanently masking real staleness.
+  # Skip AND keep the flag.
+  if [ "$(jq 'has("stashedAutoConf")' "$UPGRADE_MARKER_FILE" 2>/dev/null)" != "true" ]; then
+    echo "post-upgrade: legacy upgrade marker (no stashedAutoConf field) — reindex self-heal skipped; needsReindex stays set for the dashboard-driven flow"
+    return 0
+  fi
+  # Operator kill switch: skip every rebuild AND every stamp refresh, keep
+  # the flag (clearing it would declare the indexes healthy), and say so.
+  # Same truthy convention as WAL_HEARTBEAT_DISABLED. While the flag is up
+  # the boot-time blind collation refresh keeps standing down too, so the
+  # staleness evidence survives for whoever the operator hands it to.
+  if [ "${POST_UPGRADE_REINDEX_DISABLED:-0}" = "1" ]; then
+    echo "post-upgrade: reindex skipped by operator request (POST_UPGRADE_REINDEX_DISABLED=1); needsReindex stays set and no version stamps are refreshed"
+    return 0
+  fi
   local rx_from_major rx_baseline_unknown
   rx_from_major="$(jq -r '.from // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null)"
   rx_baseline_unknown=0
@@ -1959,15 +2003,31 @@ fork_post_upgrade_reindex() {
           UNION SELECT c.oid FROM pg_collation c, dflt d
             WHERE c.collname = 'default'
               AND (d.stale OR ($rx_baseline_unknown = 1 AND d.versioned))
+        ), suspect_index_oids AS (
+          -- indcollation covers key columns only; a pg_depend edge is the
+          -- sole record of some collation dependencies (a partial-index
+          -- predicate's COLLATE, an index expression's). Without the union,
+          -- those indexes would be skipped here and the REFRESH VERSION
+          -- step would then stamp their collations current — permanently
+          -- masking the staleness.
+          SELECT i.indexrelid AS oid
+          FROM pg_index i,
+               unnest(string_to_array(i.indcollation::text, ' ')::oid[]) u(collid)
+          WHERE u.collid IN (SELECT oid FROM suspect)
+          UNION
+          SELECT d.objid
+          FROM pg_depend d
+          WHERE d.classid = 'pg_class'::regclass
+            AND d.refclassid = 'pg_collation'::regclass
+            AND d.refobjid IN (SELECT oid FROM suspect)
         )
         SELECT DISTINCT (EXISTS (SELECT 1 FROM pg_constraint x WHERE x.conindid = i.indexrelid AND x.contype = 'x'))::int
                || ' ' || format('%I.%I', n.nspname, c.relname)
-        FROM pg_index i
+        FROM suspect_index_oids s
+        JOIN pg_index i ON i.indexrelid = s.oid
         JOIN pg_class c ON c.oid = i.indexrelid
-        JOIN pg_namespace n ON n.oid = c.relnamespace,
-             unnest(string_to_array(i.indcollation::text, ' ')::oid[]) u(collid)
-        WHERE u.collid IN (SELECT oid FROM suspect)
-          AND c.relkind = 'i'
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind = 'i'
           AND n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema')
           AND n.nspname NOT LIKE 'pg_temp%'
           AND n.nspname NOT LIKE 'pg_toast_temp%'"


### PR DESCRIPTION
Closes the verified findings from the adversarial audit of merge fddfe89 (PR #126). Every fix keeps the audit-era hardening's intent (no silent degradation) while restoring the availability contract: destructive actions stay fail-closed; availability paths WARN and take a safe default instead of exiting.

## P0

- **Cert self-heal restored** (`init-ssl.sh`): the keep-guard from 8dbd637 skipped generation whenever the three cert files existed — but `wrapper.sh` re-runs init-ssl precisely to REPLACE certs that are not x509v3 or expire within 30 days, so both heals had become no-ops (a fleet-wide cert-expiry time bomb). Keep is now keyed on validity: full set present AND `openssl x509 -checkend 2592000` passes AND the same `DNS:localhost` v3/SAN probe wrapper.sh uses — the two scripts can never disagree. Private-hostname SAN and 0600 key perms from 8dbd637 kept.

## P1

- **SSL_CERT_DAYS warn-not-exit** (`init-ssl.sh`): validation ran before the keep-check and `exit 1`'d under wrapper's `set -e` — a latent bad value would crash-loop a healthy DB the day its cert crossed T-30d. Now validated inside the generation branch; malformed → WARN + default 820.
- **WAL_DROP_THRESHOLD_MB warn-not-exit** (`pgbackrest-archive-push-wrapper.sh`): a value like `5g` made every `archive_command` invocation exit 1 forever → Postgres retains WAL → disk fills, with the anti-disk-fill escape hatch disabled. Malformed → loud log + fall back to the same volume-proportional threshold `compute_volume_thresholds` would export absent the override (min(5 GiB, ~50% of volume), floor 128 MiB). 63a0c42's async `.error`-file grep widening untouched.
- **Watcher knobs warn-not-exit** (`pgbackrest-backup-watcher.sh`): fa1d9ab's `require_uint` exited at startup, but there is no supervisor (single fork, no respawn — deliberate), so one typo silently disabled initial backup, gap recovery, LSN-lag detection, and the WAL heartbeat. Per-knob WARN + documented default, extended to the knobs the commit skipped (`POLL_INTERVAL_SECONDS`, `GAP_RECOVERY_BACKOFF_SECONDS`, `FULL_RETRY_BACKOFF_SECONDS`, `WAL_LAG_GAP_THRESHOLD_SEGMENTS`); hours-derived `*_SECONDS` computed only after the hours knobs are sanitized (a malformed value would abort the arithmetic and trip `set -u`).
- **archive_timeout accepts GUC syntax** (`pgbackrest-init.sh`): f620e37 refused `5min`/`1h` (valid, previously working) and `0` (legitimate), and only on the fresh-init path — refused once, accepted on restart. Now accepts `^[0-9]+(ms|s|min|h|d)?$` including 0; anything else WARNs + defaults to 60, never failing initdb. f620e37's atomic marker publish and pg_controldata fail-loud kept.
- **Generation-gated self-heal** (`wrapper.sh` + `upgrade-job.sh`): the config-restore and reindex forks fired on ANY volume with the flags set — including pre-merge upgrades, where replaying a months-old auto.conf stash overwrites user re-tuning, and where (source ≥15) the old blind collation refresh already destroyed the staleness evidence so the detector would falsely clear the flag. Both forks now require the marker to carry `stashedAutoConf` (written only by the new-generation job); on a legacy marker they log the skip and keep the flags for the dashboard-driven flow.

## P2

- **pg_depend suspects** (`wrapper.sh`): suspect-index enumeration used `pg_index.indcollation` only, missing indexes whose sole collation dependency is a pg_depend edge (e.g. a partial-index predicate's `COLLATE`) — REFRESH VERSION then stamped them current, permanently masking staleness. Union in indexes reachable via pg_depend (classid `pg_class`, refclassid `pg_collation`), deduped; all existing exclusions kept. Verified against PG17: the old query missed a predicate-only partial index the new one catches.
- **Reindex kill switch** (`wrapper.sh`, README): `POST_UPGRADE_REINDEX_DISABLED=1` skips every rebuild and stamp refresh, keeps `needsReindex`, logs the operator opt-out. Default unchanged.
- **CONFIG_RESTORE_SKIP_GUCS** (`wrapper.sh`): adds `archive_library`, `recovery_end_command`, `archive_cleanup_command`; `wal_level` special-cased — never restored when archiving is enabled (a stashed `minimal` onto an archiving cluster refuses the next boot), restored normally otherwise.
- **Coherence** (`upgrade-job.sh`, `wrapper.sh`, README): `stashedAutoConf` written as a real boolean (`--argjson`), reader accepts both the boolean and the legacy string form already on volumes; skip-GUC comment names `add_pg_stat_statements` (the cited `ensure_pg_stat_statements` never existed); README restores the deleted caveat that markerless image rebuilds still blind-refresh collation stamps without rebuilding, and scopes the no-operator-in-the-loop claim to the standalone image (HA members boot a different image without these forks).

## Validation

- `bash -n` on all six modified scripts; shellcheck delta vs `origin/main` is empty (zero new warnings).
- FIX 7 SQL run against a live PG17 container: new query returns the predicate-only partial index the old query missed, no duplicates.
- init-ssl keep/regenerate decision matrix exercised with real openssl certs (valid+SAN → keep; expiring, SAN-less, incomplete, absent → regenerate).
- Watcher/archive-push/init warn+default paths smoke-tested with garbage knobs (all warn and continue; exit 0 where required).
- The three self-heal e2e tests (`t_config_restore_self_heals`, `t_config_restore_all_rejected`, `t_reindex_self_heals`) build their markers via the upgrade job, which writes `stashedAutoConf` — the generation gate does not affect them; no test constructs a legacy-shaped marker with the self-heal flags. Full e2e runs in CI on this PR.
