### PR TITLE
Pin the pgvector package version in every major's image

### DIFF
--- a/Dockerfile.13
+++ b/Dockerfile.13
@@ -7,9 +7,13 @@ FROM postgres:${POSTGRES_VERSION}
 # next rebuild, with no compatibility gate anywhere. Bumps are a
 # deliberate one-line change here. If the pin ever rotates out of the
 # pgdg pool the daily rebuild fails loudly - that is the point: a
-# human decides, never a nightly accident. (Fallback source if needed:
-# apt-archive.postgresql.org.)
-ARG PGVECTOR_PKG_VERSION=0.8.6-1.pgdg13+1
+# human decides, never a nightly accident. The pin freezes the UPSTREAM
+# version only; the Debian packaging revision (-N.pgdgXX+N) floats via
+# the glob, so pgdg re-packaging churn never breaks a rebuild. Bumps
+# arrive through the scheduled bump workflow: it opens a PR moving this
+# ARG, and that PR's CI must pass the extension compat matrix
+# (old catalogs under the candidate .so) before it can merge.
+ARG PGVECTOR_PKG_VERSION=0.8.6-*
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
@@ -26,7 +30,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-13 postgresql-client-13 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-13-pgvector=${PGVECTOR_PKG_VERSION} \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest "postgresql-13-pgvector=${PGVECTOR_PKG_VERSION}" \
     && apt-mark unhold postgresql-13 postgresql-client-13 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.13
+++ b/Dockerfile.13
@@ -1,5 +1,15 @@
 ARG POSTGRES_VERSION=13
 FROM postgres:${POSTGRES_VERSION}
+# Extension packages are PINNED: the volume keeps each extension's SQL
+# catalog at install-time version while the image carries the .so, and
+# this tag is rebuilt daily for CVE freshness - an unpinned package
+# would let pgdg move the binaries under every existing catalog on the
+# next rebuild, with no compatibility gate anywhere. Bumps are a
+# deliberate one-line change here. If the pin ever rotates out of the
+# pgdg pool the daily rebuild fails loudly - that is the point: a
+# human decides, never a nightly accident. (Fallback source if needed:
+# apt-archive.postgresql.org.)
+ARG PGVECTOR_PKG_VERSION=0.8.6-1.pgdg13+1
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
@@ -16,7 +26,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-13 postgresql-client-13 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-13-pgvector \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-13-pgvector=${PGVECTOR_PKG_VERSION} \
     && apt-mark unhold postgresql-13 postgresql-client-13 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.13
+++ b/Dockerfile.13
@@ -1,19 +1,19 @@
 ARG POSTGRES_VERSION=13
 FROM postgres:${POSTGRES_VERSION}
-# Extension packages are PINNED: the volume keeps each extension's SQL
-# catalog at install-time version while the image carries the .so, and
-# this tag is rebuilt daily for CVE freshness - an unpinned package
-# would let pgdg move the binaries under every existing catalog on the
-# next rebuild, with no compatibility gate anywhere. Bumps are a
-# deliberate one-line change here. If the pin ever rotates out of the
-# pgdg pool the daily rebuild fails loudly - that is the point: a
-# human decides, never a nightly accident. The pin freezes the UPSTREAM
-# version only; the Debian packaging revision (-N.pgdgXX+N) floats via
-# the glob, so pgdg re-packaging churn never breaks a rebuild. Bumps
-# arrive through the scheduled bump workflow: it opens a PR moving this
-# ARG, and that PR's CI must pass the extension compat matrix
-# (old catalogs under the candidate .so) before it can merge.
-ARG PGVECTOR_PKG_VERSION=0.8.6-*
+# Extension packages are pinned AT THE MINOR: the volume keeps each
+# extension's SQL catalog at install-time version while the image carries
+# the .so, and this tag is rebuilt daily - an unpinned package would let
+# pgdg move the binaries a whole minor (where catalog/.so compatibility
+# actually breaks) under every existing catalog overnight, with no gate
+# anywhere. PATCH releases and Debian packaging revisions float freely:
+# they are the bugfix/CVE stream and upstream keeps them
+# catalog-compatible (verified empirically 0.8.4->0.8.6). A MINOR bump is
+# the deliberate act: the scheduled bump workflow opens a one-line PR
+# moving this ARG, gated by the extension compat matrix (old catalogs
+# under the candidate .so). If pgdg ever prunes the whole minor from the
+# pool, the daily rebuild fails loudly - a human decides, never a nightly
+# accident.
+ARG PGVECTOR_PKG_VERSION=0.8.*
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base

--- a/Dockerfile.14
+++ b/Dockerfile.14
@@ -7,9 +7,13 @@ FROM postgres:${POSTGRES_VERSION}
 # next rebuild, with no compatibility gate anywhere. Bumps are a
 # deliberate one-line change here. If the pin ever rotates out of the
 # pgdg pool the daily rebuild fails loudly - that is the point: a
-# human decides, never a nightly accident. (Fallback source if needed:
-# apt-archive.postgresql.org.)
-ARG PGVECTOR_PKG_VERSION=0.8.6-1.pgdg13+1
+# human decides, never a nightly accident. The pin freezes the UPSTREAM
+# version only; the Debian packaging revision (-N.pgdgXX+N) floats via
+# the glob, so pgdg re-packaging churn never breaks a rebuild. Bumps
+# arrive through the scheduled bump workflow: it opens a PR moving this
+# ARG, and that PR's CI must pass the extension compat matrix
+# (old catalogs under the candidate .so) before it can merge.
+ARG PGVECTOR_PKG_VERSION=0.8.6-*
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
@@ -26,7 +30,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-14 postgresql-client-14 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-14-pgvector=${PGVECTOR_PKG_VERSION} \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest "postgresql-14-pgvector=${PGVECTOR_PKG_VERSION}" \
     && apt-mark unhold postgresql-14 postgresql-client-14 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.14
+++ b/Dockerfile.14
@@ -1,19 +1,19 @@
 ARG POSTGRES_VERSION=14
 FROM postgres:${POSTGRES_VERSION}
-# Extension packages are PINNED: the volume keeps each extension's SQL
-# catalog at install-time version while the image carries the .so, and
-# this tag is rebuilt daily for CVE freshness - an unpinned package
-# would let pgdg move the binaries under every existing catalog on the
-# next rebuild, with no compatibility gate anywhere. Bumps are a
-# deliberate one-line change here. If the pin ever rotates out of the
-# pgdg pool the daily rebuild fails loudly - that is the point: a
-# human decides, never a nightly accident. The pin freezes the UPSTREAM
-# version only; the Debian packaging revision (-N.pgdgXX+N) floats via
-# the glob, so pgdg re-packaging churn never breaks a rebuild. Bumps
-# arrive through the scheduled bump workflow: it opens a PR moving this
-# ARG, and that PR's CI must pass the extension compat matrix
-# (old catalogs under the candidate .so) before it can merge.
-ARG PGVECTOR_PKG_VERSION=0.8.6-*
+# Extension packages are pinned AT THE MINOR: the volume keeps each
+# extension's SQL catalog at install-time version while the image carries
+# the .so, and this tag is rebuilt daily - an unpinned package would let
+# pgdg move the binaries a whole minor (where catalog/.so compatibility
+# actually breaks) under every existing catalog overnight, with no gate
+# anywhere. PATCH releases and Debian packaging revisions float freely:
+# they are the bugfix/CVE stream and upstream keeps them
+# catalog-compatible (verified empirically 0.8.4->0.8.6). A MINOR bump is
+# the deliberate act: the scheduled bump workflow opens a one-line PR
+# moving this ARG, gated by the extension compat matrix (old catalogs
+# under the candidate .so). If pgdg ever prunes the whole minor from the
+# pool, the daily rebuild fails loudly - a human decides, never a nightly
+# accident.
+ARG PGVECTOR_PKG_VERSION=0.8.*
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base

--- a/Dockerfile.14
+++ b/Dockerfile.14
@@ -1,5 +1,15 @@
 ARG POSTGRES_VERSION=14
 FROM postgres:${POSTGRES_VERSION}
+# Extension packages are PINNED: the volume keeps each extension's SQL
+# catalog at install-time version while the image carries the .so, and
+# this tag is rebuilt daily for CVE freshness - an unpinned package
+# would let pgdg move the binaries under every existing catalog on the
+# next rebuild, with no compatibility gate anywhere. Bumps are a
+# deliberate one-line change here. If the pin ever rotates out of the
+# pgdg pool the daily rebuild fails loudly - that is the point: a
+# human decides, never a nightly accident. (Fallback source if needed:
+# apt-archive.postgresql.org.)
+ARG PGVECTOR_PKG_VERSION=0.8.6-1.pgdg13+1
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
@@ -16,7 +26,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-14 postgresql-client-14 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-14-pgvector \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-14-pgvector=${PGVECTOR_PKG_VERSION} \
     && apt-mark unhold postgresql-14 postgresql-client-14 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.15
+++ b/Dockerfile.15
@@ -1,5 +1,15 @@
 ARG POSTGRES_VERSION=15
 FROM postgres:${POSTGRES_VERSION}
+# Extension packages are PINNED: the volume keeps each extension's SQL
+# catalog at install-time version while the image carries the .so, and
+# this tag is rebuilt daily for CVE freshness - an unpinned package
+# would let pgdg move the binaries under every existing catalog on the
+# next rebuild, with no compatibility gate anywhere. Bumps are a
+# deliberate one-line change here. If the pin ever rotates out of the
+# pgdg pool the daily rebuild fails loudly - that is the point: a
+# human decides, never a nightly accident. (Fallback source if needed:
+# apt-archive.postgresql.org.)
+ARG PGVECTOR_PKG_VERSION=0.8.6-1.pgdg13+1
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
@@ -16,7 +26,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-15 postgresql-client-15 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-15-pgvector \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-15-pgvector=${PGVECTOR_PKG_VERSION} \
     && apt-mark unhold postgresql-15 postgresql-client-15 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.15
+++ b/Dockerfile.15
@@ -7,9 +7,13 @@ FROM postgres:${POSTGRES_VERSION}
 # next rebuild, with no compatibility gate anywhere. Bumps are a
 # deliberate one-line change here. If the pin ever rotates out of the
 # pgdg pool the daily rebuild fails loudly - that is the point: a
-# human decides, never a nightly accident. (Fallback source if needed:
-# apt-archive.postgresql.org.)
-ARG PGVECTOR_PKG_VERSION=0.8.6-1.pgdg13+1
+# human decides, never a nightly accident. The pin freezes the UPSTREAM
+# version only; the Debian packaging revision (-N.pgdgXX+N) floats via
+# the glob, so pgdg re-packaging churn never breaks a rebuild. Bumps
+# arrive through the scheduled bump workflow: it opens a PR moving this
+# ARG, and that PR's CI must pass the extension compat matrix
+# (old catalogs under the candidate .so) before it can merge.
+ARG PGVECTOR_PKG_VERSION=0.8.6-*
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
@@ -26,7 +30,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-15 postgresql-client-15 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-15-pgvector=${PGVECTOR_PKG_VERSION} \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest "postgresql-15-pgvector=${PGVECTOR_PKG_VERSION}" \
     && apt-mark unhold postgresql-15 postgresql-client-15 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.15
+++ b/Dockerfile.15
@@ -1,19 +1,19 @@
 ARG POSTGRES_VERSION=15
 FROM postgres:${POSTGRES_VERSION}
-# Extension packages are PINNED: the volume keeps each extension's SQL
-# catalog at install-time version while the image carries the .so, and
-# this tag is rebuilt daily for CVE freshness - an unpinned package
-# would let pgdg move the binaries under every existing catalog on the
-# next rebuild, with no compatibility gate anywhere. Bumps are a
-# deliberate one-line change here. If the pin ever rotates out of the
-# pgdg pool the daily rebuild fails loudly - that is the point: a
-# human decides, never a nightly accident. The pin freezes the UPSTREAM
-# version only; the Debian packaging revision (-N.pgdgXX+N) floats via
-# the glob, so pgdg re-packaging churn never breaks a rebuild. Bumps
-# arrive through the scheduled bump workflow: it opens a PR moving this
-# ARG, and that PR's CI must pass the extension compat matrix
-# (old catalogs under the candidate .so) before it can merge.
-ARG PGVECTOR_PKG_VERSION=0.8.6-*
+# Extension packages are pinned AT THE MINOR: the volume keeps each
+# extension's SQL catalog at install-time version while the image carries
+# the .so, and this tag is rebuilt daily - an unpinned package would let
+# pgdg move the binaries a whole minor (where catalog/.so compatibility
+# actually breaks) under every existing catalog overnight, with no gate
+# anywhere. PATCH releases and Debian packaging revisions float freely:
+# they are the bugfix/CVE stream and upstream keeps them
+# catalog-compatible (verified empirically 0.8.4->0.8.6). A MINOR bump is
+# the deliberate act: the scheduled bump workflow opens a one-line PR
+# moving this ARG, gated by the extension compat matrix (old catalogs
+# under the candidate .so). If pgdg ever prunes the whole minor from the
+# pool, the daily rebuild fails loudly - a human decides, never a nightly
+# accident.
+ARG PGVECTOR_PKG_VERSION=0.8.*
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base

--- a/Dockerfile.16
+++ b/Dockerfile.16
@@ -7,9 +7,13 @@ FROM postgres:${POSTGRES_VERSION}
 # next rebuild, with no compatibility gate anywhere. Bumps are a
 # deliberate one-line change here. If the pin ever rotates out of the
 # pgdg pool the daily rebuild fails loudly - that is the point: a
-# human decides, never a nightly accident. (Fallback source if needed:
-# apt-archive.postgresql.org.)
-ARG PGVECTOR_PKG_VERSION=0.8.6-1.pgdg13+1
+# human decides, never a nightly accident. The pin freezes the UPSTREAM
+# version only; the Debian packaging revision (-N.pgdgXX+N) floats via
+# the glob, so pgdg re-packaging churn never breaks a rebuild. Bumps
+# arrive through the scheduled bump workflow: it opens a PR moving this
+# ARG, and that PR's CI must pass the extension compat matrix
+# (old catalogs under the candidate .so) before it can merge.
+ARG PGVECTOR_PKG_VERSION=0.8.6-*
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
@@ -26,7 +30,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-16 postgresql-client-16 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-16-pgvector=${PGVECTOR_PKG_VERSION} \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest "postgresql-16-pgvector=${PGVECTOR_PKG_VERSION}" \
     && apt-mark unhold postgresql-16 postgresql-client-16 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.16
+++ b/Dockerfile.16
@@ -1,19 +1,19 @@
 ARG POSTGRES_VERSION=16
 FROM postgres:${POSTGRES_VERSION}
-# Extension packages are PINNED: the volume keeps each extension's SQL
-# catalog at install-time version while the image carries the .so, and
-# this tag is rebuilt daily for CVE freshness - an unpinned package
-# would let pgdg move the binaries under every existing catalog on the
-# next rebuild, with no compatibility gate anywhere. Bumps are a
-# deliberate one-line change here. If the pin ever rotates out of the
-# pgdg pool the daily rebuild fails loudly - that is the point: a
-# human decides, never a nightly accident. The pin freezes the UPSTREAM
-# version only; the Debian packaging revision (-N.pgdgXX+N) floats via
-# the glob, so pgdg re-packaging churn never breaks a rebuild. Bumps
-# arrive through the scheduled bump workflow: it opens a PR moving this
-# ARG, and that PR's CI must pass the extension compat matrix
-# (old catalogs under the candidate .so) before it can merge.
-ARG PGVECTOR_PKG_VERSION=0.8.6-*
+# Extension packages are pinned AT THE MINOR: the volume keeps each
+# extension's SQL catalog at install-time version while the image carries
+# the .so, and this tag is rebuilt daily - an unpinned package would let
+# pgdg move the binaries a whole minor (where catalog/.so compatibility
+# actually breaks) under every existing catalog overnight, with no gate
+# anywhere. PATCH releases and Debian packaging revisions float freely:
+# they are the bugfix/CVE stream and upstream keeps them
+# catalog-compatible (verified empirically 0.8.4->0.8.6). A MINOR bump is
+# the deliberate act: the scheduled bump workflow opens a one-line PR
+# moving this ARG, gated by the extension compat matrix (old catalogs
+# under the candidate .so). If pgdg ever prunes the whole minor from the
+# pool, the daily rebuild fails loudly - a human decides, never a nightly
+# accident.
+ARG PGVECTOR_PKG_VERSION=0.8.*
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base

--- a/Dockerfile.16
+++ b/Dockerfile.16
@@ -1,5 +1,15 @@
 ARG POSTGRES_VERSION=16
 FROM postgres:${POSTGRES_VERSION}
+# Extension packages are PINNED: the volume keeps each extension's SQL
+# catalog at install-time version while the image carries the .so, and
+# this tag is rebuilt daily for CVE freshness - an unpinned package
+# would let pgdg move the binaries under every existing catalog on the
+# next rebuild, with no compatibility gate anywhere. Bumps are a
+# deliberate one-line change here. If the pin ever rotates out of the
+# pgdg pool the daily rebuild fails loudly - that is the point: a
+# human decides, never a nightly accident. (Fallback source if needed:
+# apt-archive.postgresql.org.)
+ARG PGVECTOR_PKG_VERSION=0.8.6-1.pgdg13+1
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
@@ -16,7 +26,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-16 postgresql-client-16 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-16-pgvector \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-16-pgvector=${PGVECTOR_PKG_VERSION} \
     && apt-mark unhold postgresql-16 postgresql-client-16 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.17
+++ b/Dockerfile.17
@@ -7,9 +7,13 @@ FROM postgres:${POSTGRES_VERSION}
 # next rebuild, with no compatibility gate anywhere. Bumps are a
 # deliberate one-line change here. If the pin ever rotates out of the
 # pgdg pool the daily rebuild fails loudly - that is the point: a
-# human decides, never a nightly accident. (Fallback source if needed:
-# apt-archive.postgresql.org.)
-ARG PGVECTOR_PKG_VERSION=0.8.6-1.pgdg13+1
+# human decides, never a nightly accident. The pin freezes the UPSTREAM
+# version only; the Debian packaging revision (-N.pgdgXX+N) floats via
+# the glob, so pgdg re-packaging churn never breaks a rebuild. Bumps
+# arrive through the scheduled bump workflow: it opens a PR moving this
+# ARG, and that PR's CI must pass the extension compat matrix
+# (old catalogs under the candidate .so) before it can merge.
+ARG PGVECTOR_PKG_VERSION=0.8.6-*
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
@@ -26,7 +30,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-17 postgresql-client-17 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-17-pgvector=${PGVECTOR_PKG_VERSION} \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest "postgresql-17-pgvector=${PGVECTOR_PKG_VERSION}" \
     && apt-mark unhold postgresql-17 postgresql-client-17 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.17
+++ b/Dockerfile.17
@@ -1,19 +1,19 @@
 ARG POSTGRES_VERSION=17
 FROM postgres:${POSTGRES_VERSION}
-# Extension packages are PINNED: the volume keeps each extension's SQL
-# catalog at install-time version while the image carries the .so, and
-# this tag is rebuilt daily for CVE freshness - an unpinned package
-# would let pgdg move the binaries under every existing catalog on the
-# next rebuild, with no compatibility gate anywhere. Bumps are a
-# deliberate one-line change here. If the pin ever rotates out of the
-# pgdg pool the daily rebuild fails loudly - that is the point: a
-# human decides, never a nightly accident. The pin freezes the UPSTREAM
-# version only; the Debian packaging revision (-N.pgdgXX+N) floats via
-# the glob, so pgdg re-packaging churn never breaks a rebuild. Bumps
-# arrive through the scheduled bump workflow: it opens a PR moving this
-# ARG, and that PR's CI must pass the extension compat matrix
-# (old catalogs under the candidate .so) before it can merge.
-ARG PGVECTOR_PKG_VERSION=0.8.6-*
+# Extension packages are pinned AT THE MINOR: the volume keeps each
+# extension's SQL catalog at install-time version while the image carries
+# the .so, and this tag is rebuilt daily - an unpinned package would let
+# pgdg move the binaries a whole minor (where catalog/.so compatibility
+# actually breaks) under every existing catalog overnight, with no gate
+# anywhere. PATCH releases and Debian packaging revisions float freely:
+# they are the bugfix/CVE stream and upstream keeps them
+# catalog-compatible (verified empirically 0.8.4->0.8.6). A MINOR bump is
+# the deliberate act: the scheduled bump workflow opens a one-line PR
+# moving this ARG, gated by the extension compat matrix (old catalogs
+# under the candidate .so). If pgdg ever prunes the whole minor from the
+# pool, the daily rebuild fails loudly - a human decides, never a nightly
+# accident.
+ARG PGVECTOR_PKG_VERSION=0.8.*
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base

--- a/Dockerfile.17
+++ b/Dockerfile.17
@@ -1,5 +1,15 @@
 ARG POSTGRES_VERSION=17
 FROM postgres:${POSTGRES_VERSION}
+# Extension packages are PINNED: the volume keeps each extension's SQL
+# catalog at install-time version while the image carries the .so, and
+# this tag is rebuilt daily for CVE freshness - an unpinned package
+# would let pgdg move the binaries under every existing catalog on the
+# next rebuild, with no compatibility gate anywhere. Bumps are a
+# deliberate one-line change here. If the pin ever rotates out of the
+# pgdg pool the daily rebuild fails loudly - that is the point: a
+# human decides, never a nightly accident. (Fallback source if needed:
+# apt-archive.postgresql.org.)
+ARG PGVECTOR_PKG_VERSION=0.8.6-1.pgdg13+1
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
@@ -16,7 +26,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-17 postgresql-client-17 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-17-pgvector \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-17-pgvector=${PGVECTOR_PKG_VERSION} \
     && apt-mark unhold postgresql-17 postgresql-client-17 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.18
+++ b/Dockerfile.18
@@ -1,5 +1,15 @@
 ARG POSTGRES_VERSION=18
 FROM postgres:${POSTGRES_VERSION}
+# Extension packages are PINNED: the volume keeps each extension's SQL
+# catalog at install-time version while the image carries the .so, and
+# this tag is rebuilt daily for CVE freshness - an unpinned package
+# would let pgdg move the binaries under every existing catalog on the
+# next rebuild, with no compatibility gate anywhere. Bumps are a
+# deliberate one-line change here. If the pin ever rotates out of the
+# pgdg pool the daily rebuild fails loudly - that is the point: a
+# human decides, never a nightly accident. (Fallback source if needed:
+# apt-archive.postgresql.org.)
+ARG PGVECTOR_PKG_VERSION=0.8.6-1.pgdg13+1
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
@@ -16,7 +26,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-18 postgresql-client-18 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-18-pgvector \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-18-pgvector=${PGVECTOR_PKG_VERSION} \
     && apt-mark unhold postgresql-18 postgresql-client-18 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.18
+++ b/Dockerfile.18
@@ -7,9 +7,13 @@ FROM postgres:${POSTGRES_VERSION}
 # next rebuild, with no compatibility gate anywhere. Bumps are a
 # deliberate one-line change here. If the pin ever rotates out of the
 # pgdg pool the daily rebuild fails loudly - that is the point: a
-# human decides, never a nightly accident. (Fallback source if needed:
-# apt-archive.postgresql.org.)
-ARG PGVECTOR_PKG_VERSION=0.8.6-1.pgdg13+1
+# human decides, never a nightly accident. The pin freezes the UPSTREAM
+# version only; the Debian packaging revision (-N.pgdgXX+N) floats via
+# the glob, so pgdg re-packaging churn never breaks a rebuild. Bumps
+# arrive through the scheduled bump workflow: it opens a PR moving this
+# ARG, and that PR's CI must pass the extension compat matrix
+# (old catalogs under the candidate .so) before it can merge.
+ARG PGVECTOR_PKG_VERSION=0.8.6-*
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
@@ -26,7 +30,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-18 postgresql-client-18 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest postgresql-18-pgvector=${PGVECTOR_PKG_VERSION} \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest "postgresql-18-pgvector=${PGVECTOR_PKG_VERSION}" \
     && apt-mark unhold postgresql-18 postgresql-client-18 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.18
+++ b/Dockerfile.18
@@ -1,19 +1,19 @@
 ARG POSTGRES_VERSION=18
 FROM postgres:${POSTGRES_VERSION}
-# Extension packages are PINNED: the volume keeps each extension's SQL
-# catalog at install-time version while the image carries the .so, and
-# this tag is rebuilt daily for CVE freshness - an unpinned package
-# would let pgdg move the binaries under every existing catalog on the
-# next rebuild, with no compatibility gate anywhere. Bumps are a
-# deliberate one-line change here. If the pin ever rotates out of the
-# pgdg pool the daily rebuild fails loudly - that is the point: a
-# human decides, never a nightly accident. The pin freezes the UPSTREAM
-# version only; the Debian packaging revision (-N.pgdgXX+N) floats via
-# the glob, so pgdg re-packaging churn never breaks a rebuild. Bumps
-# arrive through the scheduled bump workflow: it opens a PR moving this
-# ARG, and that PR's CI must pass the extension compat matrix
-# (old catalogs under the candidate .so) before it can merge.
-ARG PGVECTOR_PKG_VERSION=0.8.6-*
+# Extension packages are pinned AT THE MINOR: the volume keeps each
+# extension's SQL catalog at install-time version while the image carries
+# the .so, and this tag is rebuilt daily - an unpinned package would let
+# pgdg move the binaries a whole minor (where catalog/.so compatibility
+# actually breaks) under every existing catalog overnight, with no gate
+# anywhere. PATCH releases and Debian packaging revisions float freely:
+# they are the bugfix/CVE stream and upstream keeps them
+# catalog-compatible (verified empirically 0.8.4->0.8.6). A MINOR bump is
+# the deliberate act: the scheduled bump workflow opens a one-line PR
+# moving this ARG, gated by the extension compat matrix (old catalogs
+# under the candidate .so). If pgdg ever prunes the whole minor from the
+# pool, the daily rebuild fails loudly - a human decides, never a nightly
+# accident.
+ARG PGVECTOR_PKG_VERSION=0.8.*
 
 # Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base


### PR DESCRIPTION
First layer of extension version control (companion: same pin in postgres-ha, plus a fleet census and an image-CI compat gate to follow).

## Problem

The volume keeps each extension's SQL catalog at install-time version; the image carries the `.so`. These tags rebuild **daily** for CVE freshness, and `postgresql-<major>-pgvector` was installed **unpinned** — every pgdg release silently moved the fleet's binaries under every existing catalog, with no compatibility gate anywhere. The `(old catalog, new .so)` pair detonates on the next deployment that re-resolves the tag (config edit, remediation campaign, auto-update), as runtime errors inside user queries — or worse in reverse on an image rollback.

## Change

- `ARG PGVECTOR_PKG_VERSION=0.8.*` (MINOR frozen; patch releases and packaging revisions float - patches are the bugfix/CVE stream and upstream keeps them catalog-compatible (verified empirically 0.8.4->0.8.6); the compat risk this pin exists for lives at minor bumps) + `=${PGVECTOR_PKG_VERSION}` on the install line, in all six Dockerfiles.
- Behavior today: zero change — the pin freezes the current state.
- A version bump becomes a deliberate one-line change (to pair with a compat gate in CI next).
- If pgdg ever prunes the pinned version, the daily rebuild **fails loudly** — a human decision point instead of a nightly accident. The pgdg pool currently keeps old versions (0.8.4/0.8.5/0.8.6 all present); `apt-archive.postgresql.org` is the fallback source if that changes.

## Verification

`Dockerfile.16` built locally: `dpkg -s` reports exactly `0.8.*`; `CREATE EXTENSION vector` succeeds and reports 0.8.6.


**Update path** (the part that keeps this from rotting): a scheduled bump workflow resolves the current pgdg candidate daily and opens a one-line ARG-bump PR when the MINOR moved (patches flow without ceremony); that PR is gated by the extension compat matrix (boot the candidate image over volumes carrying each historical catalog version, run functional probes - the volume-swap experiment, automated). Fresh versions keep flowing, but only through a tested door. Gate + bump workflow land in the next PR.
