### PR TITLE
Run wrapper.sh under tini so postgres receives the stop signal; keep helpers out of the postmaster's process tree

### DIFF
--- a/Dockerfile.13
+++ b/Dockerfile.13
@@ -15,7 +15,8 @@ FROM postgres:${POSTGRES_VERSION}
 # accident.
 ARG PGVECTOR_PKG_VERSION=0.8.*
 
-# Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
+# Install OpenSSL, sudo, pgvector, pgbackrest, tini (PID 1, see ENTRYPOINT
+# below), and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
 # CI passes its content key here (see the build workflow's content gate):
@@ -30,7 +31,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-13 postgresql-client-13 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest "postgresql-13-pgvector=${PGVECTOR_PKG_VERSION}" \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest tini "postgresql-13-pgvector=${PGVECTOR_PKG_VERSION}" \
     && apt-mark unhold postgresql-13 postgresql-client-13 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -46,5 +47,17 @@ COPY --chmod=755 pgbackrest-archive-push-wrapper.sh /usr/local/bin/pgbackrest-ar
 COPY --chmod=755 pgbackrest-backup-watcher.sh /usr/local/bin/pgbackrest-backup-watcher.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
-ENTRYPOINT ["wrapper.sh"]
+# tini is PID 1. The runtime stops a container by signaling PID 1 only; a
+# shell there with no handler drops the signal, and the stop ends in SIGKILL
+# once the grace period runs out — every restart becomes a hard kill and the
+# next boot a WAL crash recovery. wrapper.sh cannot simply exec postgres
+# either: it forks background helpers (backup watcher, post-upgrade tasks)
+# that exec would re-parent onto the postmaster, which PANICs on their
+# SIGCHLD. tini -g delivers the stop signal to wrapper.sh's process group
+# (the wrapper and the postgres it runs in the foreground), reaps the
+# helpers when they exit, and exits with the wrapper's status. SIGINT is
+# postgres's fast-shutdown signal; the base image already declares it, and
+# it is restated here because the whole arrangement depends on it.
+STOPSIGNAL SIGINT
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/usr/local/bin/wrapper.sh"]
 CMD ["postgres", "-p", "5432", "-c", "listen_addresses=*"]

--- a/Dockerfile.14
+++ b/Dockerfile.14
@@ -15,7 +15,8 @@ FROM postgres:${POSTGRES_VERSION}
 # accident.
 ARG PGVECTOR_PKG_VERSION=0.8.*
 
-# Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
+# Install OpenSSL, sudo, pgvector, pgbackrest, tini (PID 1, see ENTRYPOINT
+# below), and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
 # CI passes its content key here (see the build workflow's content gate):
@@ -30,7 +31,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-14 postgresql-client-14 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest "postgresql-14-pgvector=${PGVECTOR_PKG_VERSION}" \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest tini "postgresql-14-pgvector=${PGVECTOR_PKG_VERSION}" \
     && apt-mark unhold postgresql-14 postgresql-client-14 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -46,5 +47,17 @@ COPY --chmod=755 pgbackrest-archive-push-wrapper.sh /usr/local/bin/pgbackrest-ar
 COPY --chmod=755 pgbackrest-backup-watcher.sh /usr/local/bin/pgbackrest-backup-watcher.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
-ENTRYPOINT ["wrapper.sh"]
+# tini is PID 1. The runtime stops a container by signaling PID 1 only; a
+# shell there with no handler drops the signal, and the stop ends in SIGKILL
+# once the grace period runs out — every restart becomes a hard kill and the
+# next boot a WAL crash recovery. wrapper.sh cannot simply exec postgres
+# either: it forks background helpers (backup watcher, post-upgrade tasks)
+# that exec would re-parent onto the postmaster, which PANICs on their
+# SIGCHLD. tini -g delivers the stop signal to wrapper.sh's process group
+# (the wrapper and the postgres it runs in the foreground), reaps the
+# helpers when they exit, and exits with the wrapper's status. SIGINT is
+# postgres's fast-shutdown signal; the base image already declares it, and
+# it is restated here because the whole arrangement depends on it.
+STOPSIGNAL SIGINT
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/usr/local/bin/wrapper.sh"]
 CMD ["postgres", "-p", "5432", "-c", "listen_addresses=*"]

--- a/Dockerfile.15
+++ b/Dockerfile.15
@@ -15,7 +15,8 @@ FROM postgres:${POSTGRES_VERSION}
 # accident.
 ARG PGVECTOR_PKG_VERSION=0.8.*
 
-# Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
+# Install OpenSSL, sudo, pgvector, pgbackrest, tini (PID 1, see ENTRYPOINT
+# below), and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
 # CI passes its content key here (see the build workflow's content gate):
@@ -30,7 +31,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-15 postgresql-client-15 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest "postgresql-15-pgvector=${PGVECTOR_PKG_VERSION}" \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest tini "postgresql-15-pgvector=${PGVECTOR_PKG_VERSION}" \
     && apt-mark unhold postgresql-15 postgresql-client-15 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -46,5 +47,17 @@ COPY --chmod=755 pgbackrest-archive-push-wrapper.sh /usr/local/bin/pgbackrest-ar
 COPY --chmod=755 pgbackrest-backup-watcher.sh /usr/local/bin/pgbackrest-backup-watcher.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
-ENTRYPOINT ["wrapper.sh"]
+# tini is PID 1. The runtime stops a container by signaling PID 1 only; a
+# shell there with no handler drops the signal, and the stop ends in SIGKILL
+# once the grace period runs out — every restart becomes a hard kill and the
+# next boot a WAL crash recovery. wrapper.sh cannot simply exec postgres
+# either: it forks background helpers (backup watcher, post-upgrade tasks)
+# that exec would re-parent onto the postmaster, which PANICs on their
+# SIGCHLD. tini -g delivers the stop signal to wrapper.sh's process group
+# (the wrapper and the postgres it runs in the foreground), reaps the
+# helpers when they exit, and exits with the wrapper's status. SIGINT is
+# postgres's fast-shutdown signal; the base image already declares it, and
+# it is restated here because the whole arrangement depends on it.
+STOPSIGNAL SIGINT
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/usr/local/bin/wrapper.sh"]
 CMD ["postgres", "-p", "5432", "-c", "listen_addresses=*"]

--- a/Dockerfile.16
+++ b/Dockerfile.16
@@ -15,7 +15,8 @@ FROM postgres:${POSTGRES_VERSION}
 # accident.
 ARG PGVECTOR_PKG_VERSION=0.8.*
 
-# Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
+# Install OpenSSL, sudo, pgvector, pgbackrest, tini (PID 1, see ENTRYPOINT
+# below), and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
 # CI passes its content key here (see the build workflow's content gate):
@@ -30,7 +31,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-16 postgresql-client-16 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest "postgresql-16-pgvector=${PGVECTOR_PKG_VERSION}" \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest tini "postgresql-16-pgvector=${PGVECTOR_PKG_VERSION}" \
     && apt-mark unhold postgresql-16 postgresql-client-16 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -46,5 +47,17 @@ COPY --chmod=755 pgbackrest-archive-push-wrapper.sh /usr/local/bin/pgbackrest-ar
 COPY --chmod=755 pgbackrest-backup-watcher.sh /usr/local/bin/pgbackrest-backup-watcher.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
-ENTRYPOINT ["wrapper.sh"]
+# tini is PID 1. The runtime stops a container by signaling PID 1 only; a
+# shell there with no handler drops the signal, and the stop ends in SIGKILL
+# once the grace period runs out — every restart becomes a hard kill and the
+# next boot a WAL crash recovery. wrapper.sh cannot simply exec postgres
+# either: it forks background helpers (backup watcher, post-upgrade tasks)
+# that exec would re-parent onto the postmaster, which PANICs on their
+# SIGCHLD. tini -g delivers the stop signal to wrapper.sh's process group
+# (the wrapper and the postgres it runs in the foreground), reaps the
+# helpers when they exit, and exits with the wrapper's status. SIGINT is
+# postgres's fast-shutdown signal; the base image already declares it, and
+# it is restated here because the whole arrangement depends on it.
+STOPSIGNAL SIGINT
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/usr/local/bin/wrapper.sh"]
 CMD ["postgres", "-p", "5432", "-c", "listen_addresses=*"]

--- a/Dockerfile.17
+++ b/Dockerfile.17
@@ -15,7 +15,8 @@ FROM postgres:${POSTGRES_VERSION}
 # accident.
 ARG PGVECTOR_PKG_VERSION=0.8.*
 
-# Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
+# Install OpenSSL, sudo, pgvector, pgbackrest, tini (PID 1, see ENTRYPOINT
+# below), and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
 # CI passes its content key here (see the build workflow's content gate):
@@ -30,7 +31,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-17 postgresql-client-17 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest "postgresql-17-pgvector=${PGVECTOR_PKG_VERSION}" \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest tini "postgresql-17-pgvector=${PGVECTOR_PKG_VERSION}" \
     && apt-mark unhold postgresql-17 postgresql-client-17 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -46,5 +47,17 @@ COPY --chmod=755 pgbackrest-archive-push-wrapper.sh /usr/local/bin/pgbackrest-ar
 COPY --chmod=755 pgbackrest-backup-watcher.sh /usr/local/bin/pgbackrest-backup-watcher.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
-ENTRYPOINT ["wrapper.sh"]
+# tini is PID 1. The runtime stops a container by signaling PID 1 only; a
+# shell there with no handler drops the signal, and the stop ends in SIGKILL
+# once the grace period runs out — every restart becomes a hard kill and the
+# next boot a WAL crash recovery. wrapper.sh cannot simply exec postgres
+# either: it forks background helpers (backup watcher, post-upgrade tasks)
+# that exec would re-parent onto the postmaster, which PANICs on their
+# SIGCHLD. tini -g delivers the stop signal to wrapper.sh's process group
+# (the wrapper and the postgres it runs in the foreground), reaps the
+# helpers when they exit, and exits with the wrapper's status. SIGINT is
+# postgres's fast-shutdown signal; the base image already declares it, and
+# it is restated here because the whole arrangement depends on it.
+STOPSIGNAL SIGINT
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/usr/local/bin/wrapper.sh"]
 CMD ["postgres", "-p", "5432", "-c", "listen_addresses=*"]

--- a/Dockerfile.18
+++ b/Dockerfile.18
@@ -15,7 +15,8 @@ FROM postgres:${POSTGRES_VERSION}
 # accident.
 ARG PGVECTOR_PKG_VERSION=0.8.*
 
-# Install OpenSSL, sudo, pgvector, pgbackrest, and ca-certificates (needed
+# Install OpenSSL, sudo, pgvector, pgbackrest, tini (PID 1, see ENTRYPOINT
+# below), and ca-certificates (needed
 # so pgbackrest can verify the TLS cert of the S3 endpoint — postgres base
 # image disables apt Recommends, so ca-certificates isn't pulled implicitly)
 # CI passes its content key here (see the build workflow's content gate):
@@ -30,7 +31,7 @@ ARG PKG_REFRESH=none
 RUN echo "refresh key: ${PKG_REFRESH}" \
     && apt-mark hold postgresql-18 postgresql-client-18 \
     && apt-get update && apt-get upgrade -y \
-    && apt-get install -y openssl sudo ca-certificates jq pgbackrest "postgresql-18-pgvector=${PGVECTOR_PKG_VERSION}" \
+    && apt-get install -y openssl sudo ca-certificates jq pgbackrest tini "postgresql-18-pgvector=${PGVECTOR_PKG_VERSION}" \
     && apt-mark unhold postgresql-18 postgresql-client-18 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -46,5 +47,17 @@ COPY --chmod=755 pgbackrest-archive-push-wrapper.sh /usr/local/bin/pgbackrest-ar
 COPY --chmod=755 pgbackrest-backup-watcher.sh /usr/local/bin/pgbackrest-backup-watcher.sh
 COPY --chmod=755 wrapper.sh /usr/local/bin/wrapper.sh
 
-ENTRYPOINT ["wrapper.sh"]
+# tini is PID 1. The runtime stops a container by signaling PID 1 only; a
+# shell there with no handler drops the signal, and the stop ends in SIGKILL
+# once the grace period runs out — every restart becomes a hard kill and the
+# next boot a WAL crash recovery. wrapper.sh cannot simply exec postgres
+# either: it forks background helpers (backup watcher, post-upgrade tasks)
+# that exec would re-parent onto the postmaster, which PANICs on their
+# SIGCHLD. tini -g delivers the stop signal to wrapper.sh's process group
+# (the wrapper and the postgres it runs in the foreground), reaps the
+# helpers when they exit, and exits with the wrapper's status. SIGINT is
+# postgres's fast-shutdown signal; the base image already declares it, and
+# it is restated here because the whole arrangement depends on it.
+STOPSIGNAL SIGINT
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/usr/local/bin/wrapper.sh"]
 CMD ["postgres", "-p", "5432", "-c", "listen_addresses=*"]

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -538,9 +538,12 @@ t_requested_stop_still_exits_zero() {
     || { ko t_requested_stop_still_exits_zero "initdb did not complete"; fail_dump t_requested_stop_still_exits_zero "$name"; return; }
   wait_for_pg "$name" || { ko t_requested_stop_still_exits_zero "postgres did not start"; fail_dump t_requested_stop_still_exits_zero "$name"; return; }
 
-  # Simulate the runtime's stop: TERM to the wrapper (PID 1), then a clean
-  # postgres shutdown. The wrapper's trap only records the request; the
-  # shutdown itself is postgres's own.
+  # Simulate the runtime's stop: TERM to PID 1 (tini, which forwards it to
+  # the wrapper's process group), then a clean postgres shutdown. The
+  # wrapper's trap only records the request; the shutdown itself is
+  # postgres's own — pg_ctl below is a no-op if the forwarded TERM already
+  # finished it. The real stop path (SIGINT, fast shutdown, timing) is
+  # pinned by t_stop_is_clean_and_restart_keeps_watcher.
   docker exec "$name" kill -TERM 1
   docker exec -u postgres "$name" bash -c 'pg_ctl stop -D "$PGDATA" -m fast -w'
 
@@ -567,6 +570,138 @@ t_requested_stop_still_exits_zero() {
   fi
 
   ok t_requested_stop_still_exits_zero
+  docker rm -f "$name" >/dev/null
+  docker volume rm "$vol" >/dev/null
+}
+
+t_stop_is_clean_and_restart_keeps_watcher() {
+  # The runtime stops a container by signaling PID 1 only. With a shell as
+  # PID 1 and no handler that signal was dropped, so every stop ran out the
+  # grace period, ended in SIGKILL, and the next boot did WAL crash recovery.
+  # tini is PID 1 now and hands SIGINT to the wrapper's process group, so a
+  # stop must be a fast shutdown: well inside the grace period, exit 0, the
+  # shutdown logged. The background helpers must stay out of the postmaster's
+  # process tree (no SIGCHLD PANIC / exit 103 — the reason `exec` was never
+  # an option here) and come back on start/restart, and ALTER SYSTEM must
+  # survive `docker restart` (the failure mode of the bash-forwarding shape).
+  local name=t-clean-stop-${PG_VERSION}
+  local vol=${name}-vol
+  local t=t_stop_is_clean_and_restart_keeps_watcher
+  # Asserts on wrapper.sh + Dockerfile behavior — never trust a pre-existing tag.
+  if ! rebuild_image; then
+    ko "$t" "could not rebuild $IMAGE"
+    return
+  fi
+  reset_bucket
+  new_volume "$vol"
+  docker rm -f "$name" >/dev/null 2>&1 || true
+  # Archiving on so the watcher is forked: the helper whose re-parenting
+  # sank the exec approach, and the one that must survive the stop signal.
+  run_archiving_pg "$name" "$vol" -e PGDATA=/var/lib/postgresql/data/pgdata
+  wait_for_log_line "$name" "init process complete" 120 \
+    || { ko "$t" "initdb did not complete"; fail_dump "$t" "$name"; return; }
+  wait_for_pg "$name" || { ko "$t" "postgres did not start"; fail_dump "$t" "$name"; return; }
+
+  local pid1
+  pid1=$(docker exec "$name" cat /proc/1/comm 2>/dev/null)
+  assert_eq "$pid1" "tini" "PID 1 inside the container" || { ko "$t" ""; fail_dump "$t" "$name"; return; }
+  if ! docker exec "$name" pgrep -f pgbackrest-backup-watcher.sh >/dev/null; then
+    ko "$t" "backup watcher not running before the stop"; fail_dump "$t" "$name"; return
+  fi
+  # Let archiving settle before stopping: a fast shutdown waits for the
+  # archiver's in-flight archive_command, and right after boot that command
+  # can be mid-retry while stanza-create is still running — seconds that are
+  # postgres's own, not the signal path's. Stanza present + one segment
+  # pushed = steady state, which is what the stop timing below measures.
+  local deadline=$(($(date +%s) + 60)) settled=0
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if grep -qF "stanza-create completed" <<<"$(docker logs "$name" 2>&1)"; then settled=1; break; fi
+    sleep 1
+  done
+  [ "$settled" = "1" ] || { ko "$t" "stanza-create did not complete"; fail_dump "$t" "$name"; return; }
+  # A write that needs a checkpoint on shutdown, so "shut down" below is a
+  # real fast shutdown and not an idle no-op; the WAL switch archives it now
+  # rather than at shutdown.
+  docker exec "$name" psql -U postgres -c "CREATE TABLE stop_probe(id int); INSERT INTO stop_probe SELECT generate_series(1, 1000); SELECT pg_switch_wal();" >/dev/null
+  deadline=$(($(date +%s) + 60)); settled=0
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if grep -qF "pushed WAL file" <<<"$(docker logs "$name" 2>&1)"; then settled=1; break; fi
+    sleep 1
+  done
+  [ "$settled" = "1" ] || { ko "$t" "first WAL segment was never archived"; fail_dump "$t" "$name"; return; }
+
+  # The platform's stop: STOPSIGNAL (SIGINT) to PID 1, 15 s grace, then
+  # SIGKILL. A dropped signal shows up as ~15 s and exit 137; a delivered
+  # one as a sub-second fast shutdown at steady state (measured ~0.5 s).
+  # The bound below leaves room for a shutdown checkpoint or one archive
+  # push on a loaded host while staying well clear of the grace period.
+  local started stopped dur exit_code
+  started=$(date +%s)
+  docker stop -t 15 "$name" >/dev/null
+  stopped=$(date +%s)
+  dur=$((stopped - started))
+  exit_code=$(docker inspect -f '{{.State.ExitCode}}' "$name")
+  assert_eq "$exit_code" "0" "container exit code after docker stop" || { ko "$t" ""; fail_dump "$t" "$name"; return; }
+  if [ "$dur" -ge 12 ]; then
+    ko "$t" "docker stop took ${dur}s — a delivered SIGINT finishes in about a second; this ran out the grace period"
+    fail_dump "$t" "$name"; return
+  fi
+  # Capture the log once and grep the variable: `docker logs | grep -q` is
+  # the pipefail/SIGPIPE trap logs_on_stream describes, and here the match
+  # is the LAST line of a long log, so a 141 would read as "not shut down".
+  local logs="" deadline=$(($(date +%s) + 10))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    logs=$(docker logs "$name" 2>&1)
+    grep -qF "database system is shut down" <<<"$logs" && break
+    sleep 0.5
+  done
+  grep -qF "database system is shut down" <<<"$logs" \
+    || { ko "$t" "postgres did not log a clean shutdown"; fail_dump "$t" "$name"; return; }
+  grep -qF "received fast shutdown request" <<<"$logs" \
+    || { ko "$t" "postgres did not receive the fast-shutdown signal (SIGINT never reached it)"; fail_dump "$t" "$name"; return; }
+  if grep -qE "exit_code=103|PANIC" <<<"$logs"; then
+    ko "$t" "postmaster panicked during the stop (a helper re-parented onto it?)"; fail_dump "$t" "$name"; return
+  fi
+  if grep -qF "no stop was requested" <<<"$logs"; then
+    ko "$t" "requested stop was misclassified as unasked"; fail_dump "$t" "$name"; return
+  fi
+  note "docker stop -t 15: ${dur}s, exit ${exit_code}"
+
+  # Back up: no crash recovery (the shutdown was clean), watcher forked again.
+  docker start "$name" >/dev/null
+  wait_for_pg "$name" || { ko "$t" "postgres did not come back after docker start"; fail_dump "$t" "$name"; return; }
+  logs=$(docker logs "$name" 2>&1)
+  if grep -qF "database system was interrupted" <<<"$logs"; then
+    ko "$t" "the restarted postgres ran crash recovery — the stop was not clean"; fail_dump "$t" "$name"; return
+  fi
+  local deadline=$(($(date +%s) + 30)) watcher_back=0
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if docker exec "$name" pgrep -f pgbackrest-backup-watcher.sh >/dev/null 2>&1; then watcher_back=1; break; fi
+    sleep 1
+  done
+  [ "$watcher_back" = "1" ] || { ko "$t" "backup watcher did not come back after docker start"; fail_dump "$t" "$name"; return; }
+
+  # docker restart = the shape that lost auto.conf under the bash-forwarding
+  # attempt: an ALTER SYSTEM must survive it, and the watcher must be alive
+  # afterwards.
+  docker exec "$name" psql -U postgres -c "ALTER SYSTEM SET work_mem = '48MB';" >/dev/null
+  docker restart -t 15 "$name" >/dev/null
+  wait_for_pg "$name" || { ko "$t" "postgres did not come back after docker restart"; fail_dump "$t" "$name"; return; }
+  local work_mem rows
+  work_mem=$(docker exec "$name" psql -U postgres -At -c "SHOW work_mem")
+  assert_eq "$work_mem" "48MB" "work_mem from auto.conf after docker restart" || { ko "$t" ""; fail_dump "$t" "$name"; return; }
+  rows=$(docker exec "$name" psql -U postgres -At -c "SELECT count(*) FROM stop_probe")
+  assert_eq "$rows" "1000" "rows written before the stop" || { ko "$t" ""; fail_dump "$t" "$name"; return; }
+  deadline=$(($(date +%s) + 30)); watcher_back=0
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if docker exec "$name" pgrep -f pgbackrest-backup-watcher.sh >/dev/null 2>&1; then watcher_back=1; break; fi
+    sleep 1
+  done
+  [ "$watcher_back" = "1" ] || { ko "$t" "backup watcher did not come back after docker restart"; fail_dump "$t" "$name"; return; }
+  pid1=$(docker exec "$name" cat /proc/1/comm 2>/dev/null)
+  assert_eq "$pid1" "tini" "PID 1 after docker restart" || { ko "$t" ""; fail_dump "$t" "$name"; return; }
+
+  ok "$t"
   docker rm -f "$name" >/dev/null
   docker volume rm "$vol" >/dev/null
 }
@@ -4886,6 +5021,7 @@ ALL_TESTS=(
   t_runtime_lock_blocks_overlapping_boot
   t_unasked_clean_exit_is_nonzero
   t_requested_stop_still_exits_zero
+  t_stop_is_clean_and_restart_keeps_watcher
   t_collation_refresh_no_permission_error
   t_invalid_bucket_skips_archive
   t_archiving_boot

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -39,10 +39,11 @@ fi
 # races refuse instead of corrupting: a job dispatched against a live
 # database fails its exclusive lock, and a database deployed while a job is
 # mid-flight fails here. The fd is opened by THIS shell, which stays alive
-# as PID 1 (docker-entrypoint.sh below is a child, not an exec), so the
-# lock is held exactly as long as the container regardless of what postgres
-# does with its inherited copy of the fd — closing a duplicate descriptor
-# does not release a flock while the original stays open.
+# for the container's whole lifetime (tini is PID 1 and this shell is its
+# only child; docker-entrypoint.sh below is a child of this shell, not an
+# exec), so the lock is held exactly as long as the container regardless of
+# what postgres does with its inherited copy of the fd — closing a duplicate
+# descriptor does not release a flock while the original stays open.
 #
 # Legacy PGDATA-at-the-volume-root layouts skip the lock on first init:
 # creating the lock file inside an empty PGDATA would make docker-entrypoint
@@ -115,8 +116,9 @@ fi
 
 # -----------------------------------------------------------------------------
 # Runtime lock: at most one postgres container touches this volume at a time.
-# Held EXCLUSIVELY (fd 9) for the container's lifetime, same shell-as-PID-1
-# mechanics as the upgrade lock above — the kernel releases it only when the
+# Held EXCLUSIVELY (fd 9) for the container's lifetime, same shell-lives-as-
+# long-as-the-container mechanics as the upgrade lock above — the kernel
+# releases it only when the
 # last process holding the open description exits, so "lock free" really
 # means every process of the previous container is gone, however that
 # container ended (graceful stop, SIGKILL, OOM).
@@ -1290,6 +1292,7 @@ bootstrap_pgbackrest_stanza() {
   [ -z "${WAL_ARCHIVE_BUCKET:-}" ] && return 0
 
   (
+    trap '' INT TERM  # background helper — see "Process tree and the stop signal" before the foreground call
     # No `local` here: subshells are their own scope so it's redundant, and
     # the construct misleads if the body is ever lifted out of a function.
     deadline=$(( $(date +%s) + 600 ))
@@ -1710,9 +1713,16 @@ EOF
 # stale file. With the watcher's own main loop holding a fixed PID, only
 # the transient iteration subshell churns (always short-lived,
 # never lands in postmaster.pid's range at container-start time).
+#
+# setsid: the watcher runs in its own session and process group, so the stop
+# signal tini delivers to this shell's group (see "Process tree and the stop
+# signal" before the foreground call) never reaches it or its pgbackrest
+# children. A backgrounded child is not a group leader, so setsid(2) applies
+# in-process — no extra fork, the watcher keeps the single long-lived PID
+# the paragraph above depends on, and it stays THIS shell's child.
 fork_pgbackrest_backup_watcher() {
   [ -z "${WAL_ARCHIVE_BUCKET:-}" ] && return 0
-  gosu postgres /usr/local/bin/pgbackrest-backup-watcher.sh &
+  setsid gosu postgres /usr/local/bin/pgbackrest-backup-watcher.sh &
 }
 
 # Wait for postgres to be ready then refresh collation versions on all databases.
@@ -1729,6 +1739,7 @@ fork_collation_refresh() {
     return 0
   fi
   (
+    trap '' INT TERM  # background helper — see "Process tree and the stop signal" before the foreground call
     local i=0
     while ! gosu postgres pg_isready -q 2>/dev/null; do
       sleep 2
@@ -1796,6 +1807,7 @@ ENDSQL
 # down with it.
 fork_extension_reconcile() {
   (
+    trap '' INT TERM  # background helper — see "Process tree and the stop signal" before the foreground call
     local i=0
     while ! gosu postgres pg_isready -q 2>/dev/null; do
       sleep 2
@@ -1965,6 +1977,7 @@ fork_post_upgrade_analyze() {
   [ -f "$UPGRADE_MARKER_FILE" ] || return 0
   [ "$(jq -r '.needsAnalyze // false' "$UPGRADE_MARKER_FILE" 2>/dev/null)" = "true" ] || return 0
   (
+    trap '' INT TERM  # background helper — see "Process tree and the stop signal" before the foreground call
     for _ in $(seq 1 120); do
       if pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null; then
         echo "post-upgrade: rebuilding planner statistics in stages"
@@ -2051,6 +2064,7 @@ fork_post_upgrade_config_restore() {
     return 0
   fi
   (
+    trap '' INT TERM  # background helper — see "Process tree and the stop signal" before the foreground call
     for _ in $(seq 1 120); do
       if pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null; then
         echo "post-upgrade: re-applying ALTER SYSTEM settings from $(basename "$stash")"
@@ -2171,6 +2185,7 @@ fork_post_upgrade_reindex() {
     rx_baseline_unknown=1
   fi
   (
+    trap '' INT TERM  # background helper — see "Process tree and the stop signal" before the foreground call
     # Same connection shape as fork_post_upgrade_analyze: the cluster's
     # actual superuser over the local socket — a custom-POSTGRES_USER
     # cluster has no 'postgres' role at all.
@@ -2343,6 +2358,7 @@ fork_old_datadir_reclaim() {
   [ "$(jq -r '.phase // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null || true)" = "completed" ] || return 0
   compgen -G "${PGDATA}.old-*" >/dev/null 2>&1 || return 0
   (
+    trap '' INT TERM  # background helper — see "Process tree and the stop signal" before the foreground call
     retention="${UPGRADE_OLD_DIR_RETENTION_SECONDS:-86400}"
     marker_stamped=0
     [ -n "$(jq -r '.oldDataDirRemovedAt // empty' "$UPGRADE_MARKER_FILE" 2>/dev/null || true)" ] && marker_stamped=1
@@ -2416,21 +2432,30 @@ fork_post_upgrade_config_restore
 fork_post_upgrade_reindex
 fork_old_datadir_reclaim
 
-# H1 (audit): we considered `exec docker-entrypoint.sh` and a
-# trap+wait+forward-SIGTERM pattern to make `docker stop` flush
-# postgres's graceful shutdown sequence and clear postmaster.pid.
-# Neither survived CI: exec re-parents the watcher/bootstrap subshells
-# onto postmaster (postmaster panics on SIGCHLD with exit 103); the
-# trap+wait pattern disturbed docker-entrypoint's initdb-time temp
-# postmaster lifecycle and broke `docker restart` (auto.conf changes
-# didn't survive). The real production failure mode the audit named —
-# stale postmaster.pid colliding with a recently-respawned watcher PID —
-# is already mitigated by PR #86 reverting the wrapper.sh supervisor:
-# the watcher's long-lived PID no longer churns, so the in-container
-# kill(stale_pid, 0) liveness check no longer hits one of its
-# subprocesses. Falling back to the simple foreground invocation
-# preserves the e2e suite's existing behavior on docker stop / docker
-# restart.
+# Process tree and the stop signal. tini is PID 1 (see the Dockerfile) and
+# runs this script as its only child; docker-entrypoint.sh below runs in the
+# FOREGROUND as a child of this shell and execs postgres, so postgres shares
+# this shell's process group. The runtime stops the container by sending
+# SIGINT (STOPSIGNAL) to PID 1 alone; tini -g forwards it to that process
+# group — postgres takes a fast shutdown, this shell latches STOP_REQUESTED
+# (trap below) and, once the foreground child returns, exits 0; tini exits
+# with that status. The background helpers forked above must NOT be in that
+# group: the watcher is started under setsid (own session, own group) and
+# each `( ... ) &` subshell ignores INT/TERM as its first statement, so the
+# group signal neither stops a helper mid-task nor makes one exit early.
+# They stay children of this shell — never of the postmaster — and tini
+# reaps whatever is still running when the container ends.
+#
+# History, so the two simpler shapes are not retried: `exec
+# docker-entrypoint.sh` made postgres PID 1 and re-parented the helpers
+# onto it — the postmaster PANICs on an unexpected SIGCHLD (exit 103); a
+# bash trap+wait+forward loop around a backgrounded entrypoint disturbed
+# docker-entrypoint's initdb-time temp postmaster and lost ALTER SYSTEM
+# settings across `docker restart`. Both failed in CI (#87); neither is a
+# one-liner away from working, which is why the init lives outside this
+# script. The stale-postmaster.pid vs watcher-PID collision that audit
+# also named is closed separately by the watcher holding one long-lived
+# PID (#86), and setsid above preserves that property.
 #
 # This boot is about to replay WAL from the source bucket toward a PITR
 # target — recovery.signal present (written either by
@@ -2447,21 +2472,22 @@ if [ -f "$PGDATA/recovery.signal" ] && [ -n "${WAL_RECOVER_FROM_BUCKET:-}" ]; th
 fi
 
 # The traps below deliberately do NOT forward signals or restructure the
-# foreground invocation (that is the pattern CI rejected). They only
-# record that a stop was requested: bash runs a trap after the foreground
-# child returns, so by the time the exit-code shaping below executes the
-# flag reflects whether the runtime asked us to stop. That distinction is
-# what lets a postgres that dies CLEANLY BUT UNASKED — e.g. it shut itself
-# down because something unlinked its postmaster.pid — exit this container
-# nonzero so an ON_FAILURE restart policy can bring the database back,
-# instead of the container reporting exit 0 and staying down forever.
+# foreground invocation (that is the pattern CI rejected; delivering the
+# signal to postgres is tini's job, see above). They only record that a
+# stop was requested: bash runs a trap after the foreground child returns,
+# so by the time the exit-code shaping below executes the flag reflects
+# whether the runtime asked us to stop. That distinction is what lets a
+# postgres that dies CLEANLY BUT UNASKED — e.g. it shut itself down because
+# something unlinked its postmaster.pid — exit this container nonzero so an
+# ON_FAILURE restart policy can bring the database back, instead of the
+# container reporting exit 0 and staying down forever.
 #
 # The flag is a one-shot latch: a TERM/INT that never culminates in a stop
-# (an operator poking PID 1, a platform stop that gets cancelled) still
-# reclassifies a LATER unasked clean exit as requested, exit 0, no restart.
-# Accepted: bash defers trap execution until the foreground child returns,
-# so signal-delivery time cannot be recorded and a recency check is not
-# implementable in this design — and on Railway a TERM broadcast is always
+# (an operator signaling this shell, a platform stop that gets cancelled)
+# still reclassifies a LATER unasked clean exit as requested, exit 0, no
+# restart. Accepted: bash defers trap execution until the foreground child
+# returns, so signal-delivery time cannot be recorded and a recency check is
+# not implementable in this design — and on Railway a stop signal is always
 # followed by container removal, so a latched flag never coexists with a
 # live postgres for long.
 STOP_REQUESTED=0


### PR DESCRIPTION
## Problem

A container is stopped by sending the image's `STOPSIGNAL` to **PID 1 only**, waiting a grace period, then SIGKILL-ing everything. In this image PID 1 was `wrapper.sh` (bash), which has no handler for that signal — and the kernel drops a signal PID 1 doesn't handle. So postgres never learned a stop was requested: every `docker stop` / platform restart ran out the grace period, ended in SIGKILL (exit 137), and the next boot did WAL crash recovery instead of starting from a clean shutdown.

## Why the two obvious fixes were not used

Both were tried and reverted after failing CI (#87, commit 594e9be):

- **`exec docker-entrypoint.sh`** makes postgres PID 1, but the wrapper forks eight background helpers first (pgBackRest stanza bootstrap, the backup watcher, collation refresh, extension reconcile, the post-upgrade tasks). `exec` keeps the PID, so those helpers become the **postmaster's** children — and the postmaster PANICs on an unexpected SIGCHLD (exit 103).
- **bash `trap` + `wait` + forward** requires backgrounding the entrypoint so bash can run the handler; that disturbed docker-entrypoint's initdb-time temporary postmaster and `ALTER SYSTEM` settings stopped surviving `docker restart`.

## What this does

Puts a real init in front of the wrapper instead of restructuring it:

- **Dockerfile.13–18**: install `tini` (Debian `tini` package, 0.19.0 on the current base); `ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/usr/local/bin/wrapper.sh"]`; `STOPSIGNAL SIGINT` restated. The base image already declares SIGINT — postgres's *fast shutdown* signal — but the whole arrangement depends on it, so it is explicit now.
- **wrapper.sh**: the backup watcher is started with `setsid` (own session and process group; a backgrounded child is not a group leader, so `setsid(2)` applies in-process — same single long-lived PID the stale-`postmaster.pid` fix depends on, still this shell's child). Each `( … ) &` helper subshell ignores INT/TERM as its first statement. The foreground entrypoint call, the `STOP_REQUESTED` latch (#120) and the exit-code shaping are unchanged; the latch now actually runs on a requested stop. Comments describing the old PID-1 model updated.
- **test/e2e.sh**: new `t_stop_is_clean_and_restart_keeps_watcher`.

Resulting process tree: `tini` (PID 1) → `wrapper.sh` → `postgres` in the foreground (same process group), with the helpers as the wrapper's children in their own groups. On stop, `tini -g` delivers SIGINT to the wrapper's group: postgres takes a fast shutdown, the wrapper latches the request and exits 0 once the foreground child returns, tini exits with that status. Helpers are neither signaled nor re-parented onto the postmaster; tini reaps whatever is left when the container ends (an in-flight `pgbackrest backup` still dies with the container — same as before).

## Verification

`docker stop -t 15` (the platform's grace period), `linux/amd64`, archiving enabled (watcher running), one WAL segment archived before the stop:

| | PID 1 | postgres parent | `docker stop -t 15` | exit | log | next `docker start` | `docker restart -t 15` | watcher after start / restart |
|---|---|---|---|---|---|---|---|---|
| before (published `:16`) | `bash` | `bash` | **15.4 s** | **137** | no shutdown lines | `database system was interrupted` (crash recovery) | 15.2 s | alive / alive |
| after, pg16 | `tini` | `bash` | **1.0 s** | **0** | `received fast shutdown request` → `database system is shut down` | `database system was shut down at …` | 1.2 s | alive / alive |
| after, pg17 | `tini` | `bash` | **1.0 s** | **0** | same | clean | 1.2 s | alive / alive |

No `PANIC` / `exit_code=103` in any run; `ALTER SYSTEM SET work_mem` survives `docker restart` in all three; the 1000 rows written before the stop are intact.

Edge case, stop issued during first-boot initdb (after image): 0.2 s, exit 1, `initdb: removing contents of data directory` (initdb is interrupt-safe and leaves an empty PGDATA); the following `docker start` re-ran initdb and every `docker-entrypoint-initdb.d` script — server up, SSL certificates present.

e2e (`PG_VERSION=16`): `t_vanilla_boot`, `t_log_to_stdout_moves_server_stream`, `t_runtime_lock_blocks_overlapping_boot`, `t_unasked_clean_exit_is_nonzero`, `t_requested_stop_still_exits_zero`, `t_alter_system_survives_restart` — PASS; `t_stop_is_clean_and_restart_keeps_watcher` — PASS (`docker stop -t 15: 1s, exit 0`).

Two notes from writing the new test: (1) right after boot with archiving just enabled, a fast shutdown legitimately waits for the archiver's in-flight `archive_command`, which can be mid-retry while `stanza-create` is still running — several seconds that are postgres's own, so the test waits for the stanza and one archived segment before timing the stop, and bounds the stop at 12 s (a dropped signal reads as ≥15 s / exit 137); (2) the test captures `docker logs` into a variable before grepping — `docker logs | grep -q` under `pipefail` returned 141 on 4 of 5 tries against a stopped container here (the hazard `logs_on_stream` already documents), and the shutdown line is the last line of a long log. `wait_for_log_line` still uses the pipe form; not changed in this PR.

`Dockerfile.upgrade` is untouched: it has its own one-shot entrypoint and does not run wrapper.sh.
