### PR TITLE
fix: restore LOG_TO_STDOUT — the server's log stream is a user contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ configuring the `SSL_CERT_DAYS` environment variable as needed.
 When a redeploy or restart is done the certificates expiry is checked, if it has
 expired or will expire in 30 days a new certificate is automatically generated.
 
+### Server log stream
+
+Postgres writes every log level it has — `LOG` through `PANIC` — to stderr,
+and the stream a line arrives on is what Railway reads its severity from:
+stdout is ingested as info, stderr as error. Left alone, a database that
+reports each checkpoint, connection and authentication on stderr fills a
+severity-filtered log view — including one spanning every service in the
+project — with lines that are not errors.
+
+Set `LOG_TO_STDOUT=true` (or `1`) to send the Postgres server log to stdout
+instead. Real server errors move with it, since Postgres emits all of its
+levels on the one stream, so this trades per-line severity for a log view
+where an error is an error. Unset — or any other value — keeps the upstream
+behavior.
+
+The image's own diagnostics are unaffected either way: certificate,
+volume-lock and pgBackRest warnings from `wrapper.sh` stay on stderr.
+
 ### Available image tags
 
 Images are automatically built weekly and tagged with multiple version levels

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -305,6 +305,35 @@ wait_for_log_line() {
   return 1
 }
 
+# `docker logs` is the only place the container's stdout/stderr split
+# survives outside a log pipeline: it writes the container's stdout to its
+# own stdout and the container's stderr to its own stderr. The two helpers
+# below let a test assert WHICH stream a line arrived on — the property a
+# pipeline turns into that line's severity. Both avoid `docker logs | grep`:
+# under `pipefail` a `grep -q` that exits on its first match SIGPIPEs the
+# producer and the pipeline reports 141, so a real match reads as a miss.
+logs_on_stream() {
+  local container="$1" stream="$2"
+  local prefix="/tmp/pgssl-logstream-${container}"
+  docker logs "$container" >"${prefix}.out" 2>"${prefix}.err"
+  if [ "$stream" = "stdout" ]; then cat "${prefix}.out"; else cat "${prefix}.err"; fi
+  rm -f "${prefix}.out" "${prefix}.err"
+}
+
+# Stream-scoped wait_for_log_line — same log-driver drain race, so poll
+# rather than checking once.
+wait_for_log_line_on_stream() {
+  local container="$1" pattern="$2" stream="$3" timeout="${4:-30}"
+  local deadline=$(($(date +%s) + timeout))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if grep -qF -- "$pattern" <<<"$(logs_on_stream "$container" "$stream")"; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
 cleanup_test_resources() {
   [ "${E2E_KEEP_CONTAINERS:-0}" = "1" ] && return 0
   docker rm -f $(docker ps -aq --filter "label=postgres-ssl-e2e=1") 2>/dev/null >/dev/null || true
@@ -724,7 +753,7 @@ t_archiving_boot_survives_pghostaddr() {
     fi
     sleep 1
   done
-  [ "$ready" = "1" ] || { ko t_archiving_boot_survives_pghostaddr "postgres did not start"; fail_dump t_archiving_boot_survives_pghostaddr "$name"; return; }
+  [ "$marker" = "1" ] || { ko t_archiving_boot_survives_pghostaddr "postgres did not start"; fail_dump t_archiving_boot_survives_pghostaddr "$name"; return; }
 
   # A wider deadline than t_archiving_boot's 15s: stanza-create can hit a
   # transient lock-contention retry (30s backoff, unrelated to PGHOSTADDR —
@@ -4777,10 +4806,83 @@ t_invalid_bucket_sentinel_cleared_on_disable() {
   docker volume rm "$vol" >/dev/null
 }
 
+t_log_to_stdout_moves_server_stream() {
+  # Which stream the server logs on is a user-visible contract, not an
+  # internal detail: a log pipeline reads a line's severity from its stream
+  # (stdout = info, stderr = error), so LOG_TO_STDOUT is the difference
+  # between a Postgres service that files every checkpoint and connection as
+  # an error and one that does not. Both directions are pinned here, so the
+  # branch can't be read as unreferenced and dropped again (issue #135).
+  local name=t-logstream-${PG_VERSION}
+  local vol=${name}-vol
+  # Marker chosen so it can only come from the REAL postmaster: initdb runs
+  # a temporary server whose output docker-entrypoint.sh puts on stdout, and
+  # it starts that one with `-c listen_addresses=''` (see the entrypoint's
+  # docker_temp_server_start), so "listening on IPv4 address" is never in
+  # its log. Asserting on a line the temp server also emits — "database
+  # system is ready to accept connections" — would see it on stdout on a
+  # first boot no matter what the switch does, and pass for the wrong reason.
+  local marker='listening on IPv4 address'
+  # Asserts on wrapper.sh behavior — never trust a pre-existing tag.
+  if ! rebuild_image; then
+    ko "${FUNCNAME[0]}" "could not rebuild $IMAGE"
+    return
+  fi
+  new_volume "$vol"
+  docker rm -f "$name" "${name}-b" >/dev/null 2>&1 || true
+
+  # Unset: upstream behavior — the server log stays on stderr.
+  docker run -d --name "$name" --label postgres-ssl-e2e=1 --network "$NET" \
+    -e POSTGRES_PASSWORD=test \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$IMAGE" >/dev/null
+  wait_for_pg "$name" || { ko t_log_to_stdout_moves_server_stream "postgres did not start with LOG_TO_STDOUT unset"; fail_dump t_log_to_stdout_moves_server_stream "$name"; return; }
+  wait_for_log_line_on_stream "$name" "$marker" stderr 30 \
+    || { ko t_log_to_stdout_moves_server_stream "server log did not reach stderr with LOG_TO_STDOUT unset"; fail_dump t_log_to_stdout_moves_server_stream "$name"; return; }
+
+  local on_stdout
+  on_stdout=$(logs_on_stream "$name" stdout)
+  # The entrypoint's own initdb progress is on stdout either way, so this
+  # anchor proves the stdout capture is real before asserting an absence.
+  if ! grep -qF -- "init process complete" <<<"$on_stdout"; then
+    ko t_log_to_stdout_moves_server_stream "stdout capture is missing the entrypoint's initdb output — the stream split is not being observed"
+    fail_dump t_log_to_stdout_moves_server_stream "$name"
+    return
+  fi
+  if grep -qF -- "$marker" <<<"$on_stdout"; then
+    ko t_log_to_stdout_moves_server_stream "server log reached stdout with LOG_TO_STDOUT unset"
+    fail_dump t_log_to_stdout_moves_server_stream "$name"
+    return
+  fi
+
+  # LOG_TO_STDOUT=true on the same (now initialized) volume: the server log
+  # follows the switch onto stdout and leaves stderr for real failures.
+  docker rm -f "$name" >/dev/null
+  docker run -d --name "${name}-b" --label postgres-ssl-e2e=1 --network "$NET" \
+    -e POSTGRES_PASSWORD=test \
+    -e LOG_TO_STDOUT=true \
+    -v "$vol:/var/lib/postgresql/data" \
+    "$IMAGE" >/dev/null
+  wait_for_pg "${name}-b" || { ko t_log_to_stdout_moves_server_stream "postgres did not start with LOG_TO_STDOUT=true"; fail_dump t_log_to_stdout_moves_server_stream "${name}-b"; return; }
+  wait_for_log_line_on_stream "${name}-b" "$marker" stdout 30 \
+    || { ko t_log_to_stdout_moves_server_stream "server log did not follow LOG_TO_STDOUT=true onto stdout"; fail_dump t_log_to_stdout_moves_server_stream "${name}-b"; return; }
+  if grep -qF -- "$marker" <<<"$(logs_on_stream "${name}-b" stderr)"; then
+    ko t_log_to_stdout_moves_server_stream "server log still reached stderr under LOG_TO_STDOUT=true"
+    fail_dump t_log_to_stdout_moves_server_stream "${name}-b"
+    return
+  fi
+
+  ok t_log_to_stdout_moves_server_stream
+  note "server log on stderr by default, on stdout under LOG_TO_STDOUT=true"
+  docker rm -f "${name}-b" >/dev/null
+  docker volume rm "$vol" >/dev/null
+}
+
 # ----- runner ----------------------------------------------------------------
 
 ALL_TESTS=(
   t_vanilla_boot
+  t_log_to_stdout_moves_server_stream
   t_runtime_lock_blocks_overlapping_boot
   t_unasked_clean_exit_is_nonzero
   t_requested_stop_still_exits_zero

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -753,7 +753,7 @@ t_archiving_boot_survives_pghostaddr() {
     fi
     sleep 1
   done
-  [ "$marker" = "1" ] || { ko t_archiving_boot_survives_pghostaddr "postgres did not start"; fail_dump t_archiving_boot_survives_pghostaddr "$name"; return; }
+  [ "$ready" = "1" ] || { ko t_archiving_boot_survives_pghostaddr "postgres did not start"; fail_dump t_archiving_boot_survives_pghostaddr "$name"; return; }
 
   # A wider deadline than t_archiving_boot's 15s: stanza-create can hit a
   # transient lock-contention retry (30s backoff, unrelated to PGHOSTADDR —

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -2467,6 +2467,32 @@ fi
 STOP_REQUESTED=0
 trap 'STOP_REQUESTED=1' TERM INT
 
+# LOG_TO_STDOUT=true moves the SERVER's log stream from stderr to stdout.
+# Postgres writes every level it has — LOG through PANIC — to a single
+# stream, and the stream a line arrives on is what a log pipeline reads its
+# severity from: stdout is ingested as info, stderr as error. A database
+# that reports each checkpoint, connection and authentication on stderr
+# therefore fills a severity-filtered log view with lines that are not
+# errors, which is what this switch exists to fix (issue #10). It trades
+# per-line severity for a quiet error view; unset keeps upstream behavior.
+#
+# Neither this repo nor the platform ever sets the variable — the caller
+# sets it as a service variable, so "no references here" is the contract
+# working, not dead code (#72 read it the other way and dropped the branch;
+# issue #135 is the user whose Postgres logs it took away). Both streams
+# are pinned by t_log_to_stdout_moves_server_stream in test/e2e.sh.
+#
+# The redirect is deliberately narrow: it lands past every `>&2` diagnostic
+# above and past the forked watchers (which keep the fds they were forked
+# with), so certificate, volume-lock and pgBackRest warnings from this
+# wrapper still arrive as errors.
+case "${LOG_TO_STDOUT:-}" in
+  [Tt][Rr][Uu][Ee] | 1)
+    echo "wrapper: LOG_TO_STDOUT=${LOG_TO_STDOUT} — sending the Postgres server log to stdout"
+    exec 2>&1
+    ;;
+esac
+
 ENTRYPOINT_EXIT=0
 /usr/local/bin/docker-entrypoint.sh "$@" || ENTRYPOINT_EXIT=$?
 


### PR DESCRIPTION
## Problem

`LOG_TO_STDOUT=true` moved the Postgres server's log stream from stderr to
stdout. #72 dropped the branch as dead code because nothing in this repo — or
in the platform — ever sets the variable. That is the variable's design, not
evidence against it: the caller sets it as a service variable, which is
exactly how it was requested and accepted in #10 / #11. Issue #135 is a user
who moved to a recent image and lost the feature.

The other half of #72's reasoning — the redirect is irrelevant because the
runtime captures both streams anyway — is where the mistake lands. Both
streams are captured, and the stream a line arrives on is what its severity
becomes: stdout is ingested as info, stderr as error. Postgres writes every
level it has, `LOG` through `PANIC`, to one stream. So on stderr a database
files every checkpoint, connection and authentication as an error, and a
severity-filtered log view — including one spanning every service in a
project — fills with lines that are not errors. That is what #10 opened with,
screenshots included, and what #135 asks to have back.

## Fix

Restore the switch as a guarded redirect of the wrapper's fd 2, immediately
before the foreground `docker-entrypoint.sh` invocation, so the server and
everything it starts log on stdout. `true` (any case) or `1` enables it;
anything else, unset included, keeps the upstream stderr behavior.

Scoped deliberately: the redirect lands past every `>&2` diagnostic in
`wrapper.sh` and past the forked watchers (which keep the fds they were forked
with), so certificate, volume-lock and pgBackRest warnings still arrive as
errors. The foreground invocation itself is untouched — no `exec`, no
trap+wait — so the H1 constraints documented above it still hold.

Why it read as dead code is now recorded in the three places a future cleanup
pass has to walk through: the comment at the branch, a README section that
documents the variable as a user-facing contract, and an e2e test that fails
if the branch disappears again.

## Validation (docker, `postgres-ssl-pitr:17`, PG 17.11)

- New `t_log_to_stdout_moves_server_stream`: **PASS**. Default boot — the real
  postmaster's log on stderr, absent from stdout; same volume rebooted with
  `LOG_TO_STDOUT=true` — the same lines on stdout, absent from stderr.
- Mutation check: with the `wrapper.sh` hunk reverted and the image rebuilt,
  the test **FAILS** (`server log did not follow LOG_TO_STDOUT=true onto
  stdout`), so it pins the behavior instead of passing vacuously.
- The test asserts on `listening on IPv4 address`, not on `database system is
  ready to accept connections`: initdb's temporary server logs on stdout and
  runs with `listen_addresses=''`, so the ready line is on stdout during a
  first boot no matter what the switch does. The first draft asserted on it
  and failed for exactly that reason.
- `bash -n wrapper.sh`, `bash -n test/e2e.sh` clean.

Closes #135.
