### PR TITLE
fix(init-ssl): recover from a torn serial file when regenerating; sync certs to disk

### DIFF
--- a/init-ssl.sh
+++ b/init-ssl.sh
@@ -85,9 +85,22 @@ keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
 subjectAltName = ${SSL_SAN}
 EOF
 
+# -CAcreateserial only CREATES the serial file when absent — a present-but-torn
+# root.srl (e.g. a volume restored from a snapshot that caught a cert write
+# before it synced; 2026-08-22: a rehearsal copy crash-looped on
+# "Unable to load number from .../root.srl ... a2i_ASN1_INTEGER:short line")
+# makes openssl fail and, under set -e, kills the whole boot. Everything is
+# being re-signed anyway, so a fresh serial is always correct here.
+rm -f "$SSL_DIR/root.srl"
 openssl x509 -req -in "$SSL_SERVER_CSR" -extfile "$SSL_V3_EXT" -extensions v3_req -text -days "$SSL_CERT_DAYS_VALUE" -CA "$SSL_ROOT_CRT" -CAkey "$SSL_ROOT_KEY" -CAcreateserial -out "$SSL_SERVER_CRT"
 
 chown postgres:postgres "$SSL_SERVER_CRT"
+
+# Flush the freshly written certs to disk: a snapshot taken moments after this
+# boot (upgrade rehearsals snapshot the live volume; users take backups) must
+# capture a complete certs/ dir, not the torn state this block just learned to
+# recover from.
+sync "$SSL_DIR"/* "$SSL_DIR" 2>/dev/null || sync
 
 fi
 


### PR DESCRIPTION
Product half of today's rehearsal failure (backboard half: railwayapp/mono#36328).

**What happened:** the rehearsal snapshot captured `certs/` before the source's first cert write synced. On the copy, #128's validity guard correctly detected the unreadable `server.crt` and regenerated — but `-CAcreateserial` only creates `root.srl` when ABSENT; the torn one made openssl exit 1 (`Unable to load number from .../root.srl ... a2i_ASN1_INTEGER:short line`), `set -e` killed the boot, and the copy crash-looped silently (verified in the copy's deploy logs, 2 boots then restart-policy stop).

**Fix:**
- `rm -f root.srl` before signing — everything on this path is re-signed anyway, a fresh serial is always correct. Reproduced locally: torn srl → exit 1; after `rm -f` → exit 0.
- `sync` the certs dir after generation so a snapshot moments after boot captures complete certs instead of reproducing the torn state.

Any restored backup/rehearsal volume with torn certs now self-heals through the regeneration path end-to-end.