### PR TITLE
fix(pitr): keep the replaying fork unreadable until it promotes

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -269,12 +269,14 @@ wait_for_pg() {
 }
 
 # Wait for the cluster to finish recovery and promote (i.e.
-# pg_is_in_recovery() returns 'f'). pg_isready / wait_for_pg returns true
-# during archive recovery — postgres accepts read-only connections before
-# the promote completes — which can let restart-mid-flight tests rip the
-# container before recovery flushes recovery.signal. Use this helper after
-# wait_for_pg in tests that depend on the cluster being fully promoted
-# (e.g. a second boot must NOT re-stage recovery).
+# pg_is_in_recovery() returns 'f'). On PITR replay paths the image stages
+# hot_standby=off, so pg_isready / wait_for_pg now fails until the promote
+# ("the database system is starting up") and implicitly waits it out — but
+# keep using this helper after wait_for_pg in tests that depend on the
+# cluster being fully promoted (e.g. a second boot must NOT re-stage
+# recovery): it asserts the promoted state EXPLICITLY, covers recovery
+# paths that don't stage hot_standby=off (crash recovery, standby.signal),
+# and doesn't depend on the staging being in place.
 wait_for_promoted() {
   local container="$1" deadline=$(($(date +%s) + 120))
   while [ "$(date +%s)" -lt "$deadline" ]; do
@@ -1951,6 +1953,18 @@ t_empty_volume_restore_from_s3() {
   fi
   if docker exec "$rest_name" test -f /var/lib/postgresql/data/.pitr_staging; then
     ko t_empty_volume_restore_from_s3 ".pitr_staging must not be written on the empty-volume restore path"
+    return
+  fi
+
+  # The replay-window guard must have been staged: `pgbackrest restore`
+  # leaves hot_standby at its default (on), which would let clients read
+  # the base-backup state mid-replay. The wrapper stages hot_standby=off in
+  # its own conf.d file; it survives until the next boot's
+  # configure_pgbackrest_recovery sees recovery genuinely done (removal is
+  # covered by t_restored_marker_persists_across_restarts).
+  if ! docker exec "$rest_name" test -f /var/lib/postgresql/data/conf.d/pgbackrest-restore-hot-standby.conf; then
+    ko t_empty_volume_restore_from_s3 "conf.d/pgbackrest-restore-hot-standby.conf missing — replaying fork would be readable at the base-backup state"
+    fail_dump t_empty_volume_restore_from_s3 "$rest_name"
     return
   fi
 
@@ -3729,6 +3743,16 @@ t_restored_marker_persists_across_restarts() {
     fail_dump t_restored_marker_persists_across_restarts "$rest_name"
     return
   fi
+  # The replay-window hot_standby=off staging must not survive promotion:
+  # configure_pgbackrest_recovery removes it on the first boot that finds
+  # recovery genuinely done. Leaving it behind is harmless to a promoted
+  # primary (hot_standby is only consulted during recovery) but would leak
+  # replay-scoped config into the service's steady-state conf.d.
+  if docker exec "$rest_name" test -f /var/lib/postgresql/data/conf.d/pgbackrest-restore-hot-standby.conf; then
+    ko t_restored_marker_persists_across_restarts "conf.d/pgbackrest-restore-hot-standby.conf survived the post-promote boot"
+    fail_dump t_restored_marker_persists_across_restarts "$rest_name"
+    return
+  fi
 
   ok t_restored_marker_persists_across_restarts
   note ".pgbackrest_restored survived restart; configure_pgbackrest_recovery deferred"
@@ -3753,8 +3777,10 @@ t_restored_marker_persists_across_restarts() {
 # enough of a replay window to reliably catch mid-flight. This test builds
 # its own source with a bulk insert between the base backup and the target
 # so recovery has real, measurable replay work, then force-kills the
-# restore as soon as it accepts connections (wait_for_pg returns true
-# during recovery, before promote) rather than racing a fixed sleep.
+# restore as soon as its restore_command starts fetching WAL (archive-get
+# traffic in docker logs) rather than racing a fixed sleep — the replaying
+# fork stages hot_standby=off, so it accepts no connections until promote
+# and readiness probes can't serve as the mid-replay signal.
 t_recovery_conf_persists_across_restart_mid_replay() {
   local src_name=t-src-heavy-${PG_VERSION}
   local src_vol=${src_name}-vol
@@ -3852,20 +3878,27 @@ t_recovery_conf_persists_across_restart_mid_replay() {
     -v "$rest_vol:/var/lib/postgresql/data" \
     "$IMAGE" >/dev/null
 
-  # Tight-poll pg_isready and kill the instant it succeeds — wait_for_pg
-  # returns true during recovery, before promote, so this catches the
-  # restore genuinely mid-replay instead of racing a fixed sleep against
-  # an unknown promote time.
+  # Catch the restore genuinely mid-replay via pgbackrest's archive-get
+  # traffic: restore_command only starts fetching WAL once the postmaster
+  # is up and replaying, and the lines land in docker logs on every major
+  # (postgres's own server LOG lines don't, on all of them). This used to
+  # tight-poll pg_isready — that only worked because hot_standby defaulted
+  # on and postgres accepted read-only connections mid-replay; the image
+  # now stages hot_standby=off for the whole replay (clients get "the
+  # database system is starting up" until promote), so pg_isready fails by
+  # design until recovery finishes, exactly what the mid-replay read-race
+  # fix wants. Also a wider catch window: archive-get begins at redo start,
+  # not at consistent-state.
   local caught=0 i
   for i in $(seq 1 600); do
-    if docker exec "$rest_name" pg_isready -U postgres -q 2>/dev/null; then
+    if docker logs "$rest_name" 2>&1 | grep -q "archive-get command begin"; then
       caught=1
       break
     fi
     local status
     status=$(docker inspect -f '{{.State.Status}}' "$rest_name" 2>/dev/null || echo "")
     if [ "$status" = "exited" ]; then
-      ko t_recovery_conf_persists_across_restart_mid_replay "1st boot exited before becoming ready"
+      ko t_recovery_conf_persists_across_restart_mid_replay "1st boot exited before starting replay"
       fail_dump t_recovery_conf_persists_across_restart_mid_replay "$rest_name"
       docker rm -f "$src_name" "$rest_name" >/dev/null; docker volume rm "$src_vol" "$rest_vol" >/dev/null
       return
@@ -3873,7 +3906,7 @@ t_recovery_conf_persists_across_restart_mid_replay() {
     sleep 0.2
   done
   if [ "$caught" -ne 1 ]; then
-    ko t_recovery_conf_persists_across_restart_mid_replay "1st boot never became ready"
+    ko t_recovery_conf_persists_across_restart_mid_replay "1st boot never started replaying (no archive-get traffic)"
     fail_dump t_recovery_conf_persists_across_restart_mid_replay "$rest_name"
     docker rm -f "$src_name" "$rest_name" >/dev/null; docker volume rm "$src_vol" "$rest_vol" >/dev/null
     return

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -461,6 +461,15 @@ PGBACKREST_RECOVERY_S3_CONF="/etc/pgbackrest/pgbackrest-recovery-source.conf"
 PGBACKREST_CONFD_DIR="$PGDATA/conf.d"
 PGBACKREST_ARCHIVE_CONF="$PGBACKREST_CONFD_DIR/pgbackrest.conf"
 PGBACKREST_RECOVERY_CONF="$PGBACKREST_CONFD_DIR/pgbackrest-recovery.conf"
+# Companion to the empty-volume restore path: `pgbackrest restore` writes the
+# recovery params into postgresql.auto.conf itself (so the conf.d recovery
+# file above is never staged on that path), but it does NOT turn hot_standby
+# off — leaving the replaying fork readable at the base-backup state before
+# redo reaches the target. This one-line conf.d file closes that window; it
+# is removed by configure_pgbackrest_recovery once recovery is genuinely done
+# (post-promote), and by clear_pgbackrest_state_if_disabled when the recovery
+# role is dropped.
+PGBACKREST_RESTORE_STANDBY_CONF="$PGBACKREST_CONFD_DIR/pgbackrest-restore-hot-standby.conf"
 PGBACKREST_SPOOL_DIR="$PGDATA/pgbackrest-spool"
 
 # PITR staging stamps. .pitr_staging is written when a replay is handed off
@@ -1168,6 +1177,7 @@ clear_pgbackrest_state_if_disabled() {
     [ -f "$PITR_STAGING_FILE" ] && rm -f "$PITR_STAGING_FILE" && removed=1
     [ -f "$PITR_DONE_MARKER" ] && rm -f "$PITR_DONE_MARKER" && removed=1
     [ -f "$PGBACKREST_RESTORED_MARKER" ] && rm -f "$PGBACKREST_RESTORED_MARKER" && removed=1
+    [ -f "$PGBACKREST_RESTORE_STANDBY_CONF" ] && rm -f "$PGBACKREST_RESTORE_STANDBY_CONF" && removed=1
   fi
   if [ -z "${WAL_ARCHIVE_BUCKET:-}" ] && [ -z "${WAL_RECOVER_FROM_BUCKET:-}" ]; then
     [ -f "$PGBACKREST_CONF_FILE" ] && rm -f "$PGBACKREST_CONF_FILE" && removed=1
@@ -1348,6 +1358,14 @@ pg1-port=5432
 EOF
     chown postgres:postgres "$PGBACKREST_RECOVERY_S3_CONF"
     chmod 0640 "$PGBACKREST_RECOVERY_S3_CONF"
+  else
+    # Recovery genuinely finished (promoted): drop the empty-volume restore
+    # path's hot_standby=off staging so the setting cannot outlive the
+    # replay it protected. Readability itself already returned at promote —
+    # hot_standby is only consulted during recovery — this just keeps the
+    # conf.d of a promoted service clean, mirroring the staging path's
+    # deletion of $PGBACKREST_RECOVERY_CONF below.
+    rm -f "$PGBACKREST_RESTORE_STANDBY_CONF" 2>/dev/null || true
   fi
 
   # Recovery already done on this volume, OR the conf.d write below would
@@ -1398,10 +1416,22 @@ EOF
     local escaped_target="${POSTGRES_RECOVERY_TARGET_TIME//\'/\'\'}"
     recovery_param="recovery_target_time = '${escaped_target}'"
   fi
+  # hot_standby = off keeps the replaying fork unreadable until it promotes.
+  # With the default (on), postgres starts accepting READ-ONLY connections
+  # the moment it reaches consistency — which is the BASE-BACKUP state —
+  # while redo keeps replaying toward the recovery target. A client
+  # connecting in that window reads pre-restore-point data (tables created
+  # after the base backup "do not exist") even though the restore is sound
+  # and completes moments later; on a genuinely unreachable target, every
+  # crash-loop cycle re-opens the same pre-target read window before its
+  # FATAL. With hot_standby off, clients get "the database system is
+  # starting up" until the promote — and this whole file is deleted by the
+  # post-promote cleanup above, so the setting never outlives recovery.
   cat > "$PGBACKREST_RECOVERY_CONF" <<EOF
 restore_command = '${escaped_restore}'
 ${recovery_param}
 recovery_target_action = 'promote'
+hot_standby = off
 EOF
   chown postgres:postgres "$PGBACKREST_RECOVERY_CONF"
   chmod 0640 "$PGBACKREST_RECOVERY_CONF"
@@ -1534,6 +1564,28 @@ EOF
     echo "pgbackrest: restore from source bucket failed; fix env vars (WAL_RECOVER_FROM_*, POSTGRES_RECOVERY_TARGET_TIME, POSTGRES_RECOVERY_TARGET_XID) and redeploy" >&2
     exit 1
   fi
+
+  # Keep the fork unreadable while it replays toward the target — same read
+  # race as the conf.d staging path (see configure_pgbackrest_recovery's
+  # hot_standby note): `pgbackrest restore` writes the recovery params into
+  # postgresql.auto.conf but leaves hot_standby at its default (on), so
+  # postgres would accept read-only connections at the base-backup state
+  # while redo is still replaying to the target. Staged as a one-line conf.d
+  # file AFTER the restore succeeds (writing into PGDATA any earlier makes
+  # pgbackrest see a non-empty data dir and abort) and BEFORE the restored
+  # marker below: a crash between the two lands on the externally-restored
+  # path next boot, where configure_pgbackrest_recovery stages hot_standby
+  # off itself. configure_pgbackrest_recovery removes this file once
+  # recovery is genuinely done, so readability returns exactly at promote
+  # (hot_standby is only consulted during recovery) and the setting never
+  # survives a post-promote boot.
+  ensure_pg_includes_confd
+  install -d -m 0750 -o postgres -g postgres "$PGBACKREST_CONFD_DIR"
+  cat > "$PGBACKREST_RESTORE_STANDBY_CONF" <<EOF
+hot_standby = off
+EOF
+  chown postgres:postgres "$PGBACKREST_RESTORE_STANDBY_CONF"
+  chmod 0640 "$PGBACKREST_RESTORE_STANDBY_CONF"
 
   touch "$PGBACKREST_RESTORED_MARKER"
   chown postgres:postgres "$PGBACKREST_RESTORED_MARKER" 2>/dev/null || true


### PR DESCRIPTION
## The read race

During a PITR restore, postgres reaches consistency at the **base-backup state** and — `hot_standby` defaulting on — immediately starts accepting read-only connections **while redo is still replaying toward the recovery target**. Verified on the real images (PG17 and PG18, faithful env contract, MinIO):

```
23:16:55.515 consistent recovery state reached at 0/2000158
23:16:55.515 database system is ready to accept read-only connections   <-- BASE-BACKUP state
23:17:09.644 redo done                                                  (14.3 s later)
23:17:11.396 database system is ready to accept connections             (promote)
```

A client connecting in that window reads pre-restore-point state — `relation "pitrtest" does not exist` for tables created after the base backup — even though the restore is sound and completes seconds later. On local MinIO the window is seconds; on prod object storage it is tens of seconds. This is exactly what the prod `writeLoad` e2e hit on 2026-08-22 (first successful connect + `relation does not exist` in the same second; the restore itself was correctly staged and would have completed with all data).

**The crash-loop case leaks reads too**: on a genuinely unreachable target, every restart cycle replays, opens the same read-only window at an early-replay state, and only then FATALs `recovery ended before configured recovery target was reached`. Even the loud failure mode intermittently serves pre-target reads.

## Fix

Stage `hot_standby = off` for exactly the replay window, on both restore paths:

- **conf.d staging path** (`configure_pgbackrest_recovery`): the line is added to `conf.d/pgbackrest-recovery.conf`. The existing post-promote cleanup already deletes that file, so nothing outlives recovery.
- **empty-volume restore path** (`restore_from_pgbackrest_if_empty_volume`): `pgbackrest restore` writes the recovery params itself but leaves `hot_standby` on, so the wrapper stages a one-line `conf.d/pgbackrest-restore-hot-standby.conf` after a successful restore (staged after the restore — writing into PGDATA earlier makes pgbackrest abort on a non-empty data dir — and before the restored marker, so a crash between the two converges on the conf.d staging path next boot). `configure_pgbackrest_recovery` removes it on the first boot that finds recovery genuinely done; `clear_pgbackrest_state_if_disabled` removes it when the recovery role is dropped.

Clients now get `FATAL: the database system is starting up` until the promote. Readability returns **exactly at promote**: `hot_standby` is only consulted during recovery, and the staged files never survive a post-promote boot.

## No consumer needs mid-replay reads (verified)

- No Dockerfile has a `HEALTHCHECK`, and Railway deployment readiness does not gate on postgres accepting connections (prod evidence: deployment SUCCESS while replay was still running). The unreadable window is strictly an extension of the one `pgbackrest restore` itself already creates before postgres even starts.
- The backup watcher skips iterations while `pg_isready` fails, and self-heals a missing stanza (backup exit 55 → `stanza-create` → retry), so nothing is lost even when replay outlasts the stanza bootstrap poller's 600s deadline. (Pre-fix, a >600s replay had stanza-create failing in its retry loop against a cluster in recovery anyway — pgBackRest requires a primary.)
- The collation-refresh fork's mid-replay refresh was already a no-op (read-only transaction); it now just waits, and retries on a later boot if it times out.

## e2e

- `t_recovery_conf_persists_across_restart_mid_replay` used `pg_isready` succeeding during recovery as its mid-replay catch — removed **by design** by this fix. It now catches replay via pgbackrest `archive-get` traffic in docker logs (version-independent — postgres server LOG lines don't reach docker logs on every major — and a wider window: archive-get begins at redo start, not at consistent-state).
- `t_empty_volume_restore_from_s3` asserts the staging file exists on the restored fork; `t_restored_marker_persists_across_restarts` asserts it does not survive the post-promote boot.
- `wait_for_pg` (pg_isready) now implicitly waits out replay on PITR paths; `wait_for_promoted` stays as the explicit gate (and covers recovery paths that don't stage `hot_standby=off`).

Run locally (PG17): `t_empty_volume_restore_from_s3`, `t_pitr_happy_path`, `t_restored_marker_persists_across_restarts`, `t_recovery_conf_persists_across_restart_mid_replay`, `t_pitr_missing_wal_segment_fatals` — 5/5 pass, and the run log contains zero `ready to accept read-only connections` lines. A second local batch of the remaining PITR-family tests was kicked off; PR CI runs the full matrix either way.

## Notes

- One residual sharp edge, unchanged in kind: a fork of a **just-promoted** primary cloned before its next boot could carry the staged conf.d file — but that clone already carries the far more dangerous `restore_command` + `recovery_target_*` from the same file, so this adds no new exposure class (and Patroni-managed replicas enforce their own `hot_standby=on` after the include).
- Harness-side companion: the test-postgres-pitr harness now waits for `pg_is_in_recovery() = false` before asserting, tolerating both the old (hot-standby reads) and new ("starting up") window shapes — see the companion PR referenced in the comments below.

Repro evidence: prod Datadog trace `6a89e5af0000000070ce4d4764beb01c` (writeLoad, 2026-08-22 18:03Z), local variants A–E on `postgres-ssl:17`/`:18`.
