### PR TITLE
Run the post-upgrade collation reindex only after the staged analyze has finished

### DIFF
--- a/test/e2e-upgrade.sh
+++ b/test/e2e-upgrade.sh
@@ -642,16 +642,47 @@ t_analyze_staged() {
   wait_for_pg analyze-pg || { fail_dump analyze analyze-pg; return 1; }
   local deadline=$(($(date +%s) + 120))
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    if [ "$(marker_field "$vol" needsAnalyze)" = "false" ]; then
-      stop_pg analyze-pg
-      return 0
-    fi
+    [ "$(marker_field "$vol" needsAnalyze)" = "false" ] && break
     sleep 5
   done
-  fail_dump analyze analyze-pg
+  if [ "$(marker_field "$vol" needsAnalyze)" != "false" ]; then
+    fail_dump analyze analyze-pg
+    stop_pg analyze-pg
+    echo "  needsAnalyze never flipped to false"
+    return 1
+  fi
+  # The collation reindex forks on the same boot and rebuilds indexes on the
+  # very tables the staged ANALYZE is sampling; run together they deadlock
+  # (ShareUpdateExclusiveLock vs REINDEX CONCURRENTLY's wait on the ANALYZE
+  # transaction) and the statistics pass is pushed to the next boot. The
+  # reindex must therefore start only after the analyze has finished: its
+  # first index touch — or its zero-work verdict — has to follow the
+  # "statistics rebuild complete" line, and the flag must still self-clear.
+  deadline=$(($(date +%s) + 180))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    [ "$(marker_field "$vol" needsReindex)" = "false" ] && break
+    sleep 5
+  done
+  local logs analyze_done reindex_start
+  logs=$(docker logs analyze-pg 2>&1)
+  assert_eq "$(marker_field "$vol" needsReindex)" "false" "reindex flag self-cleared on the same boot" || { fail_dump analyze analyze-pg; stop_pg analyze-pg; return 1; }
+  assert_contains "$logs" "reindex waits for the staged statistics rebuild" "reindex fork saw the pending analyze and waited" || { stop_pg analyze-pg; return 1; }
+  analyze_done=$(echo "$logs" | grep -n "post-upgrade: statistics rebuild complete" | head -1 | cut -d: -f1)
+  reindex_start=$(echo "$logs" | grep -nE "post-upgrade: (reindexing |reindexed [0-9]+ collation-dependent|no collation-dependent indexes to rebuild|collation library unchanged)" | head -1 | cut -d: -f1)
+  if [ -z "$analyze_done" ] || [ -z "$reindex_start" ] || [ "$analyze_done" -ge "$reindex_start" ]; then
+    echo "  expected the statistics rebuild to complete (line $analyze_done) before the reindex touched an index (line $reindex_start)"
+    echo "$logs" | grep -nE "post-upgrade: (statistics|reindex|no collation|collation library)" | sed 's/^/    /'
+    stop_pg analyze-pg
+    return 1
+  fi
+  if echo "$logs" | grep -q "deadlock detected"; then
+    echo "  the staged analyze and the reindex still deadlocked"
+    echo "$logs" | grep -n "deadlock" | sed 's/^/    /'
+    stop_pg analyze-pg
+    return 1
+  fi
   stop_pg analyze-pg
-  echo "  needsAnalyze never flipped to false"
-  return 1
+  return 0
 }
 
 # No marker, TO image on FROM data: the wrapper refuses with an explicit

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1978,6 +1978,9 @@ fork_post_upgrade_analyze() {
   [ "$(jq -r '.needsAnalyze // false' "$UPGRADE_MARKER_FILE" 2>/dev/null)" = "true" ] || return 0
   (
     trap '' INT TERM  # background helper — see "Process tree and the stop signal" before the foreground call
+    # fork_post_upgrade_reindex waits on this: the sentinel means the staged
+    # analyze is no longer running, whichever way it ended.
+    trap 'touch "$POST_UPGRADE_ANALYZE_DONE" 2>/dev/null' EXIT
     for _ in $(seq 1 120); do
       if pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null; then
         echo "post-upgrade: rebuilding planner statistics in stages"
@@ -2258,6 +2261,31 @@ fork_post_upgrade_reindex() {
     while ! pg_isready -q -h /var/run/postgresql -p 5432 2>/dev/null; do
       sleep 5; i=$((i+1)); [ "$i" -ge 120 ] && exit 0
     done
+    # The staged analyze forks on the same boot and works the same tables:
+    # ANALYZE takes ShareUpdateExclusiveLock on a table while REINDEX INDEX
+    # CONCURRENTLY needs that same lock and then waits out every transaction
+    # that saw the old index — with both in flight Postgres reports a
+    # deadlock, aborts the ANALYZE stage and the statistics rebuild is
+    # pushed to the next boot. Let the analyze finish first (either way —
+    # the sentinel marks completion, the flag marks success). The ceiling
+    # only bounds a wedged ANALYZE; past it the rebuild goes ahead so a
+    # stalled statistics pass can never hold up a collation repair forever.
+    if [ "$(jq -r '.needsAnalyze // false' "$UPGRADE_MARKER_FILE" 2>/dev/null)" = "true" ]; then
+      rx_wait_secs=${POST_UPGRADE_REINDEX_WAIT_SECONDS:-14400}
+      rx_wait_deadline=$(( $(date +%s) + rx_wait_secs ))
+      echo "post-upgrade: reindex waits for the staged statistics rebuild to finish"
+      while [ ! -e "$POST_UPGRADE_ANALYZE_DONE" ] \
+        && [ "$(jq -r '.needsAnalyze // false' "$UPGRADE_MARKER_FILE" 2>/dev/null)" = "true" ]; do
+        if [ "$(date +%s)" -ge "$rx_wait_deadline" ]; then
+          echo "post-upgrade: staged statistics rebuild still running after ${rx_wait_secs}s; reindex proceeds"
+          break
+        fi
+        sleep 5
+      done
+      if [ -e "$POST_UPGRADE_ANALYZE_DONE" ] || [ "$(jq -r '.needsAnalyze // false' "$UPGRADE_MARKER_FILE" 2>/dev/null)" != "true" ]; then
+        echo "post-upgrade: staged statistics rebuild finished; reindex check starts"
+      fi
+    fi
     pg_major=$(cat "$PGDATA/PG_VERSION" 2>/dev/null || echo "0")
     if [ "$pg_major" -lt 15 ] 2>/dev/null; then
       # Defensive only: the upgrade job's supported range (14-18) can never
@@ -2427,6 +2455,11 @@ bootstrap_pgbackrest_stanza
 fork_pgbackrest_backup_watcher
 fork_collation_refresh
 fork_extension_reconcile
+# Completion sentinel shared by the two post-upgrade forks below; lives in
+# the container's /tmp, not on the volume, and is cleared here because a
+# restarted container keeps its /tmp and hands this script the same PID.
+POST_UPGRADE_ANALYZE_DONE="/tmp/.post-upgrade-analyze-done.$$"
+rm -f "$POST_UPGRADE_ANALYZE_DONE" 2>/dev/null
 fork_post_upgrade_analyze
 fork_post_upgrade_config_restore
 fork_post_upgrade_reindex


### PR DESCRIPTION
## What

On the first runtime boot after a major upgrade, `wrapper.sh` forks two background tasks that work the same tables: the staged statistics rebuild (`vacuumdb --all --analyze-in-stages`, `fork_post_upgrade_analyze`) and the collation reindex (`REINDEX INDEX CONCURRENTLY` of every suspect index, `fork_post_upgrade_reindex`). Both only wait for `pg_isready`, so they run concurrently.

`ANALYZE` takes `ShareUpdateExclusiveLock` on the table; `REINDEX INDEX CONCURRENTLY` needs that same lock and then waits out every transaction that saw the old index. Started together they can deadlock. Postgres picks the ANALYZE as the victim, the marker keeps `needsAnalyze=true`, and the statistics pass is pushed to the next boot while the planner runs on whatever stages completed.

Seen once on `main` (`e2e-upgrade (14, 17)`, `t_analyze_staged`, https://github.com/railwayapp-templates/postgres-ssl/actions/runs/33892113812/attempts/1):

```
ERROR:  deadlock detected
DETAIL:  Process 193 waits for ShareUpdateExclusiveLock on relation 16385 of database 13844; blocked by process 196.
         Process 196 waits for ShareLock on virtual transaction 19/19; blocked by process 193.
         Process 193: ANALYZE public.upgrade_canary;
         Process 196: REINDEX INDEX CONCURRENTLY public.upgrade_canary_body_idx
post-upgrade: statistics rebuild failed; will retry on next boot
```

The pre-15 source is what makes the window real: with no collation-version baseline every collation-dependent index is suspect, so the reindex actually has work at the same moment the analyze is sampling.

## How

- `fork_post_upgrade_reindex` waits for the analyze fork to finish before touching any index. The analyze fork marks completion — either outcome — on a per-boot sentinel in the container's `/tmp`; the reindex proceeds once the sentinel exists or `needsAnalyze` has cleared. Waiting on completion rather than on success keeps an analyze that fails on every boot (an auth-hardened local rule, a missing role) from blocking the collation repair.
- A ceiling (`POST_UPGRADE_REINDEX_WAIT_SECONDS`, default 4h) bounds a wedged `ANALYZE`; past it the reindex goes ahead and says so.
- The sentinel is cleared before the forks start: a restarted container keeps its `/tmp` and hands the script the same PID.

## Verification

`t_analyze_staged` now also waits for `needsReindex` to self-clear on the same boot and asserts from the container log that the statistics rebuild completed before the reindex touched an index (or reached its zero-work verdict), and that no deadlock was reported. Runs across the whole `e2e-upgrade` matrix, so both the pre-15 (reindex has work) and 15+ (zero-work verdict) shapes are pinned.

`shellcheck -S warning` on `wrapper.sh` and `test/e2e-upgrade.sh`: no new findings.
