### PR TITLE
fix(upgrade-job): route non-numeric df output through the documented warn+proceed path

### DIFF
--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -625,10 +625,15 @@ run_pg_upgrade() {
 check_free_space() {
   local avail_kb avail_mb
   avail_kb=$(df -Pk "$VOLUME_ROOT" 2>/dev/null | awk 'NR==2 {print $4}')
-  if [ -z "${avail_kb:-}" ]; then
-    log "could not read free space on $VOLUME_ROOT; continuing without the free-space check"
-    return 0
-  fi
+  # Non-numeric garbage must take the same documented warn+proceed path as an
+  # empty read: without this, alpha output dies with a misleading "0 MiB free"
+  # and digit-prefixed garbage aborts the whole job through set -u.
+  case "${avail_kb:-}" in
+    ''|*[!0-9]*)
+      log "could not read free space on $VOLUME_ROOT (df returned '${avail_kb:-}'); continuing without the free-space check"
+      return 0
+      ;;
+  esac
   avail_mb=$(( avail_kb / 1024 ))
   if [ "$avail_mb" -lt "$UPGRADE_MIN_FREE_MB" ]; then
     die 2 "only ${avail_mb} MiB free on the volume (need at least ${UPGRADE_MIN_FREE_MB} MiB for the new cluster's catalogs and pg_upgrade's work files) — free up space or grow the volume, then re-run (override with UPGRADE_MIN_FREE_MB)"


### PR DESCRIPTION
One latent bug in `check_free_space` (from #124): the unreadable-df arm — deliberately warn+proceed, since `check_mount`, the job flock, and `probe_sibling_slot` already proved the volume — only matched EMPTY output. Non-numeric df output instead failed closed ungracefully: alpha garbage evaluated as a variable name → `die` with a misleading "only 0 MiB free"; digit-prefixed garbage → arithmetic error + `set -u` abort of the whole job. A `case` numeric guard now routes any unparseable value through the same documented warn+proceed path, with the raw value in the log line.

Verified posture call (Pass-3 audit, SP3-1): proceed-on-unreadable stays — blocking a fenced, recoverable, user-initiated upgrade on a df quirk is the wrong trade; an ENOSPC mid-upgrade is exactly what recover mode (#122) exists to clean up.