### PR TITLE
fix: fsync config appends so volume snapshots can't capture torn files

### DIFF
--- a/init-ssl.sh
+++ b/init-ssl.sh
@@ -115,3 +115,9 @@ ssl_ca_file = '$SSL_ROOT_CRT'
 shared_preload_libraries = 'pg_stat_statements'
 EOF
 fi
+# Flush the ssl append to disk. postgresql.conf is parsed at every boot but
+# written only here; nothing else ever fsyncs it. A block-level volume
+# snapshot taken before the page cache flushes the append captures the new
+# file size with zeroed data blocks, and a copy restored from that snapshot
+# fails to boot on the torn file.
+sync "$POSTGRES_CONF_FILE"

--- a/pgbackrest-init.sh
+++ b/pgbackrest-init.sh
@@ -49,6 +49,15 @@ if ! grep -qE "^[[:space:]]*include_dir[[:space:]]*=[[:space:]]*['\"]?conf\.d['\
   echo "include_dir = 'conf.d'" >> "$PGDATA/postgresql.conf"
 fi
 
+# This is the last initdb-era writer of boot-parsed config, so flush the
+# whole volume filesystem here: initdb's sample, the entrypoint's pg_hba
+# append, init-ssl's ssl block, and the include_dir line above are all
+# buffered writes that nothing fsyncs. A block-level volume snapshot taken
+# before the page cache flushes them captures the new file sizes with zeroed
+# data blocks, and a copy restored from that snapshot fails to boot on the
+# torn file ("syntax error ... near token \"\"").
+sync -f "$PGDATA/PG_VERSION"
+
 mkdir -p "$PGDATA/conf.d"
 chmod 0750 "$PGDATA/conf.d"
 

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -340,6 +340,9 @@ ssl_cert_file = '$SSL_DIR/server.crt'
 ssl_key_file = '$SSL_DIR/server.key'
 ssl_ca_file = '$SSL_DIR/root.crt'
 EOF
+  # Flush the append: a block-level volume snapshot taken before writeback
+  # would capture the new size with zeroed data blocks (torn conf on restore).
+  sync "$POSTGRES_CONF_FILE"
 fi
 
 # Re-append the remote-access rule when pg_hba.conf has been reset to
@@ -376,6 +379,8 @@ if [ -f "$POSTGRES_CONF_FILE" ] && [ -f "$PG_HBA_FILE" ] \
 
 host all all all ${POSTGRES_HOST_AUTH_METHOD:-scram-sha-256}
 EOF
+  # Flush the append: same torn-tail-on-snapshot hazard as postgresql.conf.
+  sync "$PG_HBA_FILE"
 fi
 
 # Adds pg_stat_statements to shared_preload_libraries in a config file
@@ -669,6 +674,8 @@ ensure_pg_includes_confd() {
     return 0
   fi
   echo "include_dir = 'conf.d'" >> "$POSTGRES_CONF_FILE"
+  # Flush the append: same torn-tail-on-snapshot hazard as the ssl block.
+  sync "$POSTGRES_CONF_FILE"
   echo "pgbackrest: enabled include_dir 'conf.d' in postgresql.conf"
 }
 


### PR DESCRIPTION
## Problem

`postgresql.conf` and `pg_hba.conf` are parsed at every boot but written only at initdb time (initdb sample, the entrypoint's `pg_hba` remote-access rule, init-ssl's ssl block, pgbackrest's `include_dir`) plus a few rare wrapper heal paths — and none of those writers ever fsync. On a freshly provisioned database the appended tails sit in the page cache with nothing forcing them to disk.

A block-level volume snapshot taken in that window captures the updated file **size** with zeroed **data** blocks. A copy restored from such a snapshot fails to boot:

```
LOG:  syntax error in file ".../postgresql.conf" line 800, near token ""
FATAL: configuration file ".../postgresql.conf" contains errors
grep: .../pg_hba.conf: binary file matches
```

Line 800 is exactly where init-ssl's append begins on a pg14 sample (the base ends at 799). The NUL-tail shape was matched byte-for-byte against the pg14 parser: only a zero-filled tail produces `near token ""`; truncation gives `near end of line` at 799, non-NUL garbage gives `near token "?"`.

The database's own files are immune — Postgres fsyncs them — which is why restored copies always recover cleanly except for these config tails. Observed as upgrade-rehearsal failures where the snapshot fires ~90s after initdb: deterministic on pg14 fixtures (6/6 attempts), intermittent on pg15 (1/2), rare on pg16+.

## Fix

Flush at every append site:

- `99-pgbackrest-init.sh` is the **last initdb-era writer** of boot-parsed config, so one `sync -f` (syncfs) there covers everything written during provisioning — initdb's sample, the entrypoint's pg_hba rule, init-ssl's ssl block, and the include_dir line — in a single call.
- Targeted `sync <file>` in init-ssl's later cert-regeneration path and the wrapper's three heal appends (ssl re-apply, pg_hba re-append, `ensure_pg_includes_confd`), which can also run long after initdb and would otherwise reopen the window.

No behavior change beyond durability; `sync` on a file is a no-op cost at these sizes.