### PR TITLE
Reconcile pg_stat_statements to the image's shipped version at boot

### DIFF
--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1772,6 +1772,74 @@ ENDSQL
   ) &
 }
 
+# Wait for postgres to be ready, then bring pg_stat_statements up to the
+# version this image's binaries ship, in every database that has it
+# installed. The platform owns this extension end to end — the image
+# preloads it via shared_preload_libraries and the dashboard's Stats tab
+# reads its view — but pg_upgrade preserves the extension's SQL-level
+# version, so an upgraded database stays on the OLD version's view/function
+# definitions forever (nothing else ever runs ALTER EXTENSION ... UPDATE).
+# Left alone, the fleet forks into per-major dialects of the same view and
+# the dashboard's single hardcoded query eventually breaks on upgraded
+# databases only. Reconciling at boot heals upgrades and already-lagging
+# volumes alike, one redeploy at a time.
+#
+# Deliberately scoped to pg_stat_statements: user-installed extensions are
+# the user's to update (an update can carry semantics/cost we shouldn't
+# decide for them); the dashboard preflight warns about those instead.
+# For pg_stat_statements the update only redefines views/functions — no
+# table data is touched — so running it idempotently at every boot is safe.
+#
+# Runs only when postgres is writable (skipped in recovery: a PITR restore
+# or standby heals on the boot after promotion instead). Errors are logged
+# and swallowed — a failed extension update must never take the database
+# down with it.
+fork_extension_reconcile() {
+  (
+    local i=0
+    while ! gosu postgres pg_isready -q 2>/dev/null; do
+      sleep 2
+      i=$((i+1))
+      [ $i -ge 60 ] && exit 0
+    done
+
+    if [ "$(gosu postgres psql -qAt -c 'SELECT pg_is_in_recovery()' 2>/dev/null)" != "f" ]; then
+      echo "extension-reconcile: postgres is in recovery; skipping (heals on the boot after promotion)"
+      exit 0
+    fi
+
+    local dbs
+    dbs=$(gosu postgres psql -qAt -c "SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate" 2>/dev/null) || exit 0
+
+    while IFS= read -r db; do
+      [ -z "$db" ] && continue
+      gosu postgres psql -v ON_ERROR_STOP=0 -qAt -d "$db" 2>&1 << 'ENDSQL' | while IFS= read -r line; do [ -n "$line" ] && echo "extension-reconcile: [$db] $line"; done
+DO $body$
+DECLARE
+  installed text;
+  available text;
+BEGIN
+  SELECT e.extversion, ae.default_version INTO installed, available
+  FROM pg_catalog.pg_extension e
+  JOIN pg_catalog.pg_available_extensions ae ON ae.name = e.extname
+  WHERE e.extname = 'pg_stat_statements';
+  IF installed IS NOT NULL AND available IS NOT NULL AND installed <> available THEN
+    BEGIN
+      EXECUTE 'ALTER EXTENSION pg_stat_statements UPDATE';
+      RAISE NOTICE 'pg_stat_statements updated % -> %', installed, available;
+    EXCEPTION WHEN OTHERS THEN
+      -- No upgrade path from a very old version, or a concurrent DDL lock:
+      -- surface it in the logs and leave the extension as it was.
+      RAISE WARNING 'pg_stat_statements update % -> % failed: %', installed, available, SQLERRM;
+    END;
+  END IF;
+END
+$body$;
+ENDSQL
+    done <<< "$dbs"
+  ) &
+}
+
 compute_volume_thresholds
 # Inject the computed pg_wal drop threshold into the env that postgres (and
 # its archive_command wrapper) inherits, unless the operator pinned it. The
@@ -2342,6 +2410,7 @@ fork_old_datadir_reclaim() {
 bootstrap_pgbackrest_stanza
 fork_pgbackrest_backup_watcher
 fork_collation_refresh
+fork_extension_reconcile
 fork_post_upgrade_analyze
 fork_post_upgrade_config_restore
 fork_post_upgrade_reindex


### PR DESCRIPTION
## Problem

`pg_upgrade` preserves an extension's SQL-level version, and nothing in the image or the upgrade job ever runs `ALTER EXTENSION ... UPDATE` afterwards. So a database major-upgraded through the dashboard keeps `pg_stat_statements` at whatever its original major shipped (e.g. 1.10 on a cluster now running 18), forever — the dashboard preflight re-surfaces the same 'Run ALTER EXTENSION … UPDATE' warning on every subsequent upgrade with no instruction and no self-heal, and the fleet forks into per-major dialects of the same view. The dashboard's Stats tab owns this extension (the image preloads it via `shared_preload_libraries`; the dashboard installs and queries it) and has one hardcoded query for the whole fleet: the first time it needs a column upstream added or renamed (as upstream did in 1.11), it breaks on upgraded databases only, silently.

Found during a production UX battery of the HA major-upgrade flow: after 16→17→18, the cluster serves 18.6 with `pg_stat_statements` still at 1.10.

## Fix

A `fork_extension_reconcile` boot one-shot, same shape as `fork_collation_refresh`: wait for `pg_isready`, skip while in recovery (a restore/standby heals on the boot after promotion), then for every connectable database bring `pg_stat_statements` up to the image's `default_version` when it lags. Errors are logged and swallowed — an extension update failure must never take the database down.

**Deliberately scoped to `pg_stat_statements` only.** User-installed extensions are the user's to update (updates can carry semantics/cost that aren't ours to decide); the dashboard preflight continues to warn about those. For `pg_stat_statements` the update only redefines views/functions — no table data — so an idempotent per-boot run is safe.

This heals both future major upgrades and the already-lagging fleet, one natural redeploy at a time (no fleet campaign needed).

## Validation (live, postgres-ssl:17 + this wrapper)

- `CREATE EXTENSION pg_stat_statements VERSION '1.9'` → restart → `extversion` = **1.11** with log `extension-reconcile: [postgres] NOTICE: pg_stat_statements updated 1.9 -> 1.11` (proves the chained multi-hop script path).
- Second restart: silent no-op, version stays 1.11.
- Fresh-init boot with the extension absent: no-op, no log noise.
- `bash -n` clean; the single shellcheck warning in the file predates this change.

Companion PR on postgres-patroni brings the same reconcile to HA clusters (primary-only; replicas receive it via WAL).