### PR TITLE
feat(upgrade-job): persist HA reseed markers on stopped volumes

### DIFF
--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -1957,6 +1957,59 @@ t_railway_env_without_mode_var_refused() {
   assert_eq "$(volume_data_major "$vol")" "$FROM_VERSION" "volume untouched — did not silently upgrade" || return 1
 }
 
+# A stopped HA replica has no container to exec into. The one-shot job mounts
+# that volume directly and must durably arm the reverse (TO -> FROM) reseed
+# before mono repins it to the old major.
+t_reseed_marker_on_stopped_reverse_replica() {
+  local vol="upg-e2e-reseed-reverse"
+  fresh_volume "$vol" || return 1
+  run_pg reseed-source "$vol" "$TO_IMAGE" || return 1
+  wait_for_pg reseed-source || return 1
+  stop_pg reseed-source
+
+  run_job "$vol" reseed-marker \
+    -e "RESEED_MARKER_FROM=$TO_VERSION" \
+    -e "RESEED_MARKER_TO=$FROM_VERSION"
+  assert_eq "$JOB_RC" "0" "marker job succeeds without a live database container" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_eq "$(marker_field "$vol" phase)" "reseed" "reseed phase persisted" || return 1
+  assert_eq "$(marker_field "$vol" from)" "$TO_VERSION" "reverse source major persisted" || return 1
+  assert_eq "$(marker_field "$vol" to)" "$FROM_VERSION" "reverse target major persisted" || return 1
+
+  # Idempotent retry re-fsyncs the identical marker and still succeeds.
+  run_job "$vol" reseed-marker \
+    -e "RESEED_MARKER_FROM=$TO_VERSION" \
+    -e "RESEED_MARKER_TO=$FROM_VERSION"
+  assert_eq "$JOB_RC" "0" "identical marker retry succeeds" || return 1
+}
+
+t_reseed_marker_never_arms_target_major() {
+  local vol="upg-e2e-reseed-target"
+  seed_from_cluster "$vol" || return 1
+
+  run_job "$vol" reseed-marker \
+    -e "RESEED_MARKER_FROM=$TO_VERSION" \
+    -e "RESEED_MARKER_TO=$FROM_VERSION"
+  assert_eq "$JOB_RC" "0" "already-target volume is an idempotent success" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_contains "$JOB_OUT" '"alreadyDone":true' "result proves no wipe was armed" || return 1
+  assert_eq "$(marker_field "$vol" phase)" "" "target-major volume remains unarmed" || return 1
+}
+
+t_reseed_marker_refuses_foreign_inflight_state() {
+  local vol="upg-e2e-reseed-foreign"
+  fresh_volume "$vol" || return 1
+  run_pg reseed-foreign-source "$vol" "$TO_IMAGE" || return 1
+  wait_for_pg reseed-foreign-source || return 1
+  stop_pg reseed-foreign-source
+  in_volume "$vol" "printf '%s' '{\"phase\":\"upgraded\",\"from\":\"16\",\"to\":\"17\"}' > $MARKER_PATH" || return 1
+
+  run_job "$vol" reseed-marker \
+    -e "RESEED_MARKER_FROM=$TO_VERSION" \
+    -e "RESEED_MARKER_TO=$FROM_VERSION"
+  assert_eq "$JOB_RC" "2" "foreign in-flight marker is refused" || { echo "$JOB_OUT" | tail -30; return 1; }
+  assert_contains "$JOB_OUT" "belongs to another volume operation" "refusal names the owner conflict" || return 1
+  assert_eq "$(marker_field "$vol" phase)" "upgraded" "foreign marker remains untouched" || return 1
+}
+
 # ----- runner -----------------------------------------------------------------
 ALL_TESTS=(
   t_vanilla_boot
@@ -2017,6 +2070,9 @@ ALL_TESTS=(
   t_bare_invocation_defaults_to_read_only_mode
   t_upgrade_job_mode_env_var_selects_mode
   t_railway_env_without_mode_var_refused
+  t_reseed_marker_on_stopped_reverse_replica
+  t_reseed_marker_never_arms_target_major
+  t_reseed_marker_refuses_foreign_inflight_state
 )
 
 TESTS=("${@:-}")

--- a/upgrade-job.sh
+++ b/upgrade-job.sh
@@ -29,6 +29,10 @@
 #              the workflow to decide roll-back vs roll-forward on resume.
 #   manifest — print the extensions available on the TARGET major as JSON.
 #              Feeds the dashboard preflight's extension check.
+#   reseed-marker — durably write the HA replica reseed marker without
+#              starting Postgres. RESEED_MARKER_FROM/TO carry the direction,
+#              which may be a downgrade during revert; the dual-binary image
+#              pair itself remains the published ascending pair.
 #   recover  — roll-back ONLY, never redoes the upgrade: return a volume
 #              whose job died BEFORE the commit point (no marker) to a
 #              bootable FROM-major state — reverse pg_upgrade's pg_control
@@ -228,10 +232,10 @@ if [ -z "$MODE" ]; then
   if [ "$#" -gt 0 ]; then
     for _arg in "$@"; do
       case "$_arg" in
-        check | upgrade | status | manifest | recover) MODE="$_arg" ;;
+        check | upgrade | status | manifest | recover | reseed-marker) MODE="$_arg" ;;
       esac
     done
-    [ -n "$MODE" ] || die 2 "no recognized mode among arguments: $* (expected one of: check, upgrade, status, manifest, recover)"
+    [ -n "$MODE" ] || die 2 "no recognized mode among arguments: $* (expected one of: check, upgrade, status, manifest, recover, reseed-marker)"
   fi
 fi
 MODE="${MODE:-upgrade}"
@@ -737,6 +741,52 @@ mode_manifest() {
   exit 0
 }
 
+mode_reseed_marker() {
+  check_mount
+  take_job_lock
+  refuse_unreadable_marker
+
+  local from="${RESEED_MARKER_FROM:-}" to="${RESEED_MARKER_TO:-}"
+  [[ "$from" =~ ^[0-9]+$ ]] || die 2 "RESEED_MARKER_FROM must be a Postgres major"
+  [[ "$to" =~ ^[0-9]+$ ]] || die 2 "RESEED_MARKER_TO must be a Postgres major"
+  [ "$from" != "$to" ] || die 2 "reseed marker source and target majors must differ"
+
+  local major phase marker_from marker_to
+  major="$(data_major)"
+  phase="$(read_marker_field phase)"
+  marker_from="$(read_marker_field from)"
+  marker_to="$(read_marker_field to)"
+
+  # A retry after the replica already reseeded must never arm a fresh wipe on
+  # target-major data. Empty/completed state is already safe. A matching
+  # reseed marker is still in flight and is re-fsynced below; every other
+  # in-flight phase belongs to another operation and must fail closed.
+  if [ "$major" = "$to" ]; then
+    if [ -z "$phase" ] || [ "$phase" = "completed" ]; then
+      result "$(jq -nc --arg from "$from" --arg to "$to" --arg major "$major" \
+        '{ok: true, mode: "reseed-marker", phase: "completed", from: $from, to: $to, dataMajor: $major, alreadyDone: true}')"
+      exit 0
+    fi
+  fi
+  if [ "$major" != "$from" ] \
+    && ! { [ "$phase" = "reseed" ] && [ "$marker_from" = "$from" ] && [ "$marker_to" = "$to" ]; }; then
+    die 2 "volume data major '${major:-missing}' is neither reseed source $from nor a target with its matching in-flight marker"
+  fi
+
+  if [ -n "$phase" ] && [ "$phase" != "completed" ] \
+    && { [ "$phase" != "reseed" ] || [ "$marker_from" != "$from" ] || [ "$marker_to" != "$to" ]; }; then
+    die 2 "marker phase '$phase' (${marker_from:-?} -> ${marker_to:-?}) belongs to another volume operation — refusing to overwrite it"
+  fi
+
+  # Re-write even an identical marker: write_marker fsyncs the temp file, the
+  # renamed file, and the volume root, so success is positive durability proof.
+  write_marker "$(jq -nc --arg from "$from" --arg to "$to" \
+    '{phase: "reseed", from: $from, to: $to}')"
+  result "$(jq -nc --arg from "$from" --arg to "$to" --arg major "$major" \
+    '{ok: true, mode: "reseed-marker", phase: "reseed", from: $from, to: $to, dataMajor: $major}')"
+  exit 0
+}
+
 mode_check() {
   check_mount
   take_job_lock
@@ -1172,5 +1222,6 @@ case "$MODE" in
   status) mode_status ;;
   manifest) mode_manifest ;;
   recover) mode_recover ;;
-  *) die 2 "unknown mode '$MODE' (expected check|upgrade|status|manifest|recover)" ;;
+  reseed-marker) mode_reseed_marker ;;
+  *) die 2 "unknown mode '$MODE' (expected check|upgrade|status|manifest|recover|reseed-marker)" ;;
 esac


### PR DESCRIPTION
## Why

HA major-upgrade revert can reach a replica whose database container is already stopped. An exec-based marker write cannot prove anything about that volume, but repinning without a durable reseed marker makes the target image hit its cross-major boot refusal instead of wiping and cloning safely.

## What changed

- add a read/write-isolated reseed-marker mode to the existing one-shot upgrade image
- carry the actual marker direction in RESEED_MARKER_FROM/TO, independently of the published ascending image pair
- mount the stopped service volume, take the volume lock, atomically write the marker, and fsync the file plus parent directory
- make retries idempotent
- never arm a target-major volume again
- refuse unreadable, foreign, or conflicting in-flight marker state

## Verification

Docker E2E against real Postgres 16/17 volumes:

- stopped reverse replica: pass
- retry/already-target idempotency: pass
- foreign in-flight state remains untouched and is refused: pass

3/3 focused E2Es passing; bash syntax checks passing.
